### PR TITLE
v0.5.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ after_success: npm run coveralls
 
 matrix:
   allow_failures:
-    - env: "NODE_VERSION=iojs"
+    - os: osx
   fast_finish: true
 
 notifications:

--- a/bower.json
+++ b/bower.json
@@ -14,7 +14,6 @@
     "bsw-yeti": "~3.2.0",
     "jquery": ">=2.1.1",
     "fontawesome": "~4.2.0",
-    "eonasdan-bootstrap-datetimepicker": "~3.1.3",
     "bootstrap-tagsinput": "~0.4.2",
     "seiyria-bootstrap-slider": "~4.0.8",
     "typeahead.js": "~0.10.5",

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "nodecg",
-  "version": "0.0.1",
+  "version": "0.5.3",
   "homepage": "https://github.com/nodecg/nodecg",
   "authors": [
     "Matthew McNamara <matt@mattmcn.com>",

--- a/lib/bundle_views/index.js
+++ b/lib/bundle_views/index.js
@@ -60,8 +60,8 @@ app.get('/view/:bundleName*', function(req, res, next) {
             '<script>var socket = io("//%s/");' +
             'window.nodecg = new NodeCG("%s", %s, %s, socket);</script>';
 
-        scripts = util.format(scripts, filteredConfig.baseURL, bundle.name, 
-            JSON.stringify(filteredConfig), JSON.stringify(bundle.config));
+        scripts = util.format(scripts, filteredConfig.baseURL, bundle.name,
+            JSON.stringify(bundle.config), JSON.stringify(filteredConfig));
 
         var currentHead = $('head').html();
         $('head').html(scripts + currentHead);

--- a/lib/bundle_views/index.js
+++ b/lib/bundle_views/index.js
@@ -57,11 +57,11 @@ app.get('/view/:bundleName*', function(req, res, next) {
 
         var scripts = '<script src="/socket.io/socket.io.js"></script>' +
             '<script src="/nodecg-api.js"></script>' +
-            '<script>var socket = io("//%s:%s/");' +
+            '<script>var socket = io("//%s/");' +
             'window.nodecg = new NodeCG("%s", %s, %s, socket);</script>';
 
-        scripts = util.format(scripts, filteredConfig.host, filteredConfig.port,
-            bundle.name, JSON.stringify(filteredConfig), JSON.stringify(bundle.config));
+        scripts = util.format(scripts, filteredConfig.baseURL, bundle.name, 
+            JSON.stringify(filteredConfig), JSON.stringify(bundle.config));
 
         var currentHead = $('head').html();
         $('head').html(scripts + currentHead);

--- a/lib/bundles/parser/panels.js
+++ b/lib/bundles/parser/panels.js
@@ -49,6 +49,7 @@ function readDashboardPanels(bundle) {
                     // this specific bundle's config and NodeCG's config
                     panel.body = jade.renderFile(panel.file, {
                         bundleConfig: bundle.config,
+                        bundleName: bundle.name,
                         ncgConfig: config
                     });
                     break;

--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -86,17 +86,28 @@ if (fs.existsSync(jsonPath)) {
     parseConfig(cfgPath, defaultConfigCopy);
 } else {
     config = defaultConfigCopy;
+    config.listen = config.port;
+    config.baseURL = config.host + ':' + config.port;
 }
 
 function parseConfig(path, defaults) {
     var userConfig = JSON.parse(fs.readFileSync(path, 'utf8'));
     config = extend(true, defaults, userConfig);
+
+    if (!config.listen) {
+        config.listen = config.port;
+    }
+
+    if (!config.baseURL) {
+        config.baseURL = config.host + ':' + config.port;
+    }
 }
 
 // Create the filtered config
 filteredConfig = {
     host: config.host,
     port: config.port,
+    baseURL: config.baseURL,
     login: {
         enabled: config.login.enabled,
         steam: {

--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -52,6 +52,7 @@ var defaultConfig = {
     },
     ssl: {
         enabled: false,
+        allowHTTP: false,
         // Path to private key & certificate
         keyPath: '',
         certificatePath: ''
@@ -75,14 +76,14 @@ var cfgPath = path.join(cfgDirPath, 'nodecg.cfg');
 if (fs.existsSync(jsonPath)) {
     // Check if .cfg exists, warn if so
     if (fs.existsSync(cfgPath)) {
-        console.warn('warning: cfg/nodecg.json and cfg/nodecg.cfg detected!' +
+        console.warn('warning: cfg/nodecg.json and cfg/nodecg.cfg detected! ' +
             'NodeCG will use nodecg.json, it is recommended you delete one of these!');
     }
     parseConfig(jsonPath, defaultConfigCopy);
 } else if (fs.existsSync(cfgPath)) {
     // Warn that the file should be called .json
-    console.warn('warning: NodeCG prefers cfg/nodecg.json,' +
-        ' it is recommended you rename your config file to nodecg.json!');
+    console.warn('warning: NodeCG prefers cfg/nodecg.json, ' +
+        'it is recommended you rename your config file to nodecg.json!');
     parseConfig(cfgPath, defaultConfigCopy);
 } else {
     config = defaultConfigCopy;

--- a/lib/dashboard/public/dashboard.jade
+++ b/lib/dashboard/public/dashboard.jade
@@ -37,7 +37,6 @@ html(lang="en")
 
         //- Bower component CSS
         link(rel='stylesheet', href='/components/fontawesome/css/font-awesome.min.css')
-        link(rel='stylesheet', href='/components/eonasdan-bootstrap-datetimepicker/build/css/bootstrap-datetimepicker.min.css')
         link(rel='stylesheet', href='/components/bootstrap-tagsinput/dist/bootstrap-tagsinput.css')
         link(rel='stylesheet', href='/components/seiyria-bootstrap-slider/dist/css/bootstrap-slider.min.css')
 
@@ -90,8 +89,6 @@ html(lang="en")
         script(src='/components/bootstrap/js/popover.js')
         script(src='/components/masonry/dist/masonry.pkgd.min.js')
         script(src='/components/imagesloaded/imagesloaded.pkgd.min.js')
-        script(src='/components/moment/min/moment.min.js')
-        script(src='/components/eonasdan-bootstrap-datetimepicker/build/js/bootstrap-datetimepicker.min.js')
         script(src='/components/bootstrap-tagsinput/dist/bootstrap-tagsinput.min.js')
         script(src='/components/seiyria-bootstrap-slider/dist/bootstrap-slider.min.js')
         script(src='/components/typeahead.js/dist/typeahead.jquery.min.js')

--- a/lib/dashboard/public/dashboard.jade
+++ b/lib/dashboard/public/dashboard.jade
@@ -99,7 +99,7 @@ html(lang="en")
         //- Load socket.io and immediately create a socket that all dashboard code will use
         script(src='/socket.io/socket.io.js')
         script(type='text/javascript').
-            window.socket = io.connect('//#{ ncgConfig.host }:#{ ncgConfig.port }/');
+            window.socket = io.connect('//#{ ncgConfig.baseURL }/');
         script(src='/nodecg-api.js')
 
         script(src='/dashboard/dashboard.js')

--- a/lib/dashboard/public/dashboard.jade
+++ b/lib/dashboard/public/dashboard.jade
@@ -76,12 +76,6 @@ html(lang="en")
         //- Spacer
         p
 
-        //- Bundle panels
-        div.container
-            div.dashboard-panels
-                each bundle in bundles
-                    +panels(bundle)
-
         //- Core JavaScript
         script(src='/components/jquery/dist/jquery.min.js')
         script(src='/components/bootstrap/dist/js/bootstrap.min.js')
@@ -109,6 +103,14 @@ html(lang="en")
         script(src='/nodecg-api.js')
 
         script(src='/dashboard/dashboard.js')
+
+        //- Bundle panels
+            We load these after all JS is loaded to ensure that any scripts declared inline are loaded after
+            all the core JS is loaded.
+        div.container
+            div.dashboard-panels
+                each bundle in bundles
+                    +panels(bundle)
 
         //- Bundle javascript
         each bundle in bundles

--- a/lib/extension_api/index.js
+++ b/lib/extension_api/index.js
@@ -247,7 +247,7 @@ NodeCG.prototype.destroySyncedVar = function (args) {
 /**
  * Gets the server Socket.IO context.
  */
-NodeCG.prototype.getIO = server.getIO;
+NodeCG.prototype.getSocketIOServer = server.getIO;
 
 /**
  * Mounts express middleware to the main server express app.

--- a/lib/extension_api/index.js
+++ b/lib/extension_api/index.js
@@ -245,6 +245,11 @@ NodeCG.prototype.destroySyncedVar = function (args) {
 };
 
 /**
+ * Gets the server Socket.IO context.
+ */
+NodeCG.prototype.getIO = server.getIO;
+
+/**
  * Mounts express middleware to the main server express app.
  * See http://expressjs.com/api.html#app.use for usage.
  */

--- a/lib/extension_api/index.js
+++ b/lib/extension_api/index.js
@@ -103,7 +103,7 @@ function NodeCG(bundle) {
 /**
  * Sends a message within the current bundle.
  * @param {string}   messageName The name of the message.
- * @param {Mixed}    [data]      The data to send.
+ * @param {mixed}    [data]      The data to send.
  */
 NodeCG.prototype.sendMessage = function (messageName, data) {
     this.sendMessageToBundle(messageName, this.bundleName, data);
@@ -113,7 +113,7 @@ NodeCG.prototype.sendMessage = function (messageName, data) {
  * Sends a message to a specific bundle.
  * @param {string}   messageName The name of the message.
  * @param {string}   bundleName  The name of the target bundle.
- * @param {Mixed}    [data]      The data to send
+ * @param {mixed}    [data]      The data to send
  */
 NodeCG.prototype.sendMessageToBundle = function (messageName, bundleName, data) {
     log.trace('[%s] Sending message %s to bundle %s with data:',

--- a/lib/extension_api/index.js
+++ b/lib/extension_api/index.js
@@ -190,9 +190,6 @@ NodeCG.prototype.declareSyncedVar = function (args) {
         }
     }
 
-    // Run the setter with the initial value, or the found value if the var already existed
-    setter(syncedVariables.findOrDeclare(bundle, name, value));
-
     // Add the 'setter' callback to the array of handlers that will be invoked
     // when the value of this variable changes
     this._varHandlers.push({
@@ -210,6 +207,9 @@ NodeCG.prototype.declareSyncedVar = function (args) {
         },
         enumerable: true
     });
+
+    // Run the setter with the initial value, or the found value if the var already existed
+    setter(syncedVariables.findOrDeclare(bundle, name, value));
 };
 
 /**

--- a/lib/login/index.js
+++ b/lib/login/index.js
@@ -25,8 +25,8 @@ passport.deserializeUser(function(obj, done) {
 
 if (config.login.steam.enabled) {
     passport.use(new SteamStrategy({
-            returnURL: 'http://'+ config.host +':'+ config.port +'/login/auth/steam',
-            realm: 'http://'+ config.host +':'+ config.port +'/login/auth/steam',
+            returnURL: 'http://'+ config.baseURL +'/login/auth/steam',
+            realm: 'http://'+ config.baseURL +'/login/auth/steam',
             apiKey: config.login.steam.apiKey
         },
         function(identifier, profile, done) {
@@ -49,7 +49,7 @@ if (config.login.twitch.enabled) {
     passport.use(new TwitchStrategy({
             clientID: config.login.twitch.clientID,
             clientSecret: config.login.twitch.clientSecret,
-            callbackURL: 'http://'+ config.host +':'+ config.port +'/login/auth/twitch',
+            callbackURL: 'http://'+ config.baseURL +'/login/auth/twitch',
             scope: config.login.twitch.scope
         },
         function(accessToken, refreshToken, profile, done) {

--- a/lib/server/index.js
+++ b/lib/server/index.js
@@ -45,7 +45,11 @@ exports.start = function() {
             cert: fs.readFileSync(config.ssl.certificatePath)
         };
 
-        server = require('https').createServer(sslOpts, app);
+        // If we allow HTTP on the same port, use httpolyglot
+        // otherwise, standard https server
+        server = config.ssl.allowHTTP ?
+            require('httpolyglot').createServer(sslOpts, app) :
+            require('https').createServer(sslOpts, app);
     } else {
         server = require('http').createServer(app);
     }

--- a/lib/server/index.js
+++ b/lib/server/index.js
@@ -60,13 +60,13 @@ exports.start = function() {
         // This has two benefits:
         // 1) Prevents the dashboard/views from being opened before everything has finished loading
         // 2) Prevents dashboard/views from re-declaring synced vars on reconnect before extensions have had a chance
-        server.listen(config.port);
+        server.listen(config.listen);
         exports.emit('started');
 
         var protocol = config.ssl.enabled ?
             'https' :
             'http';
-        log.info('NodeCG running on %s://%s:%s', protocol, config.host, config.port);
+        log.info('NodeCG running on %s://%s', protocol, config.baseURL);
     });
 
     // Set up Express
@@ -113,13 +113,13 @@ exports.start = function() {
         });
     });
 
-    log.trace('Attempting to listen on port %s', config.port);
+    log.trace('Attempting to listen on %s', config.listen);
     server.on('error', function(err) {
         exports.emit('error', err);
 
         switch (err.code) {
             case 'EADDRINUSE':
-                log.error('[server.js] Port %d in use, is NodeCG already running? NodeCG will now exit.', config.port);
+                log.error('[server.js] Listen %s in use, is NodeCG already running? NodeCG will now exit.', config.listen);
                 break;
             default:
                 log.error('Unhandled error!', err);

--- a/lib/synced_variables/index.js
+++ b/lib/synced_variables/index.js
@@ -117,6 +117,7 @@ exports.findByVariableName = function(variableName) {
     var foundVars = {};
 
     for (var bundleName in declaredVars) {
+        if (!declaredVars.hasOwnProperty(bundleName)) continue;
         if (declaredVars[bundleName].hasOwnProperty(variableName)) {
             foundVars[bundleName] = variableName;
         }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "nodecg",
   "description": "Dynamic broadcast graphics rendered in a browser",
   "main": "index.js",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "repository": {
     "type": "git",
     "url": "https://github.com/nodecg/nodecg.git"

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "extend": "^2.0.0",
     "file": "^0.2.2",
     "fs.extra": "^1.3.2",
+    "httpolyglot": "^0.1.1",
     "jade": "^1.6.0",
     "nedb": "^1.1.1",
     "obs-remote": "^1.0.0",

--- a/test/dashboard.js
+++ b/test/dashboard.js
@@ -21,6 +21,10 @@ describe('dashboard', function() {
             e.browsers.dashboard.assert.text('.test-bundle.jade .js-bundleConfig', 'the_test_string');
         });
 
+        it('have access to bundleName', function() {
+            e.browsers.dashboard.assert.text('.test-bundle.jade .js-bundleName', 'test-bundle');
+        });
+
         it('have access to ncgConfig', function() {
             e.browsers.dashboard.assert.text('.test-bundle.jade .js-ncgConfig', config.host);
         });

--- a/test/setup/test-bundle/dashboard/jade.jade
+++ b/test/setup/test-bundle/dashboard/jade.jade
@@ -1,2 +1,3 @@
 p.js-bundleConfig !{ bundleConfig.test }
+p.js-bundleName !{ bundleName }
 p.js-ncgConfig !{ ncgConfig.host }

--- a/test/setup/test-constants.js
+++ b/test/setup/test-constants.js
@@ -11,7 +11,7 @@ var testBundleSrcPath   = path.resolve(rootDir, 'test/setup/', bundleName);
 var bundleDir           = path.resolve(rootDir, 'bundles', bundleName);
 var cfgDir              = path.resolve(rootDir, 'cfg');
 var bundleCfgPath       = path.resolve(cfgDir, bundleName + '.json');
-var dashboardUrl        = util.format('http://%s:%d/', config.host, config.port);
+var dashboardUrl        = util.format('http://%s/', config.baseURL);
 var dashboardBundleUrl  = dashboardUrl + 'dashboard/' + bundleName;
 var viewUrl             = dashboardUrl + 'view/' + bundleName;
 


### PR DESCRIPTION
- Fixed synced vars in extensions calling setter before setting value of `nodecg.variables.variableName`
- Removed unused dependencies
- Jade panels now have access to a `bundleName` variable
- Fixed issue with inline `<script>` tags running before core dashboard JS
- Added `baseURL` config option for more flexible server setup
- Extensions now have access to the server's Socket.io instance via `nodecg.getSocketIOServer()`
- Fixed NodeCG config and bundle config being mixed up in views
- Added `ssl.allowHTTP` to config to accept both HTTP and HTTPS connections on the same port
