### PR TITLE
chore(deps): remove obs-remote dependency

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -20,7 +20,6 @@
     "iron-selector": "PolymerElements/iron-selector#1.0.7",
     "js-throttle-debounce": "~0.1.1",
     "more-routing": "PolymerLabs/more-routing#^1.0.0",
-    "obs-remote": "^1.0.0",
     "observe-shim": "~0.4.2",
     "packery": "~1.4.3",
     "paper-button": "PolymerElements/paper-button#^1.0.10",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "node-localstorage": "^0.6.0",
     "nodecg-bundle-parser": "^0.1.14",
     "object-path": "^0.9.2",
-    "obs-remote": "^1.0.1",
     "parse-authors": "^0.2.2",
     "passport": "^0.2.0",
     "passport-steam": "^0.1.6",


### PR DESCRIPTION
Undecided if this should go in now or v0.8.0, in case people are depending on it.

Bundle authors should include the library as needed
