### PR TITLE
Implementation of bundle deactivation

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -56,6 +56,9 @@ var defaultConfig = {
         // Path to private key & certificate
         keyPath: '',
         certificatePath: ''
+    },
+    bundles: {
+        disabled: []
     }
 };
 
@@ -118,6 +121,9 @@ filteredConfig = {
     },
     ssl: {
         enabled: config.ssl.enabled
+    },
+    bundles: {
+        disabled: config.bundles.disabled
     }
 };
 

--- a/lib/server/extensions.js
+++ b/lib/server/extensions.js
@@ -7,6 +7,8 @@ var bundles = require('../bundles');
 var ExtensionApi = require('../api');
 var log = require('../logger')('nodecg/lib/server/extensions');
 
+var config = require('../config').getConfig();
+
 var extensions = {};
 
 exports = new EventEmitter();
@@ -19,6 +21,13 @@ bundles.on('allLoaded', function(allBundles) {
         for (var i = 0; i < startLen; i++) {
             // If this bundle does not have an extension, remove it from the list
             if (!allBundles[i].extension) {
+                allBundles.splice(i, 1);
+                break;
+            }
+
+            // If this bundle is disabled, remove it from the list
+            if (config.bundles.disabled.indexOf(allBundles[i].name) > -1) {
+                log.debug('Bundle %s is currently disabled', allBundles[i].name);
                 allBundles.splice(i, 1);
                 break;
             }


### PR DESCRIPTION
This is a first implementation of the bundle deactivation feature.
Bundles are first loaded to check if they are valid, then are loaded (or not) during mount process.
The user needs to specify the bundles to deactivate by adding these in `bundles.disabled` field in `nodecg.json` file, related with issue #124.
