### PR TITLE
v0.4.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 env:
   - NODE_VERSION=0.10
-#  - NODE_VERSION=0.12
-#  - NODE_VERSION=iojs
+  - NODE_VERSION=0.12
+  - NODE_VERSION=iojs
 
 sudo: false
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,8 +6,8 @@ init:
 environment:
   matrix:
     - nodejs_version: "0.10"
-#    - nodejs_version: "0.12"
-#    - nodejs_version: "iojs"
+    - nodejs_version: "0.12"
+    - nodejs_version: "iojs"
 
 # Allow failing jobs for bleeding-edge Node.js versions.
 matrix:

--- a/lib/bundles/parser.js
+++ b/lib/bundles/parser.js
@@ -51,9 +51,13 @@ module.exports = function parse(bundleName) {
     // The following operation(s) are async, so we make a collective promise for them
     return Q.all([
         installNpmPackages(bundle)
-    ]).then(function() {
-        return bundle;
-    });
+    ])
+        .then(function() {
+            return bundle;
+        })
+        .catch(function(err) {
+            log.error(err.stack);
+        });
 };
 
 function readManifest(path) {
@@ -91,6 +95,13 @@ function installNpmPackages(bundle) {
     // Check for existing dependencies
     var cmdline = 'npm ls --json --depth=0';
     exec(cmdline, { cwd: bundle.dir }, function(err, stdout) {
+        if (err) {
+            deferred.reject(new Error(
+                util.format('[%s] Failed to install npm dependencies:', bundle.name, err.message)
+            ));
+            return;
+        }
+
         var data = JSON.parse(stdout);
 
         var toInstall = [];
@@ -114,6 +125,7 @@ function installNpmPackages(bundle) {
                     deferred.reject(new Error(
                         util.format('[%s] Failed to install npm dependencies:', bundle.name, err.message)
                     ));
+                    return;
                 }
                 log.trace('Successfully installed dependencies for bundle', bundle.name);
                 deferred.resolve();

--- a/lib/bundles/watcher.js
+++ b/lib/bundles/watcher.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var gaze = require('gaze');
+var chokidar = require('chokidar');
 var path = require('path');
 var log = require('../logger')('nodecg/lib/bundles/watcher');
 var EventEmitter = require('events').EventEmitter;
@@ -16,34 +16,35 @@ var watchPatterns = [
     '!**/node_modules/**' // Ignore node_modules folders
 ];
 
-gaze(watchPatterns, function(err) {
-    if (err) {
-        log.error(err.stack, 'Couldn\'t start watcher, NodeCG will exit.');
-        process.exit(1);
-    }
+var watcher = chokidar.watch(watchPatterns, {
+    ignored: /[\/\\]\./, persistent: true
+});
 
-    // On changed/added/deleted
-    this.on('all', function(event, filepath) {
-        //extract the bundle name from the filepath
-        var bundleName = '';
-        var res = filepath.split(path.sep);
-        var prevPart = '';
+watcher.on('add', handleChange);
+watcher.on('change', handleChange);
+watcher.on('unlink', handleChange);
 
-        //walk up the path in reverse, once we find "bundles" we know the previous dir was the bundle
-        res.reverse().forEach(function(part) {
-            if(part === 'bundles') {
-                bundleName = prevPart;
-            }
-            prevPart = part;
-        });
+// On changed/added/deleted
+function handleChange(filepath) {
+    //extract the bundle name from the filepath
+    var bundleName = '';
+    var res = filepath.split(path.sep);
+    var prevPart = '';
 
-        log.debug('Change detected in', bundleName, ': ', filepath, event);
-        emitter.emit('bundleChanged', bundleName);
+    //walk up the path in reverse, once we find "bundles" we know the previous dir was the bundle
+    res.reverse().forEach(function(part) {
+        if(part === 'bundles') {
+            bundleName = prevPart;
+        }
+        prevPart = part;
     });
 
-    this.on('error', function(error) {
-        log.error('Gaze error:', error.stack);
-    });
+    log.debug('Change detected in', bundleName, ': ', filepath);
+    emitter.emit('bundleChanged', bundleName);
+}
+
+watcher.on('error', function(error) {
+    log.error(error.stack);
 });
 
 exports = module.exports = emitter;

--- a/lib/extension_api/index.js
+++ b/lib/extension_api/index.js
@@ -30,6 +30,7 @@ function NodeCG(bundle) {
     var self = this;
 
     io.on('connection', function onConnection(socket) {
+        socket.setMaxListeners(64); // Prevent console warnings when many extensions are installed
         socket.on('message', function onMessage(data, cb) {
             log.trace('[%s] Socket %s sent a message (callback: %s):', self.bundleName, socket.id, data, Boolean(cb));
             var len = self._handlers.length;

--- a/lib/server/index.js
+++ b/lib/server/index.js
@@ -30,7 +30,7 @@ request('http://registry.npmjs.org/nodecg/latest', function (err, res, body) {
 exports = new EventEmitter();
 
 exports.start = function() {
-    log.info('Starting NodeCG', pjson.version);
+    log.info('Starting NodeCG %s (Running on Node.js %s)', pjson.version, process.version);
     // Get a fresh config before starting
     config = configHelper.getConfig();
 
@@ -50,6 +50,7 @@ exports.start = function() {
         server = require('http').createServer(app);
     }
     io = require('socket.io')(server);
+    io.sockets.setMaxListeners(64); // Prevent console warnings when many extensions are installed
 
     extensionManager = require('./extensions.js');
     extensionManager.on('extensionsLoaded', function() {

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "nodecg",
-  "description": "Live, controllable graphics system rendered in a browser",
+  "description": "Dynamic broadcast graphics rendered in a browser",
   "main": "index.js",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "repository": {
     "type": "git",
     "url": "https://github.com/nodecg/nodecg.git"
@@ -12,6 +12,7 @@
   "dependencies": {
     "body-parser": "^1.2.2",
     "bower": "^1.3.10",
+    "chokidar": "^1.0.0-rc3",
     "connect-nedb-session": "0.0.3",
     "cookie-parser": "^1.1.0",
     "deasync": "0.0.8",
@@ -23,7 +24,6 @@
     "extend": "^2.0.0",
     "file": "^0.2.2",
     "fs.extra": "^1.3.2",
-    "gaze": "^0.6.4",
     "jade": "^1.6.0",
     "nedb": "^1.1.1",
     "obs-remote": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "chokidar": "^1.0.0-rc3",
     "connect-nedb-session": "0.0.3",
     "cookie-parser": "^1.1.0",
-    "deasync": "0.0.8",
+    "deasync": "0.0.10",
     "ejs": "^2.1.4",
     "express": "^4.3.1",
     "express-favicon": "^1.0.1",
@@ -35,7 +35,7 @@
     "semver": "^4.2.0",
     "socket.io": "^1.2.1",
     "string.prototype.endswith": "^0.2.0",
-    "winston": "^0.8.3"
+    "winston": "^0.9.0"
   },
   "scripts": {
     "start": "node index.js",


### PR DESCRIPTION
- Use [chokidar](https://github.com/paulmillr/chokidar) for file watching instead of [gaze](https://github.com/shama/gaze)
 - Compilation only required on OS X (and even there, it's optional)
- Support Node.js 0.12 (Fixes #90)