### PR TITLE
Implemented bundle config read/write api to nodecg in extension

### DIFF
--- a/lib/bundles/parser.js
+++ b/lib/bundles/parser.js
@@ -43,7 +43,17 @@ module.exports = function parse(bundleName) {
 
     // If there is a config file for this bundle, parse it
     var cfgPath = path.resolve(__dirname, '../../cfg/', bundle.name + '.json');
-    bundle.config = readConfig(cfgPath);
+	if (!fs.existsSync(cfgPath)) {
+		fs.writeFile(cfgPath, '{}', function (err) {
+			if (err) {
+				log.error('Unable to create config file for %s', bundle.name);
+				log.error(err);
+			} else {
+				log.trace('Created config file for %s', bundle.name);
+			}
+		});
+	}
+    bundle.config = cfgPath;
 
     // Read all HTML/CSS/JS files in the package's "dashboard" dir into memory
     // They will then get passed to dashboard.jade at the time of 'GET' and be templated into the final rendered page
@@ -225,15 +235,6 @@ function readDashboardResources(bundle) {
                 break;
         }
     });
-}
-
-function readConfig(cfgPath) {
-    if (!fs.existsSync(cfgPath)) {
-        // Skip if config does not exist
-        return {};
-    }
-
-    return JSON.parse(fs.readFileSync(cfgPath, 'utf8'));
 }
 
 function isCompatible(nodecgDependency) {

--- a/lib/extension_api/index.js
+++ b/lib/extension_api/index.js
@@ -1,12 +1,15 @@
 /* jshint unused:false */
 'use strict';
 
+var fs = require('fs');
 var syncedVariables = require('../synced_variables');
 var io = {};
 var server = require('../server');
 var log = require('../logger')('nodecg/lib/extension_api');
 var filteredConfig = require('../config').getFilteredConfig();
 var utils = require('../util');
+var bundleConfigPath = '';
+var bundleConfig = {};
 
 /**
  * Creates a new NodeCG extension API instance.
@@ -14,9 +17,13 @@ var utils = require('../util');
  * @param {object} bundle The bundle object to build an API instance from.
  */
 function NodeCG(bundle) {
-    // Make bundle name and config publicly accessible
+	// Load in bundle config
+	bundleConfigPath = bundle.config;
+	bundleConfig = JSON.parse(fs.readFileSync(bundleConfigPath, 'utf8'));
+
+    // Make bundle name publicly accessible
     this.bundleName = bundle.name;
-    this.bundleConfig = bundle.config;
+
 
     // Make logger publicly accessible
     this.log = require('../logger')('extension/' + bundle.name);
@@ -242,6 +249,28 @@ NodeCG.prototype.destroySyncedVar = function (args) {
     // Automatically invokes the 'variableDestroyed' listener in the constructor of NodeCG
     // which deleted the property from NodeCG.variables
     syncedVariables.destroy(bundle, name);
+};
+
+/**
+ * Returns value from bundle config
+ * @param {string} key          The key
+ * @returns {*}    value           The value
+ */
+NodeCG.prototype.bundleConfig = function (key) {
+	return bundleConfig[key];
+};
+
+NodeCG.prototype.bundleConfig.write = function (key, value) {
+	bundleConfig[key] = value;
+
+	fs.writeFile(bundleConfigPath, JSON.stringify(bundleConfig, null, '\t'), function (err) {
+		if (err) {
+			log.error('Failed to save config for %s', NodeCG.bundleName);
+			log.error(err);
+		} else {
+			log.trace('Saved config for %s', NodeCG.bundleName);
+		}
+	});
 };
 
 /**


### PR DESCRIPTION
- Automatically creates a bundle cfg file if it doesn't exist
- Read config variable using `nodecg.bundleConfig(key)`
- Write config variable using `nodecg.bundleConfig.write(key, value)`
