### PR TITLE
Cleaner log functions

### DIFF
--- a/lib/bundle_views/index.js
+++ b/lib/bundle_views/index.js
@@ -7,12 +7,12 @@ var express = require('express'),
     filteredConfig = configs.filteredConfig,
     path = require('path'),
     fs = require('fs'),
-    log = require('../logger'),
+    log = require('../logger')('nodecg/lib/bundle_views'),
     Bundles = require('../bundles');
 
 require('string.prototype.endswith');
 
-log.trace('[lib/bundle_views/index.js] Adding Express routes');
+log.trace('Adding Express routes');
 
 app.set('views', process.cwd());
 
@@ -29,7 +29,7 @@ app.get('/viewsetup.js', function(req, res) {
         if (req.headers['user-agent'].indexOf('Zombie.js')) {
             bundleName = 'test-bundle';
         } else {
-            log.error("[lib/bundle_views] viewsetup.js requested with no referer by", req.connection.remoteAddress);
+            log.error("viewsetup.js requested with no referer by", req.connection.remoteAddress);
             res.status(400).send('Bad Request, no referer');
             return;
         }

--- a/lib/bundles/index.js
+++ b/lib/bundles/index.js
@@ -6,13 +6,13 @@ var parse = require('./parser.js'),
     fs = require('fs'),
     Q = require('q'),
     util = require('util'),
-    log = require('../logger');
+    log = require('../logger')('nodecg/lib/bundles');
 
 exports = module.exports = new events.EventEmitter();
 
 var _bundles = [];
 
-log.trace("[lib/bundles/index.js] Loading bundles");
+log.trace("Loading bundles");
 
 // Do an initial scan of the bundles dir
 if (!fs.existsSync('bundles/')) {
@@ -31,7 +31,7 @@ _bundlesDir.forEach(function(bundleFolderName) {
     if (parsePromise) {
         var postParsePromise = parsePromise.then(function(bundle) {
             if (!bundle) return;
-            log.trace("[lib/bundles/index.js] Parsed bundle %s", bundle.name);
+            log.trace("Parsed bundle %s", bundle.name);
             _bundles.push(bundle);
         });
         promises.push(postParsePromise);
@@ -45,10 +45,10 @@ Q.all(promises)
                 .then(function(bundle) {
                     // If nodecg.json is missing from the bundle dir, bundle will equal false
                     if (bundle) {
-                        log.info("[lib/bundles/index.js] %s was changed, and has been reloaded from disk", name);
+                        log.info("%s was changed, and has been reloaded from disk", name);
                         exports.add(bundle);
                     } else {
-                        log.info("[lib/bundles/index.js] %s's nodecg.json can no longer be found on disk, assuming the bundle has been deleted or moved", name);
+                        log.info("%s's nodecg.json can no longer be found on disk, assuming the bundle has been deleted or moved", name);
                         exports.remove(name);
                     }
                 });
@@ -57,7 +57,7 @@ Q.all(promises)
         exports.emit('allLoaded', exports.all());
     })
     .fail(function(er) {
-        log.error('[lib/bundles]', er.stack);
+        log.error('', er.stack);
     });
 
 exports.all = function() {

--- a/lib/bundles/parser.js
+++ b/lib/bundles/parser.js
@@ -5,7 +5,7 @@ var file = require('file'),
     config = require('../../lib/config').config,
     semver = require('semver'),
     path = require('path'),
-    log = require('../logger'),
+    log = require('../logger')('nodecg/lib/bundles/parser'),
     jade = require('jade'),
     util = require('util'),
     npm = require('npm'),
@@ -21,7 +21,7 @@ module.exports = function parse(bundleName) {
         return null;
     }
 
-    log.trace("[lib/bundles/index.js] Discovered bundle in folder bundles/%s", bundleName);
+    log.trace("Discovered bundle in folder bundles/%s", bundleName);
 
     // Read metadata from the nodecg.json manifest file
     var bundle = readManifest(manifestPath);
@@ -29,7 +29,7 @@ module.exports = function parse(bundleName) {
 
     // Don't load the bundle if it depends on a different version of NodeCG
     if (!isCompatible(bundle.nodecgDependency)) {
-        log.error("[lib/bundles/parser.js] Did not load %s as it requires NodeCG %s. Current version is %s",
+        log.error("Did not load %s as it requires NodeCG %s. Current version is %s",
             bundle.name, bundle.nodecgDependency, pjson.version);
         return null;
     }
@@ -156,7 +156,7 @@ function readDashboardPanels(bundle) {
 
             bundle.dashboard.panels.push(panel);
         } catch (e) {
-            log.error("[lib/bundles/parser] Error parsing panel '%s' for bundle %s:\n", panel.name, bundle.name, e.message);
+            log.error("Error parsing panel '%s' for bundle %s:\n", panel.name, bundle.name, e.message);
         }
     });
 }

--- a/lib/bundles/watcher.js
+++ b/lib/bundles/watcher.js
@@ -3,7 +3,7 @@
 var gaze = require('gaze'),
     path = require('path'),
     util = require('util'),
-    log = require('../logger'),
+    log = require('../logger')('nodecg/lib/bundles/watcher'),
     EventEmitter = require('events').EventEmitter,
     emitter = new EventEmitter();
 
@@ -39,12 +39,12 @@ function Watcher() {
                 prevPart = part;
             });
 
-            log.debug("[lib/bundle/watcher.js] Change detected in " + bundleName + ": " + filepath + " " + event);
+            log.debug("Change detected in " + bundleName + ": " + filepath + " " + event);
             emitter.emit("bundleChanged", bundleName);
         });
 
         this.on('error', function(error) {
-            log.error("[lib/bundle/watcher.js]", error.stack);
+            log.error('Gaze error:', error.stack);
         });
     });
 }

--- a/lib/dashboard/index.js
+++ b/lib/dashboard/index.js
@@ -6,12 +6,12 @@ var express = require('express'),
     config = configs.config,
     filteredConfig = configs.filteredConfig,
     expressLess = require('express-less'),
-    log = require('../logger'),
+    log = require('../logger')('nodecg/lib/dashboard'),
     Bundles = require('../bundles'),
     clientIncludes = require('../client_includes'),
     utils = require('../util');
 
-log.trace('[lib/dashboard/index.js] Adding Express routes');
+log.trace('Adding Express routes');
 app.use('/dashboard', express.static(__dirname + '/public'));
 app.use('/dashboard', expressLess(__dirname + '/public', { compress: true }));
 app.set('views', __dirname);

--- a/lib/extension_api/index.js
+++ b/lib/extension_api/index.js
@@ -4,7 +4,7 @@ var syncedVariables = require('../synced_variables');
 var io = {};
 var path = require('path');
 var server = require('../../server.js'); // ew gross TODO fix this
-var log = require('../logger');
+var log = require('../logger')('nodecg/lib/extension_api');
 var filteredConfig = require('../config').filteredConfig;
 var utils = require('../util');
 
@@ -98,7 +98,7 @@ NodeCG.prototype.listenFor = function (messageName, bundleName, handler) {
         var existingHandler = this._handlers[i];
         if (messageName === existingHandler.messageName &&
             bundleName === existingHandler.bundleName) {
-            log.error("[lib/extension_api] %s attempted to declare a duplicate 'listenFor' handler:", this.bundleName, bundleName, messageName);
+            log.error("%s attempted to declare a duplicate 'listenFor' handler:", this.bundleName, bundleName, messageName);
             return;
         }
     }
@@ -117,7 +117,7 @@ NodeCG.prototype.declareSyncedVar = function (args) {
     var value = args.initialValue || args.initialVal;
 
     if (!name) {
-        var msg = "[lib/extension_api] Attempted to declare an unnamed variable for bundle " + bundle;
+        var msg = "Attempted to declare an unnamed variable for bundle " + bundle;
         var e = new Error(msg);
         log.error(msg);
         throw e;
@@ -129,7 +129,7 @@ NodeCG.prototype.declareSyncedVar = function (args) {
         var existingHandler = this._varHandlers[i];
         if (name === existingHandler.variableName &&
             bundle === existingHandler.bundleName) {
-            log.error("[lib/extension_api] %s attempted to declare a duplicate synced var:", this.bundleName, bundle, name);
+            log.error("%s attempted to declare a duplicate synced var:", this.bundleName, bundle, name);
             return;
         }
     }
@@ -161,7 +161,7 @@ NodeCG.prototype.destroySyncedVar = function (args) {
     var bundle = args.bundleName || this.bundleName;
 
     if (!name) {
-        var msg = "[lib/extension_api] Attempted to destroy an unnamed variable for bundle " + bundle;
+        var msg = "Attempted to destroy an unnamed variable for bundle " + bundle;
         var e = new Error(msg);
         log.error(msg);
         throw e;

--- a/lib/logger/index.js
+++ b/lib/logger/index.js
@@ -29,13 +29,48 @@ winston.addColors({
     error: 'red'
 });
 
-module.exports = new (winston.Logger)({
-    transports: transports,
-    levels: {
-        trace: 0,
-        debug: 1,
-        info: 2,
-        warn: 3,
-        error: 4
-    }
-});
+module.exports = function(filename) {
+    var logger = new (winston.Logger)({
+        transports: transports,
+        levels: {
+            trace: 0,
+            debug: 1,
+            info: 2,
+            warn: 3,
+            error: 4
+        }
+    });
+
+    logger._trace = logger.trace;
+    logger._debug = logger.debug;
+    logger._info = logger.info;
+    logger._warn = logger.warn;
+    logger._error = logger.error;
+
+    logger.trace = function() {
+        arguments[0] = '['+filename+'] ' + arguments[0];
+        logger._trace.apply(this, arguments);
+    };
+
+    logger.debug = function() {
+        arguments[0] = '['+filename+'] ' + arguments[0];
+        logger._debug.apply(this, arguments);
+    };
+
+    logger.info = function() {
+        arguments[0] = '['+filename+'] ' + arguments[0];
+        logger._info.apply(this, arguments);
+    };
+
+    logger.warn = function() {
+        arguments[0] = '['+filename+'] ' + arguments[0];
+        logger._warn.apply(this, arguments);
+    };
+
+    logger.error = function() {
+        arguments[0] = '['+filename+'] ' + arguments[0];
+        logger._error.apply(this, arguments);
+    };
+
+    return logger;
+};

--- a/lib/login/index.js
+++ b/lib/login/index.js
@@ -9,7 +9,7 @@ var express = require('express'),
     passport = require('passport'),
     SteamStrategy = require('passport-steam').Strategy,
     TwitchStrategy = require('passport-twitch').Strategy,
-    log = require('../logger');
+    log = require('../logger')('nodecg/lib/login');
 
 /**
  * Passport setup
@@ -33,9 +33,9 @@ if (config.login.steam.enabled) {
                 profile.allowed = (config.login.steam.allowedIds.indexOf(profile.id) > -1);
 
                 if (profile.allowed) {
-                    log.info("[lib/login/index.js] Granting %s (%s) access", profile.id, profile.displayName);
+                    log.info("Granting %s (%s) access", profile.id, profile.displayName);
                 } else {
-                    log.info("[lib/login/index.js] Denying %s (%s) access", profile.id, profile.displayName);
+                    log.info("Denying %s (%s) access", profile.id, profile.displayName);
                 }
 
                 return done(null, profile);
@@ -56,9 +56,9 @@ if (config.login.twitch.enabled) {
                 profile.allowed = (config.login.twitch.allowedUsernames.indexOf(profile.username) > -1);
 
                 if (profile.allowed) {
-                    log.info("[lib/login/index.js] Granting %s access", profile.username);
+                    log.info("Granting %s access", profile.username);
                 } else {
-                    log.info("[lib/login/index.js] Denying %s access", profile.username);
+                    log.info("Denying %s access", profile.username);
                 }
 
                 return done(null, profile);

--- a/lib/synced_variables/index.js
+++ b/lib/synced_variables/index.js
@@ -1,6 +1,6 @@
 'use strict';
 var io = require(process.cwd() + '/server.js').io;
-var log = require('../logger');
+var log = require('../logger')('nodecg/lib/synced_variables');
 var util = require('util');
 var events = require('events');
 var declaredVars = {};
@@ -45,7 +45,7 @@ SyncedVariables.prototype.declare = function(bundleName, variableName, initialVa
         variableName: variableName,
         value: initialVal
     });
-    log.debug("[lib/variables] Variable %s (%s) declared:", variableName, bundleName, initialVal);
+    log.debug("Variable %s (%s) declared:", variableName, bundleName, initialVal);
 
     return initialVal;
 };
@@ -69,11 +69,11 @@ SyncedVariables.prototype.destroy = function(bundleName, variableName) {
 
 SyncedVariables.prototype.assign = function(bundleName, variableName, value) {
     if (!this.exists(bundleName, variableName)) {
-        log.error("[lib/variables] Attempted to assign non-existant variable %s (%s)", variableName, bundleName)
+        log.error("Attempted to assign non-existant variable %s (%s)", variableName, bundleName)
     }
 
     declaredVars[bundleName][variableName] = value;
-    log.debug("[lib/variables] Variable %s (%s) assigned: ", variableName, bundleName, value);
+    log.debug("Variable %s (%s) assigned: ", variableName, bundleName, value);
     this.emitToAll('variableAssigned', {
         bundleName: bundleName,
         variableName: variableName,
@@ -91,7 +91,7 @@ SyncedVariables.prototype.exists = function(bundleName, variableName) {
 SyncedVariables.prototype.findOrDeclare = function(bundleName, variableName, initialVal) {
     var existingVar = this.find(bundleName, variableName);
     if (typeof(existingVar) !== 'undefined') {
-        log.debug("[lib/variables] Variable %s (%s) already existed:", variableName, bundleName, existingVar);
+        log.debug("Variable %s (%s) already existed:", variableName, bundleName, existingVar);
         return existingVar;
     }
 


### PR DESCRIPTION
The logging functions now automatically insert `[nodecg/lib/example]` rather than needing it in every log statement. This filename string is instead set when we require the logger; `require(../logger)('blah')` gives all messages the `[blah]` prefix.

I have also changed out log statements to begin with `nodecg/`, with the idea that extensions should get access to our logger with the (automatically set) prefix `[bundleName/path/to/extension.js]`. Adding `nodecg` to our statements should help someone visually filter between system and extension messages quickly.
