### PR TITLE
Lock SocketIO dependency to ~1.3 as 1.4 breaks this software

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "q": "^1.0.1",
     "request": "^2.51.0",
     "semver": "^4.3.3",
-    "socket.io": "^1.2.1",
+    "socket.io": "~1.3.0",
     "string.prototype.endswith": "^0.2.0",
     "uuid": "^2.0.1",
     "winston": "^1.0.0",


### PR DESCRIPTION
socketio 1.4 was breaking things. let's stay on 1.3 until we can fix the problem.
