### PR TITLE
v0.5.4

### DIFF
--- a/lib/bundles/parser/npm.js
+++ b/lib/bundles/parser/npm.js
@@ -31,7 +31,7 @@ exports = module.exports = function (bundle) {
         return deferred.promise;
     }
 
-    if (config.asyncNpm === false) {
+    if (config.syncNpm) {
         try {
             process.stdout.write(format('Verifying/installing npm deps for bundle %s...', bundle.name));
             execSync('npm install', { cwd: bundle.dir, stdio: ['pipe', 'pipe', 'pipe'] });

--- a/lib/bundles/parser/npm.js
+++ b/lib/bundles/parser/npm.js
@@ -5,7 +5,11 @@ var log = require('../../logger/index')('nodecg/lib/bundles/parser/npm');
 var fs = require('fs');
 var path = require('path');
 var exec = require('child_process').exec;
+var execSync = require('child_process').execSync;
 var util = require('util');
+var os = require('os');
+var format = require('util').format;
+var config = require('../../config').getConfig();
 
 exports = module.exports = function (bundle) {
     if (!bundle) return;
@@ -27,16 +31,32 @@ exports = module.exports = function (bundle) {
         return deferred.promise;
     }
 
-    exec('npm install', { cwd: bundle.dir }, function(err) {
-        if (err) {
+    if (config.asyncNpm === false) {
+        try {
+            process.stdout.write(format('Verifying/installing npm deps for bundle %s...', bundle.name));
+            execSync('npm install', { cwd: bundle.dir, stdio: ['pipe', 'pipe', 'pipe'] });
+            log.trace('Successfully installed npm dependencies for bundle', bundle.name);
+            deferred.resolve();
+            process.stdout.write(' done!' + os.EOL);
+        } catch (e) {
+            process.stdout.write(' failed!' + os.EOL);
+            console.error(e.stack);
             deferred.reject(new Error(
-                util.format('[%s] Failed to install npm dependencies:', bundle.name, err.message)
+                util.format('[%s] Failed to install npm dependencies:', bundle.name, e.message)
             ));
-            return;
         }
-        log.trace('Successfully installed npm dependencies for bundle', bundle.name);
-        deferred.resolve();
-    });
+    } else {
+        exec('npm install', { cwd: bundle.dir }, function(err) {
+            if (err) {
+                deferred.reject(new Error(
+                    util.format('[%s] Failed to install npm dependencies:', bundle.name, err.message)
+                ));
+                return;
+            }
+            log.trace('Successfully installed npm dependencies for bundle', bundle.name);
+            deferred.resolve();
+        });
+    }
 
     return deferred.promise;
 };

--- a/lib/extension_api/index.js
+++ b/lib/extension_api/index.js
@@ -267,10 +267,16 @@ NodeCG.prototype.util.authCheck = utils.authCheck;
 
 /**
  * Finds and returns a session that matches the given parameters.
- * @param {object} params A NeDB search query [https://github.com/louischatriot/nedb#finding-documents].
+ * @param {object} params   A NeDB search query [https://github.com/louischatriot/nedb#finding-documents].
  * @returns {object}
  */
 NodeCG.prototype.util.findSession = utils.findSession;
+
+/**
+ * Destroys the session matching the given SID
+ * @param {string} sid      The session ID to destroy
+ */
+NodeCG.prototype.util.destroySession = utils.destroySession;
 
 // Make all extensions accessible via 'nodecg.extensions'
 Object.defineProperty(NodeCG.prototype, 'extensions', {

--- a/lib/util/index.js
+++ b/lib/util/index.js
@@ -2,10 +2,10 @@
 
 // Open the sessions database
 var Datastore = require('nedb');
-var db = new Datastore({ filename: './db/sessions.db', autoload: true });
+var sessionDB = new Datastore({ filename: './db/sessions.db', autoload: true });
 
 // Automatically compact the DB every 5 minutes
-db.persistence.setAutocompactionInterval(300000);
+sessionDB.persistence.setAutocompactionInterval(300000);
 
 var config = require('../config').getConfig();
 
@@ -28,12 +28,18 @@ exports.authCheck = function (req, res, next) {
 
 exports.findSession = function(params, cb) {
     params = params || {};
-    db.findOne(params, function (err, doc) {
+    sessionDB.findOne(params, function (err, doc) {
         if (err) {
             cb(err);
         } else {
             cb(null, doc);
         }
+    });
+};
+
+exports.destroySession = function(sid, cb) {
+    sessionDB.remove({ sid: sid }, { multi: false }, function (err) {
+        cb(err);
     });
 };
 

--- a/package.json
+++ b/package.json
@@ -12,12 +12,12 @@
   "dependencies": {
     "body-parser": "^1.2.2",
     "bower": "^1.3.10",
-    "cheerio": "^0.18.0",
-    "chokidar": "^1.0.0-rc3",
+    "cheerio": "^0.19.0",
+    "chokidar": "^1.0.0",
     "connect-nedb-session": "0.0.3",
     "cookie-parser": "^1.1.0",
     "ejs": "^2.1.4",
-    "express": "^4.3.1",
+    "express": "^4.12.3",
     "express-favicon": "^1.0.1",
     "express-less": "0.0.6",
     "express-session": "^1.2.1",
@@ -33,10 +33,10 @@
     "passport-twitch": "^1.0.1",
     "q": "^1.0.1",
     "request": "^2.51.0",
-    "semver": "^4.2.0",
+    "semver": "^4.3.3",
     "socket.io": "^1.2.1",
     "string.prototype.endswith": "^0.2.0",
-    "winston": "^0.9.0"
+    "winston": "^1.0.0"
   },
   "scripts": {
     "start": "node index.js",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "nodecg",
   "description": "Dynamic broadcast graphics rendered in a browser",
   "main": "index.js",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "repository": {
     "type": "git",
     "url": "https://github.com/nodecg/nodecg.git"


### PR DESCRIPTION
- Add `nodecg.util.destroySession(sid)` method.
- Add `syncNpm` config boolean to control whether npm dependencies for bundles are installed one at a time (synchronously) or all at once (asynchronously).
 - This will hopefully address cases where some VPSes were running out of memory after spawning too many concurrent npm processes.
- Bumped dependency versions which were either out of date or insecure.