### PR TITLE
Support HTTP & HTTPS on the same port

### DIFF
--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -52,6 +52,7 @@ var defaultConfig = {
     },
     ssl: {
         enabled: false,
+        allowHTTP: false,
         // Path to private key & certificate
         keyPath: '',
         certificatePath: ''
@@ -75,14 +76,14 @@ var cfgPath = path.join(cfgDirPath, 'nodecg.cfg');
 if (fs.existsSync(jsonPath)) {
     // Check if .cfg exists, warn if so
     if (fs.existsSync(cfgPath)) {
-        console.warn('warning: cfg/nodecg.json and cfg/nodecg.cfg detected!' +
+        console.warn('warning: cfg/nodecg.json and cfg/nodecg.cfg detected! ' +
             'NodeCG will use nodecg.json, it is recommended you delete one of these!');
     }
     parseConfig(jsonPath, defaultConfigCopy);
 } else if (fs.existsSync(cfgPath)) {
     // Warn that the file should be called .json
-    console.warn('warning: NodeCG prefers cfg/nodecg.json,' +
-        ' it is recommended you rename your config file to nodecg.json!');
+    console.warn('warning: NodeCG prefers cfg/nodecg.json, ' +
+        'it is recommended you rename your config file to nodecg.json!');
     parseConfig(cfgPath, defaultConfigCopy);
 } else {
     config = defaultConfigCopy;

--- a/lib/server/index.js
+++ b/lib/server/index.js
@@ -45,7 +45,11 @@ exports.start = function() {
             cert: fs.readFileSync(config.ssl.certificatePath)
         };
 
-        server = require('https').createServer(sslOpts, app);
+        // If we allow HTTP on the same port, use httpolyglot
+        // otherwise, standard https server
+        server = config.ssl.allowHTTP ?
+            require('httpolyglot').createServer(sslOpts, app) :
+            require('https').createServer(sslOpts, app);
     } else {
         server = require('http').createServer(app);
     }

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "extend": "^2.0.0",
     "file": "^0.2.2",
     "fs.extra": "^1.3.2",
+    "httpolyglot": "^0.1.1",
     "jade": "^1.6.0",
     "nedb": "^1.1.1",
     "obs-remote": "^1.0.0",


### PR DESCRIPTION
This adds a new config option `ssl.allowHTTP`, defaulting to `false`.

When enabled, NodeCG will accept both HTTP and HTTPS connections on the same port.
This allows HTTPS with self-signed certificates in order to use, for example, Chromium's media APIs, while allowing HTTP access to programs which do not accept self-signed certificates, such as CasparCG.
