### PR TITLE
Add Web Component Support to Dashboard

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -18,7 +18,8 @@
     "seiyria-bootstrap-slider": "~4.0.8",
     "typeahead.js": "~0.10.5",
     "cryptojslib": "~3.1.2",
-    "obs-remote": "^1.0.0"
+    "obs-remote": "^1.0.0",
+    "webcomponentsjs": "~0.5.5"
   },
   "license": "MIT",
   "private": true,

--- a/lib/bundles/parser/panels.js
+++ b/lib/bundles/parser/panels.js
@@ -38,27 +38,28 @@ function readDashboardPanels(bundle) {
                 return;
             }
 
-            panel.file = path.join(bundle.dashboard.dir, panel.file);
+            panel.fullPath = path.join(bundle.dashboard.dir, panel.file);
             panel.width = panel.width || 2;
             panel.faIcon = panel.faIcon || 'fa-question-circle';
             panel.viewUrl = panel.viewUrl || '/view/' + bundle.name;
 
-            switch (path.extname(panel.file)) {
-                case '.jade':
-                    // Render the panel as Jade, giving it access to both
-                    // this specific bundle's config and NodeCG's config
-                    panel.body = jade.renderFile(panel.file, {
-                        bundleConfig: bundle.config,
-                        bundleName: bundle.name,
-                        ncgConfig: config
-                    });
-                    break;
-                case '.html':
-                    // Copy the HTML verbatim with no further processing
-                    panel.body = fs.readFileSync(panel.file, {encoding: 'utf8'});
-                    break;
+            if (!panel.webComponent) {
+                switch (path.extname(panel.file)) {
+                    case '.jade':
+                        // Render the panel as Jade, giving it access to both
+                        // this specific bundle's config and NodeCG's config
+                        panel.body = jade.renderFile(panel.fullPath, {
+                            bundleConfig: bundle.config,
+                            bundleName: bundle.name,
+                            ncgConfig: config
+                        });
+                        break;
+                    case '.html':
+                        // Copy the HTML verbatim with no further processing
+                        panel.body = fs.readFileSync(panel.fullPath, {encoding: 'utf8'});
+                        break;
+                }
             }
-
 
             bundle.dashboard.panels.push(panel);
         } catch (e) {

--- a/lib/dashboard/index.js
+++ b/lib/dashboard/index.js
@@ -52,6 +52,27 @@ app.get('/dashboard/:bundle/components/*', function(req, res, next) {
     res.sendFile(fileLocation);
 });
 
+app.get('/dashboard/:bundle/*', utils.authCheck, function(req, res, next) {
+    var bundle = Bundles.find(req.params.bundle);
+
+    if (!bundle || req.params[0] == 'panels.json') {
+        next();
+        return;
+    }
+
+    var resName = req.params[0];
+
+    var fileLocation = path.join(bundle.dashboard.dir, resName);
+
+    // Check if the file exists
+    if (!fs.existsSync(fileLocation)) {
+        next();
+        return;
+    }
+
+    res.sendFile(fileLocation);
+});
+
 app.get('/logout', function(req, res){
     req.logout();
     res.redirect('/');

--- a/lib/dashboard/public/dashboard.jade
+++ b/lib/dashboard/public/dashboard.jade
@@ -5,12 +5,17 @@ mixin panels(bundle)
                 h3.panel-title=panel.title
                 i(class="fa panel-icon #{ panel.faIcon }")
                 +panelInfoBtn(panel)
-            //- The body was rendered from Jade into HTML in an earlier step of bundle parsing
-            //- This is inefficient, as it means we are doing two rendering passes for each bundle:
-            //- Once to render the body, once to render the rest of the panel (container + header).
-            //- However, I see no other way to do it as Jade is a compiled language and does not
-            //- support dynamic includes.
-            .panel-body!=panel.body
+            if panel.webComponent
+                // web component support
+                .panel-body
+                    #{panel.webComponent}(bundleConfig=JSON.stringify(bundle))
+            else
+                //- The body was rendered from Jade into HTML in an earlier step of bundle parsing
+                //- This is inefficient, as it means we are doing two rendering passes for each bundle:
+                //- Once to render the body, once to render the rest of the panel (container + header).
+                //- However, I see no other way to do it as Jade is a compiled language and does not
+                //- support dynamic includes.
+                .panel-body!=panel.body
 
 //- TODO: Make panel info better. Show things like resolution, authors, etc. Lots more info
 mixin panelInfoBtn(panel)
@@ -43,10 +48,15 @@ html(lang="en")
         //- Custom styles for this template
         link(rel='stylesheet', href='/dashboard/dashboard.css')
 
+        script(src='/components/webcomponentsjs/webcomponents.js')
+
         //- Bundle CSS, perhaps these can just be linked to directly?
             The javascript needs to be cached because of the way we're injecting, but we're not doing
             anything special to the CSS, at least not yet.
         each bundle in bundles
+            each panel in bundle.dashboard.panels
+                if panel.webComponent
+                    link(rel='import', href='/dashboard/' + bundle.name + '/' + panel.file)
             //- only add the tag if there is a style, empty tags can cause long timeout delays
             if bundle.dashboard.css
                 each style in bundle.dashboard.css

--- a/lib/dashboard/public/dashboard.jade
+++ b/lib/dashboard/public/dashboard.jade
@@ -8,7 +8,7 @@ mixin panels(bundle)
             if panel.webComponent
                 // web component support
                 .panel-body
-                    #{panel.webComponent}(bundleConfig=JSON.stringify(bundle))
+                    #{panel.webComponent}(bundlename=bundle.name, bundleConfig=JSON.stringify(bundle.config))
             else
                 //- The body was rendered from Jade into HTML in an earlier step of bundle parsing
                 //- This is inefficient, as it means we are doing two rendering passes for each bundle:

--- a/test/setup/test-bundle/bower.json
+++ b/test/setup/test-bundle/bower.json
@@ -10,6 +10,7 @@
   "license": "MIT",
   "private": true,
   "dependencies": {
+    "polymer": "Polymer/polymer#~0.5.5",
     "webcomponentsjs": "~0.5.5"
   }
 }

--- a/test/setup/test-bundle/dashboard/elements/test-web-component-panel.html
+++ b/test/setup/test-bundle/dashboard/elements/test-web-component-panel.html
@@ -1,0 +1,22 @@
+<link rel="import" href="../components/polymer/polymer.html">
+
+<polymer-element name="test-web-component-panel" attributes="bundlename bundleConfig">
+    <script src="/socket.io/socket.io.js"></script>
+    <script src="/nodecg-api.js"></script>
+
+    <template>
+        <p>name: {{nodecg.bundlename}}</p>
+        <p>test: {{nodecg.bundleConfig.test}}</p>
+        <p>host: {{nodecg.config.host}}</p>
+    </template>
+
+    <script>
+        Polymer({
+            ready: function() {
+                this.nodecg = new NodeCG(this.bundlename, JSON.parse(this.bundleConfig), window.ncgConfig, window.socket);
+
+                console.log(this.nodecg);
+            }
+        });
+  </script>
+</polymer-element>

--- a/test/setup/test-bundle/dashboard/elements/test-web-component-panel.html
+++ b/test/setup/test-bundle/dashboard/elements/test-web-component-panel.html
@@ -5,7 +5,7 @@
     <script src="/nodecg-api.js"></script>
 
     <template>
-        <p>name: {{nodecg.bundlename}}</p>
+        <p>name: {{nodecg.bundleName}}</p>
         <p>test: {{nodecg.bundleConfig.test}}</p>
         <p>host: {{nodecg.config.host}}</p>
     </template>
@@ -14,8 +14,6 @@
         Polymer({
             ready: function() {
                 this.nodecg = new NodeCG(this.bundlename, JSON.parse(this.bundleConfig), window.ncgConfig, window.socket);
-
-                console.log(this.nodecg);
             }
         });
   </script>

--- a/test/setup/test-bundle/dashboard/panels.json
+++ b/test/setup/test-bundle/dashboard/panels.json
@@ -12,5 +12,13 @@
     "width": 2,
     "file": "jade.jade",
     "faIcon": "fa-meh-o"
+  },
+  {
+    "name": "web-component",
+    "title": "Web Component Panel",
+    "width": 2,
+    "webComponent": "test-web-component-panel",
+    "file": "elements/test-web-component-panel.html",
+    "faIcon": "fa-meh-o"
   }
 ]


### PR DESCRIPTION
Add support for using a custom web component instead of an HTML or Jade file as a dashboard panel.

In `panels.jade`, the panel should have `webComponent` set to the name of the web component and `file` point to the location of the file declaring the web component and imported. Omitting `webComponent` from a panel's declaration will revert to standard behavior (i.e. `file` is directly inserted as Jade or HTML). The web component will receive the bundle name and config via attributes `bundlename` and `bundleConfig`, respectively, and can/must use the NodeCG constructor in `nodecg-api.js` as well as `window.ncgConfig` and `window.socket` to construct a proper instance of `nodecg`.

A sample web component panel is included in the test bundle to demonstrate, but unfortunately it doesn't seem tests can be written yet due to tmpvar/jsdom#1030.
