### PR TITLE
Added main property to package.json to support 'npm start'

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "nodecg",
   "description": "Live, controllable graphics system rendered in a browser",
+  "main": "server.js",
   "version": "0.0.1",
   "author": "Matthew McNamara <matt@mattmcn.com>",
   "contributors": [


### PR DESCRIPTION
Added standard 'main' property to package.json.  The server can now be started via 'npm start'.
