### PR TITLE
View Config Fix

### DIFF
--- a/lib/bundle_views/index.js
+++ b/lib/bundle_views/index.js
@@ -60,8 +60,8 @@ app.get('/view/:bundleName*', function(req, res, next) {
             '<script>var socket = io("//%s/");' +
             'window.nodecg = new NodeCG("%s", %s, %s, socket);</script>';
 
-        scripts = util.format(scripts, filteredConfig.baseURL, bundle.name, 
-            JSON.stringify(filteredConfig), JSON.stringify(bundle.config));
+        scripts = util.format(scripts, filteredConfig.baseURL, bundle.name,
+            JSON.stringify(bundle.config), JSON.stringify(filteredConfig));
 
         var currentHead = $('head').html();
         $('head').html(scripts + currentHead);


### PR DESCRIPTION
Fixes NodeCG config and bundle config being switched, which causes errors when accessing these configs in a view.
