### PR TITLE
Fix issues with config.baseURL

### DIFF
--- a/lib/browser/dist/browserifiedTestApi.js
+++ b/lib/browser/dist/browserifiedTestApi.js
@@ -1,0 +1,3401 @@
+(function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);var f=new Error("Cannot find module '"+o+"'");throw f.code="MODULE_NOT_FOUND",f}var l=n[o]={exports:{}};t[o][0].call(l.exports,function(e){var n=t[o][1][e];return s(n?n:e)},l,l.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(require,module,exports){
+"use strict";
+var __cov_FzLVi9Nvs4DhBtwIHFHGaw = (Function('return this'))();
+if (!__cov_FzLVi9Nvs4DhBtwIHFHGaw.__coverage__) { __cov_FzLVi9Nvs4DhBtwIHFHGaw.__coverage__ = {}; }
+__cov_FzLVi9Nvs4DhBtwIHFHGaw = __cov_FzLVi9Nvs4DhBtwIHFHGaw.__coverage__;
+if (!(__cov_FzLVi9Nvs4DhBtwIHFHGaw['G:\\Programming\\nodecg\\lib\\api.js'])) {
+   __cov_FzLVi9Nvs4DhBtwIHFHGaw['G:\\Programming\\nodecg\\lib\\api.js'] = {"path":"G:\\Programming\\nodecg\\lib\\api.js","s":{"1":0,"2":0,"3":0,"4":0,"5":0,"6":0,"7":1,"8":0,"9":0,"10":0,"11":0,"12":0,"13":0,"14":0,"15":0,"16":0,"17":0,"18":0,"19":0,"20":0,"21":0,"22":0,"23":0,"24":0,"25":0,"26":0,"27":0,"28":0,"29":0,"30":0,"31":0,"32":0,"33":0,"34":0,"35":0,"36":0,"37":0,"38":0,"39":0,"40":0,"41":0,"42":0,"43":0,"44":0,"45":0,"46":0,"47":0,"48":0,"49":0,"50":0,"51":0,"52":0,"53":0,"54":0,"55":0,"56":0,"57":0,"58":0,"59":0,"60":0,"61":0,"62":0,"63":0,"64":0,"65":0,"66":0,"67":0,"68":0,"69":0,"70":0,"71":0,"72":0,"73":0,"74":0,"75":0,"76":0,"77":0,"78":0,"79":0,"80":0,"81":0,"82":0,"83":0,"84":0,"85":0,"86":0,"87":0,"88":0,"89":0,"90":0,"91":0,"92":0,"93":0,"94":0,"95":0,"96":0,"97":0,"98":0,"99":0,"100":0,"101":0,"102":0,"103":0,"104":0,"105":0,"106":0,"107":0,"108":0,"109":0,"110":0,"111":0,"112":0,"113":0,"114":0,"115":0},"b":{"1":[0,0],"2":[0,0],"3":[0,0],"4":[0,0],"5":[0,0],"6":[0,0],"7":[0,0],"8":[0,0],"9":[0,0],"10":[0,0],"11":[0,0],"12":[0,0],"13":[0,0],"14":[0,0],"15":[0,0],"16":[0,0],"17":[0,0],"18":[0,0],"19":[0,0],"20":[0,0],"21":[0,0],"22":[0,0],"23":[0,0],"24":[0,0],"25":[0,0],"26":[0,0],"27":[0,0],"28":[0,0],"29":[0,0],"30":[0,0],"31":[0,0],"32":[0,0]},"f":{"1":0,"2":0,"3":0,"4":0,"5":0,"6":0,"7":0,"8":0,"9":0,"10":0,"11":0,"12":0,"13":0,"14":0,"15":0,"16":0,"17":0,"18":0,"19":0,"20":0},"fnMap":{"1":{"name":"NodeCG","line":17,"loc":{"start":{"line":17,"column":0},"end":{"line":17,"column":32}}},"2":{"name":"(anonymous_2)","line":55,"loc":{"start":{"line":55,"column":48},"end":{"line":55,"column":60}}},"3":{"name":"onMessage","line":66,"loc":{"start":{"line":66,"column":23},"end":{"line":66,"column":48}}},"4":{"name":"(anonymous_4)","line":70,"loc":{"start":{"line":70,"column":33},"end":{"line":70,"column":52}}},"5":{"name":"(anonymous_5)","line":78,"loc":{"start":{"line":78,"column":21},"end":{"line":78,"column":36}}},"6":{"name":"onConnection","line":89,"loc":{"start":{"line":89,"column":22},"end":{"line":89,"column":52}}},"7":{"name":"onMessage","line":91,"loc":{"start":{"line":91,"column":24},"end":{"line":91,"column":53}}},"8":{"name":"(anonymous_8)","line":95,"loc":{"start":{"line":95,"column":34},"end":{"line":95,"column":53}}},"9":{"name":"(anonymous_9)","line":151,"loc":{"start":{"line":151,"column":31},"end":{"line":151,"column":64}}},"10":{"name":"(anonymous_10)","line":160,"loc":{"start":{"line":160,"column":29},"end":{"line":160,"column":74}}},"11":{"name":"(anonymous_11)","line":191,"loc":{"start":{"line":191,"column":39},"end":{"line":191,"column":84}}},"12":{"name":"(anonymous_12)","line":220,"loc":{"start":{"line":220,"column":29},"end":{"line":220,"column":73}}},"13":{"name":"(anonymous_13)","line":252,"loc":{"start":{"line":252,"column":19},"end":{"line":252,"column":49}}},"14":{"name":"(anonymous_14)","line":293,"loc":{"start":{"line":293,"column":29},"end":{"line":293,"column":59}}},"15":{"name":"(anonymous_15)","line":302,"loc":{"start":{"line":302,"column":23},"end":{"line":302,"column":51}}},"16":{"name":"(anonymous_16)","line":340,"loc":{"start":{"line":340,"column":33},"end":{"line":340,"column":61}}},"17":{"name":"(anonymous_17)","line":361,"loc":{"start":{"line":361,"column":38},"end":{"line":361,"column":67}}},"18":{"name":"(anonymous_18)","line":380,"loc":{"start":{"line":380,"column":30},"end":{"line":380,"column":54}}},"19":{"name":"(anonymous_19)","line":393,"loc":{"start":{"line":393,"column":38},"end":{"line":393,"column":62}}},"20":{"name":"(anonymous_20)","line":457,"loc":{"start":{"line":457,"column":7},"end":{"line":457,"column":19}}}},"statementMap":{"1":{"start":{"line":4,"column":0},"end":{"line":4,"column":47}},"2":{"start":{"line":5,"column":0},"end":{"line":5,"column":12}},"3":{"start":{"line":6,"column":0},"end":{"line":6,"column":33}},"4":{"start":{"line":7,"column":0},"end":{"line":7,"column":64}},"5":{"start":{"line":8,"column":0},"end":{"line":8,"column":30}},"6":{"start":{"line":9,"column":0},"end":{"line":9,"column":41}},"7":{"start":{"line":17,"column":0},"end":{"line":113,"column":1}},"8":{"start":{"line":18,"column":1},"end":{"line":18,"column":17}},"9":{"start":{"line":21,"column":1},"end":{"line":21,"column":31}},"10":{"start":{"line":29,"column":1},"end":{"line":29,"column":35}},"11":{"start":{"line":44,"column":1},"end":{"line":44,"column":53}},"12":{"start":{"line":46,"column":1},"end":{"line":46,"column":28}},"13":{"start":{"line":48,"column":1},"end":{"line":103,"column":2}},"14":{"start":{"line":50,"column":2},"end":{"line":52,"column":3}},"15":{"start":{"line":51,"column":3},"end":{"line":51,"column":86}},"16":{"start":{"line":55,"column":2},"end":{"line":59,"column":12}},"17":{"start":{"line":56,"column":3},"end":{"line":58,"column":4}},"18":{"start":{"line":57,"column":4},"end":{"line":57,"column":37}},"19":{"start":{"line":62,"column":2},"end":{"line":62,"column":23}},"20":{"start":{"line":63,"column":2},"end":{"line":63,"column":44}},"21":{"start":{"line":66,"column":2},"end":{"line":76,"column":5}},"22":{"start":{"line":67,"column":3},"end":{"line":68,"column":70}},"23":{"start":{"line":70,"column":3},"end":{"line":75,"column":6}},"24":{"start":{"line":71,"column":4},"end":{"line":74,"column":5}},"25":{"start":{"line":73,"column":5},"end":{"line":73,"column":32}},"26":{"start":{"line":78,"column":2},"end":{"line":85,"column":5}},"27":{"start":{"line":79,"column":3},"end":{"line":84,"column":4}},"28":{"start":{"line":80,"column":4},"end":{"line":80,"column":83}},"29":{"start":{"line":81,"column":4},"end":{"line":81,"column":105}},"30":{"start":{"line":83,"column":4},"end":{"line":83,"column":51}},"31":{"start":{"line":87,"column":2},"end":{"line":87,"column":22}},"32":{"start":{"line":89,"column":2},"end":{"line":102,"column":5}},"33":{"start":{"line":90,"column":3},"end":{"line":90,"column":30}},"34":{"start":{"line":91,"column":3},"end":{"line":101,"column":6}},"35":{"start":{"line":92,"column":4},"end":{"line":93,"column":71}},"36":{"start":{"line":95,"column":4},"end":{"line":100,"column":7}},"37":{"start":{"line":96,"column":5},"end":{"line":99,"column":6}},"38":{"start":{"line":98,"column":6},"end":{"line":98,"column":37}},"39":{"start":{"line":106,"column":1},"end":{"line":110,"column":4}},"40":{"start":{"line":112,"column":1},"end":{"line":112,"column":28}},"41":{"start":{"line":151,"column":0},"end":{"line":158,"column":2}},"42":{"start":{"line":152,"column":1},"end":{"line":155,"column":2}},"43":{"start":{"line":153,"column":2},"end":{"line":153,"column":12}},"44":{"start":{"line":154,"column":2},"end":{"line":154,"column":14}},"45":{"start":{"line":157,"column":1},"end":{"line":157,"column":66}},"46":{"start":{"line":160,"column":0},"end":{"line":179,"column":2}},"47":{"start":{"line":161,"column":1},"end":{"line":178,"column":2}},"48":{"start":{"line":162,"column":2},"end":{"line":165,"column":3}},"49":{"start":{"line":163,"column":3},"end":{"line":163,"column":13}},"50":{"start":{"line":164,"column":3},"end":{"line":164,"column":15}},"51":{"start":{"line":167,"column":2},"end":{"line":171,"column":9}},"52":{"start":{"line":173,"column":2},"end":{"line":177,"column":5}},"53":{"start":{"line":191,"column":0},"end":{"line":196,"column":2}},"54":{"start":{"line":192,"column":1},"end":{"line":193,"column":50}},"55":{"start":{"line":195,"column":1},"end":{"line":195,"column":53}},"56":{"start":{"line":220,"column":0},"end":{"line":244,"column":2}},"57":{"start":{"line":221,"column":1},"end":{"line":224,"column":2}},"58":{"start":{"line":222,"column":2},"end":{"line":222,"column":23}},"59":{"start":{"line":223,"column":2},"end":{"line":223,"column":31}},"60":{"start":{"line":226,"column":1},"end":{"line":226,"column":98}},"61":{"start":{"line":229,"column":1},"end":{"line":229,"column":40}},"62":{"start":{"line":230,"column":1},"end":{"line":237,"column":2}},"63":{"start":{"line":231,"column":2},"end":{"line":231,"column":49}},"64":{"start":{"line":232,"column":2},"end":{"line":236,"column":3}},"65":{"start":{"line":233,"column":3},"end":{"line":234,"column":46}},"66":{"start":{"line":235,"column":3},"end":{"line":235,"column":10}},"67":{"start":{"line":239,"column":1},"end":{"line":243,"column":4}},"68":{"start":{"line":250,"column":0},"end":{"line":250,"column":57}},"69":{"start":{"line":252,"column":0},"end":{"line":254,"column":2}},"70":{"start":{"line":253,"column":1},"end":{"line":253,"column":71}},"71":{"start":{"line":293,"column":0},"end":{"line":300,"column":2}},"72":{"start":{"line":294,"column":1},"end":{"line":297,"column":2}},"73":{"start":{"line":295,"column":2},"end":{"line":295,"column":16}},"74":{"start":{"line":296,"column":2},"end":{"line":296,"column":27}},"75":{"start":{"line":299,"column":1},"end":{"line":299,"column":49}},"76":{"start":{"line":302,"column":0},"end":{"line":319,"column":2}},"77":{"start":{"line":303,"column":1},"end":{"line":305,"column":2}},"78":{"start":{"line":304,"column":2},"end":{"line":304,"column":65}},"79":{"start":{"line":307,"column":1},"end":{"line":309,"column":2}},"80":{"start":{"line":308,"column":2},"end":{"line":308,"column":72}},"81":{"start":{"line":311,"column":1},"end":{"line":318,"column":2}},"82":{"start":{"line":312,"column":2},"end":{"line":312,"column":72}},"83":{"start":{"line":314,"column":2},"end":{"line":314,"column":48}},"84":{"start":{"line":315,"column":2},"end":{"line":317,"column":3}},"85":{"start":{"line":316,"column":3},"end":{"line":316,"column":26}},"86":{"start":{"line":340,"column":0},"end":{"line":347,"column":2}},"87":{"start":{"line":341,"column":1},"end":{"line":344,"column":2}},"88":{"start":{"line":342,"column":2},"end":{"line":342,"column":14}},"89":{"start":{"line":343,"column":2},"end":{"line":343,"column":27}},"90":{"start":{"line":346,"column":1},"end":{"line":346,"column":47}},"91":{"start":{"line":349,"column":0},"end":{"line":462,"column":1}},"92":{"start":{"line":350,"column":1},"end":{"line":350,"column":24}},"93":{"start":{"line":361,"column":1},"end":{"line":371,"column":3}},"94":{"start":{"line":362,"column":2},"end":{"line":362,"column":23}},"95":{"start":{"line":363,"column":2},"end":{"line":370,"column":3}},"96":{"start":{"line":364,"column":3},"end":{"line":368,"column":4}},"97":{"start":{"line":365,"column":4},"end":{"line":367,"column":5}},"98":{"start":{"line":366,"column":5},"end":{"line":366,"column":19}},"99":{"start":{"line":369,"column":3},"end":{"line":369,"column":30}},"100":{"start":{"line":380,"column":1},"end":{"line":384,"column":3}},"101":{"start":{"line":381,"column":2},"end":{"line":381,"column":37}},"102":{"start":{"line":382,"column":2},"end":{"line":382,"column":35}},"103":{"start":{"line":383,"column":2},"end":{"line":383,"column":52}},"104":{"start":{"line":393,"column":1},"end":{"line":397,"column":3}},"105":{"start":{"line":394,"column":2},"end":{"line":394,"column":37}},"106":{"start":{"line":395,"column":2},"end":{"line":395,"column":44}},"107":{"start":{"line":396,"column":2},"end":{"line":396,"column":63}},"108":{"start":{"line":404,"column":1},"end":{"line":404,"column":51}},"109":{"start":{"line":412,"column":1},"end":{"line":412,"column":39}},"110":{"start":{"line":414,"column":1},"end":{"line":414,"column":28}},"111":{"start":{"line":423,"column":1},"end":{"line":423,"column":51}},"112":{"start":{"line":431,"column":1},"end":{"line":431,"column":55}},"113":{"start":{"line":456,"column":1},"end":{"line":461,"column":4}},"114":{"start":{"line":458,"column":3},"end":{"line":458,"column":33}},"115":{"start":{"line":464,"column":0},"end":{"line":464,"column":24}}},"branchMap":{"1":{"line":48,"type":"if","locations":[{"start":{"line":48,"column":1},"end":{"line":48,"column":1}},{"start":{"line":48,"column":1},"end":{"line":48,"column":1}}]},"2":{"line":50,"type":"if","locations":[{"start":{"line":50,"column":2},"end":{"line":50,"column":2}},{"start":{"line":50,"column":2},"end":{"line":50,"column":2}}]},"3":{"line":56,"type":"if","locations":[{"start":{"line":56,"column":3},"end":{"line":56,"column":3}},{"start":{"line":56,"column":3},"end":{"line":56,"column":3}}]},"4":{"line":71,"type":"if","locations":[{"start":{"line":71,"column":4},"end":{"line":71,"column":4}},{"start":{"line":71,"column":4},"end":{"line":71,"column":4}}]},"5":{"line":71,"type":"binary-expr","locations":[{"start":{"line":71,"column":8},"end":{"line":71,"column":48}},{"start":{"line":72,"column":5},"end":{"line":72,"column":43}}]},"6":{"line":79,"type":"if","locations":[{"start":{"line":79,"column":3},"end":{"line":79,"column":3}},{"start":{"line":79,"column":3},"end":{"line":79,"column":3}}]},"7":{"line":96,"type":"if","locations":[{"start":{"line":96,"column":5},"end":{"line":96,"column":5}},{"start":{"line":96,"column":5},"end":{"line":96,"column":5}}]},"8":{"line":96,"type":"binary-expr","locations":[{"start":{"line":96,"column":9},"end":{"line":96,"column":49}},{"start":{"line":97,"column":6},"end":{"line":97,"column":44}}]},"9":{"line":152,"type":"if","locations":[{"start":{"line":152,"column":1},"end":{"line":152,"column":1}},{"start":{"line":152,"column":1},"end":{"line":152,"column":1}}]},"10":{"line":152,"type":"binary-expr","locations":[{"start":{"line":152,"column":5},"end":{"line":152,"column":30}},{"start":{"line":152,"column":34},"end":{"line":152,"column":60}}]},"11":{"line":161,"type":"if","locations":[{"start":{"line":161,"column":1},"end":{"line":161,"column":1}},{"start":{"line":161,"column":1},"end":{"line":161,"column":1}}]},"12":{"line":162,"type":"if","locations":[{"start":{"line":162,"column":2},"end":{"line":162,"column":2}},{"start":{"line":162,"column":2},"end":{"line":162,"column":2}}]},"13":{"line":162,"type":"binary-expr","locations":[{"start":{"line":162,"column":6},"end":{"line":162,"column":31}},{"start":{"line":162,"column":35},"end":{"line":162,"column":61}}]},"14":{"line":221,"type":"if","locations":[{"start":{"line":221,"column":1},"end":{"line":221,"column":1}},{"start":{"line":221,"column":1},"end":{"line":221,"column":1}}]},"15":{"line":232,"type":"if","locations":[{"start":{"line":232,"column":2},"end":{"line":232,"column":2}},{"start":{"line":232,"column":2},"end":{"line":232,"column":2}}]},"16":{"line":232,"type":"binary-expr","locations":[{"start":{"line":232,"column":6},"end":{"line":232,"column":49}},{"start":{"line":232,"column":53},"end":{"line":232,"column":94}}]},"17":{"line":253,"type":"cond-expr","locations":[{"start":{"line":253,"column":49},"end":{"line":253,"column":62}},{"start":{"line":253,"column":65},"end":{"line":253,"column":69}}]},"18":{"line":294,"type":"if","locations":[{"start":{"line":294,"column":1},"end":{"line":294,"column":1}},{"start":{"line":294,"column":1},"end":{"line":294,"column":1}}]},"19":{"line":294,"type":"binary-expr","locations":[{"start":{"line":294,"column":5},"end":{"line":294,"column":12}},{"start":{"line":294,"column":16},"end":{"line":294,"column":42}}]},"20":{"line":303,"type":"if","locations":[{"start":{"line":303,"column":1},"end":{"line":303,"column":1}},{"start":{"line":303,"column":1},"end":{"line":303,"column":1}}]},"21":{"line":303,"type":"binary-expr","locations":[{"start":{"line":303,"column":5},"end":{"line":303,"column":10}},{"start":{"line":303,"column":14},"end":{"line":303,"column":38}}]},"22":{"line":307,"type":"if","locations":[{"start":{"line":307,"column":1},"end":{"line":307,"column":1}},{"start":{"line":307,"column":1},"end":{"line":307,"column":1}}]},"23":{"line":307,"type":"binary-expr","locations":[{"start":{"line":307,"column":5},"end":{"line":307,"column":12}},{"start":{"line":307,"column":16},"end":{"line":307,"column":42}}]},"24":{"line":311,"type":"if","locations":[{"start":{"line":311,"column":1},"end":{"line":311,"column":1}},{"start":{"line":311,"column":1},"end":{"line":311,"column":1}}]},"25":{"line":315,"type":"if","locations":[{"start":{"line":315,"column":2},"end":{"line":315,"column":2}},{"start":{"line":315,"column":2},"end":{"line":315,"column":2}}]},"26":{"line":341,"type":"if","locations":[{"start":{"line":341,"column":1},"end":{"line":341,"column":1}},{"start":{"line":341,"column":1},"end":{"line":341,"column":1}}]},"27":{"line":341,"type":"binary-expr","locations":[{"start":{"line":341,"column":5},"end":{"line":341,"column":12}},{"start":{"line":341,"column":16},"end":{"line":341,"column":42}}]},"28":{"line":349,"type":"if","locations":[{"start":{"line":349,"column":0},"end":{"line":349,"column":0}},{"start":{"line":349,"column":0},"end":{"line":349,"column":0}}]},"29":{"line":364,"type":"if","locations":[{"start":{"line":364,"column":3},"end":{"line":364,"column":3}},{"start":{"line":364,"column":3},"end":{"line":364,"column":3}}]},"30":{"line":365,"type":"if","locations":[{"start":{"line":365,"column":4},"end":{"line":365,"column":4}},{"start":{"line":365,"column":4},"end":{"line":365,"column":4}}]},"31":{"line":381,"type":"binary-expr","locations":[{"start":{"line":381,"column":11},"end":{"line":381,"column":17}},{"start":{"line":381,"column":21},"end":{"line":381,"column":36}}]},"32":{"line":394,"type":"binary-expr","locations":[{"start":{"line":394,"column":11},"end":{"line":394,"column":17}},{"start":{"line":394,"column":21},"end":{"line":394,"column":36}}]}}};
+}
+__cov_FzLVi9Nvs4DhBtwIHFHGaw = __cov_FzLVi9Nvs4DhBtwIHFHGaw['G:\\Programming\\nodecg\\lib\\api.js'];
+__cov_FzLVi9Nvs4DhBtwIHFHGaw.s['1']++;var Replicant=require('./browser/replicant');__cov_FzLVi9Nvs4DhBtwIHFHGaw.s['2']++;var io={};__cov_FzLVi9Nvs4DhBtwIHFHGaw.s['3']++;var server=require('./server');__cov_FzLVi9Nvs4DhBtwIHFHGaw.s['4']++;var filteredConfig=require('./browser/config').filteredConfig;__cov_FzLVi9Nvs4DhBtwIHFHGaw.s['5']++;var utils=require('./util');__cov_FzLVi9Nvs4DhBtwIHFHGaw.s['6']++;var replicator=require('./replicator');function NodeCG(bundle,socket){__cov_FzLVi9Nvs4DhBtwIHFHGaw.f['1']++;__cov_FzLVi9Nvs4DhBtwIHFHGaw.s['8']++;var self=this;__cov_FzLVi9Nvs4DhBtwIHFHGaw.s['9']++;this.bundleName=bundle.name;__cov_FzLVi9Nvs4DhBtwIHFHGaw.s['10']++;this.bundleConfig=bundle.config;__cov_FzLVi9Nvs4DhBtwIHFHGaw.s['11']++;this.log=require('./browser/logger')(bundle.name);__cov_FzLVi9Nvs4DhBtwIHFHGaw.s['12']++;this._messageHandlers=[];__cov_FzLVi9Nvs4DhBtwIHFHGaw.s['13']++;if(true){__cov_FzLVi9Nvs4DhBtwIHFHGaw.b['1'][0]++;__cov_FzLVi9Nvs4DhBtwIHFHGaw.s['14']++;if(typeof io==='undefined'){__cov_FzLVi9Nvs4DhBtwIHFHGaw.b['2'][0]++;__cov_FzLVi9Nvs4DhBtwIHFHGaw.s['15']++;throw new Error('[nodeceg] Socket.IO must be loaded before instantiating the API');}else{__cov_FzLVi9Nvs4DhBtwIHFHGaw.b['2'][1]++;}__cov_FzLVi9Nvs4DhBtwIHFHGaw.s['16']++;document.addEventListener('DOMContentLoaded',function(){__cov_FzLVi9Nvs4DhBtwIHFHGaw.f['2']++;__cov_FzLVi9Nvs4DhBtwIHFHGaw.s['17']++;if(document.title===''){__cov_FzLVi9Nvs4DhBtwIHFHGaw.b['3'][0]++;__cov_FzLVi9Nvs4DhBtwIHFHGaw.s['18']++;document.title=self.bundleName;}else{__cov_FzLVi9Nvs4DhBtwIHFHGaw.b['3'][1]++;}},false);__cov_FzLVi9Nvs4DhBtwIHFHGaw.s['19']++;this.socket=socket;__cov_FzLVi9Nvs4DhBtwIHFHGaw.s['20']++;this.socket.emit('joinRoom',bundle.name);__cov_FzLVi9Nvs4DhBtwIHFHGaw.s['21']++;socket.on('message',function onMessage(data){__cov_FzLVi9Nvs4DhBtwIHFHGaw.f['3']++;__cov_FzLVi9Nvs4DhBtwIHFHGaw.s['22']++;self.log.trace('Received message %s (sent to bundle %s) with data:',self.bundleName,data.messageName,data.bundleName,data.content);__cov_FzLVi9Nvs4DhBtwIHFHGaw.s['23']++;self._messageHandlers.forEach(function(handler){__cov_FzLVi9Nvs4DhBtwIHFHGaw.f['4']++;__cov_FzLVi9Nvs4DhBtwIHFHGaw.s['24']++;if((__cov_FzLVi9Nvs4DhBtwIHFHGaw.b['5'][0]++,data.messageName===handler.messageName)&&(__cov_FzLVi9Nvs4DhBtwIHFHGaw.b['5'][1]++,data.bundleName===handler.bundleName)){__cov_FzLVi9Nvs4DhBtwIHFHGaw.b['4'][0]++;__cov_FzLVi9Nvs4DhBtwIHFHGaw.s['25']++;handler.func(data.content);}else{__cov_FzLVi9Nvs4DhBtwIHFHGaw.b['4'][1]++;}});});__cov_FzLVi9Nvs4DhBtwIHFHGaw.s['26']++;socket.on('error',function(err){__cov_FzLVi9Nvs4DhBtwIHFHGaw.f['5']++;__cov_FzLVi9Nvs4DhBtwIHFHGaw.s['27']++;if(err.type==='UnauthorizedError'){__cov_FzLVi9Nvs4DhBtwIHFHGaw.b['6'][0]++;__cov_FzLVi9Nvs4DhBtwIHFHGaw.s['28']++;var url=[location.protocol,'//',location.host,location.pathname].join('');__cov_FzLVi9Nvs4DhBtwIHFHGaw.s['29']++;window.location.href='/authError?code='+err.code+'&message='+err.message+'&viewUrl='+url;}else{__cov_FzLVi9Nvs4DhBtwIHFHGaw.b['6'][1]++;__cov_FzLVi9Nvs4DhBtwIHFHGaw.s['30']++;self.log.error('Unhandled socket error:',err);}});}else{__cov_FzLVi9Nvs4DhBtwIHFHGaw.b['1'][1]++;__cov_FzLVi9Nvs4DhBtwIHFHGaw.s['31']++;io=server.getIO();__cov_FzLVi9Nvs4DhBtwIHFHGaw.s['32']++;io.on('connection',function onConnection(socket){__cov_FzLVi9Nvs4DhBtwIHFHGaw.f['6']++;__cov_FzLVi9Nvs4DhBtwIHFHGaw.s['33']++;socket.setMaxListeners(64);__cov_FzLVi9Nvs4DhBtwIHFHGaw.s['34']++;socket.on('message',function onMessage(data,cb){__cov_FzLVi9Nvs4DhBtwIHFHGaw.f['7']++;__cov_FzLVi9Nvs4DhBtwIHFHGaw.s['35']++;self.log.trace('[%s] Received message %s (sent to bundle %s) with data:',self.bundleName,data.messageName,data.bundleName,data.content);__cov_FzLVi9Nvs4DhBtwIHFHGaw.s['36']++;self._messageHandlers.forEach(function(handler){__cov_FzLVi9Nvs4DhBtwIHFHGaw.f['8']++;__cov_FzLVi9Nvs4DhBtwIHFHGaw.s['37']++;if((__cov_FzLVi9Nvs4DhBtwIHFHGaw.b['8'][0]++,data.messageName===handler.messageName)&&(__cov_FzLVi9Nvs4DhBtwIHFHGaw.b['8'][1]++,data.bundleName===handler.bundleName)){__cov_FzLVi9Nvs4DhBtwIHFHGaw.b['7'][0]++;__cov_FzLVi9Nvs4DhBtwIHFHGaw.s['38']++;handler.func(data.content,cb);}else{__cov_FzLVi9Nvs4DhBtwIHFHGaw.b['7'][1]++;}});});});}__cov_FzLVi9Nvs4DhBtwIHFHGaw.s['39']++;Object.defineProperty(this,'config',{value:filteredConfig,writable:false,enumerable:true});__cov_FzLVi9Nvs4DhBtwIHFHGaw.s['40']++;Object.freeze(this.config);}__cov_FzLVi9Nvs4DhBtwIHFHGaw.s['41']++;NodeCG.prototype.sendMessage=function(messageName,data,cb){__cov_FzLVi9Nvs4DhBtwIHFHGaw.f['9']++;__cov_FzLVi9Nvs4DhBtwIHFHGaw.s['42']++;if((__cov_FzLVi9Nvs4DhBtwIHFHGaw.b['10'][0]++,typeof cb==='undefined')&&(__cov_FzLVi9Nvs4DhBtwIHFHGaw.b['10'][1]++,typeof data==='function')){__cov_FzLVi9Nvs4DhBtwIHFHGaw.b['9'][0]++;__cov_FzLVi9Nvs4DhBtwIHFHGaw.s['43']++;cb=data;__cov_FzLVi9Nvs4DhBtwIHFHGaw.s['44']++;data=null;}else{__cov_FzLVi9Nvs4DhBtwIHFHGaw.b['9'][1]++;}__cov_FzLVi9Nvs4DhBtwIHFHGaw.s['45']++;this.sendMessageToBundle(messageName,this.bundleName,data,cb);};__cov_FzLVi9Nvs4DhBtwIHFHGaw.s['46']++;NodeCG.sendMessageToBundle=function(messageName,bundleName,data,cb){__cov_FzLVi9Nvs4DhBtwIHFHGaw.f['10']++;__cov_FzLVi9Nvs4DhBtwIHFHGaw.s['47']++;if(true){__cov_FzLVi9Nvs4DhBtwIHFHGaw.b['11'][0]++;__cov_FzLVi9Nvs4DhBtwIHFHGaw.s['48']++;if((__cov_FzLVi9Nvs4DhBtwIHFHGaw.b['13'][0]++,typeof cb==='undefined')&&(__cov_FzLVi9Nvs4DhBtwIHFHGaw.b['13'][1]++,typeof data==='function')){__cov_FzLVi9Nvs4DhBtwIHFHGaw.b['12'][0]++;__cov_FzLVi9Nvs4DhBtwIHFHGaw.s['49']++;cb=data;__cov_FzLVi9Nvs4DhBtwIHFHGaw.s['50']++;data=null;}else{__cov_FzLVi9Nvs4DhBtwIHFHGaw.b['12'][1]++;}__cov_FzLVi9Nvs4DhBtwIHFHGaw.s['51']++;window.socket.emit('message',{bundleName:bundleName,messageName:messageName,content:data},cb);}else{__cov_FzLVi9Nvs4DhBtwIHFHGaw.b['11'][1]++;__cov_FzLVi9Nvs4DhBtwIHFHGaw.s['52']++;io.emit('message',{bundleName:bundleName,messageName:messageName,content:data});}};__cov_FzLVi9Nvs4DhBtwIHFHGaw.s['53']++;NodeCG.prototype.sendMessageToBundle=function(messageName,bundleName,data,cb){__cov_FzLVi9Nvs4DhBtwIHFHGaw.f['11']++;__cov_FzLVi9Nvs4DhBtwIHFHGaw.s['54']++;this.log.trace('[%s] Sending message %s to bundle %s with data:',this.bundleName,messageName,bundleName,data);__cov_FzLVi9Nvs4DhBtwIHFHGaw.s['55']++;NodeCG.sendMessageToBundle.apply(NodeCG,arguments);};__cov_FzLVi9Nvs4DhBtwIHFHGaw.s['56']++;NodeCG.prototype.listenFor=function(messageName,bundleName,handler){__cov_FzLVi9Nvs4DhBtwIHFHGaw.f['12']++;__cov_FzLVi9Nvs4DhBtwIHFHGaw.s['57']++;if(typeof handler==='undefined'){__cov_FzLVi9Nvs4DhBtwIHFHGaw.b['14'][0]++;__cov_FzLVi9Nvs4DhBtwIHFHGaw.s['58']++;handler=bundleName;__cov_FzLVi9Nvs4DhBtwIHFHGaw.s['59']++;bundleName=this.bundleName;}else{__cov_FzLVi9Nvs4DhBtwIHFHGaw.b['14'][1]++;}__cov_FzLVi9Nvs4DhBtwIHFHGaw.s['60']++;this.log.trace('[%s] Listening for %s from bundle %s',this.bundleName,messageName,bundleName);__cov_FzLVi9Nvs4DhBtwIHFHGaw.s['61']++;var len=this._messageHandlers.length;__cov_FzLVi9Nvs4DhBtwIHFHGaw.s['62']++;for(var i=0;i<len;i++){__cov_FzLVi9Nvs4DhBtwIHFHGaw.s['63']++;var existingHandler=this._messageHandlers[i];__cov_FzLVi9Nvs4DhBtwIHFHGaw.s['64']++;if((__cov_FzLVi9Nvs4DhBtwIHFHGaw.b['16'][0]++,messageName===existingHandler.messageName)&&(__cov_FzLVi9Nvs4DhBtwIHFHGaw.b['16'][1]++,bundleName===existingHandler.bundleName)){__cov_FzLVi9Nvs4DhBtwIHFHGaw.b['15'][0]++;__cov_FzLVi9Nvs4DhBtwIHFHGaw.s['65']++;this.log.error('%s attempted to declare a duplicate "listenFor" handler:',this.bundleName,bundleName,messageName);__cov_FzLVi9Nvs4DhBtwIHFHGaw.s['66']++;return;}else{__cov_FzLVi9Nvs4DhBtwIHFHGaw.b['15'][1]++;}}__cov_FzLVi9Nvs4DhBtwIHFHGaw.s['67']++;this._messageHandlers.push({messageName:messageName,bundleName:bundleName,func:handler});};__cov_FzLVi9Nvs4DhBtwIHFHGaw.s['68']++;NodeCG.declaredReplicants=Replicant.declaredReplicants;__cov_FzLVi9Nvs4DhBtwIHFHGaw.s['69']++;NodeCG.Replicant=function(name,bundle,opts){__cov_FzLVi9Nvs4DhBtwIHFHGaw.f['13']++;__cov_FzLVi9Nvs4DhBtwIHFHGaw.s['70']++;return new Replicant(name,bundle,opts,true?(__cov_FzLVi9Nvs4DhBtwIHFHGaw.b['17'][0]++,window.socket):(__cov_FzLVi9Nvs4DhBtwIHFHGaw.b['17'][1]++,null));};__cov_FzLVi9Nvs4DhBtwIHFHGaw.s['71']++;NodeCG.prototype.Replicant=function(name,bundle,opts){__cov_FzLVi9Nvs4DhBtwIHFHGaw.f['14']++;__cov_FzLVi9Nvs4DhBtwIHFHGaw.s['72']++;if((__cov_FzLVi9Nvs4DhBtwIHFHGaw.b['19'][0]++,!bundle)||(__cov_FzLVi9Nvs4DhBtwIHFHGaw.b['19'][1]++,typeof bundle!=='string')){__cov_FzLVi9Nvs4DhBtwIHFHGaw.b['18'][0]++;__cov_FzLVi9Nvs4DhBtwIHFHGaw.s['73']++;opts=bundle;__cov_FzLVi9Nvs4DhBtwIHFHGaw.s['74']++;bundle=this.bundleName;}else{__cov_FzLVi9Nvs4DhBtwIHFHGaw.b['18'][1]++;}__cov_FzLVi9Nvs4DhBtwIHFHGaw.s['75']++;return new NodeCG.Replicant(name,bundle,opts);};__cov_FzLVi9Nvs4DhBtwIHFHGaw.s['76']++;NodeCG.readReplicant=function(name,bundle,cb){__cov_FzLVi9Nvs4DhBtwIHFHGaw.f['15']++;__cov_FzLVi9Nvs4DhBtwIHFHGaw.s['77']++;if((__cov_FzLVi9Nvs4DhBtwIHFHGaw.b['21'][0]++,!name)||(__cov_FzLVi9Nvs4DhBtwIHFHGaw.b['21'][1]++,typeof name!=='string')){__cov_FzLVi9Nvs4DhBtwIHFHGaw.b['20'][0]++;__cov_FzLVi9Nvs4DhBtwIHFHGaw.s['78']++;throw new Error('Must supply a name when reading a Replicant');}else{__cov_FzLVi9Nvs4DhBtwIHFHGaw.b['20'][1]++;}__cov_FzLVi9Nvs4DhBtwIHFHGaw.s['79']++;if((__cov_FzLVi9Nvs4DhBtwIHFHGaw.b['23'][0]++,!bundle)||(__cov_FzLVi9Nvs4DhBtwIHFHGaw.b['23'][1]++,typeof bundle!=='string')){__cov_FzLVi9Nvs4DhBtwIHFHGaw.b['22'][0]++;__cov_FzLVi9Nvs4DhBtwIHFHGaw.s['80']++;throw new Error('Must supply a bundle name when reading a Replicant');}else{__cov_FzLVi9Nvs4DhBtwIHFHGaw.b['22'][1]++;}__cov_FzLVi9Nvs4DhBtwIHFHGaw.s['81']++;if(true){__cov_FzLVi9Nvs4DhBtwIHFHGaw.b['24'][0]++;__cov_FzLVi9Nvs4DhBtwIHFHGaw.s['82']++;window.socket.emit('readReplicant',{name:name,bundle:bundle},cb);}else{__cov_FzLVi9Nvs4DhBtwIHFHGaw.b['24'][1]++;__cov_FzLVi9Nvs4DhBtwIHFHGaw.s['83']++;var replicant=replicator.find(name,bundle);__cov_FzLVi9Nvs4DhBtwIHFHGaw.s['84']++;if(replicant){__cov_FzLVi9Nvs4DhBtwIHFHGaw.b['25'][0]++;__cov_FzLVi9Nvs4DhBtwIHFHGaw.s['85']++;return replicant.value;}else{__cov_FzLVi9Nvs4DhBtwIHFHGaw.b['25'][1]++;}}};__cov_FzLVi9Nvs4DhBtwIHFHGaw.s['86']++;NodeCG.prototype.readReplicant=function(name,bundle,cb){__cov_FzLVi9Nvs4DhBtwIHFHGaw.f['16']++;__cov_FzLVi9Nvs4DhBtwIHFHGaw.s['87']++;if((__cov_FzLVi9Nvs4DhBtwIHFHGaw.b['27'][0]++,!bundle)||(__cov_FzLVi9Nvs4DhBtwIHFHGaw.b['27'][1]++,typeof bundle!=='string')){__cov_FzLVi9Nvs4DhBtwIHFHGaw.b['26'][0]++;__cov_FzLVi9Nvs4DhBtwIHFHGaw.s['88']++;cb=bundle;__cov_FzLVi9Nvs4DhBtwIHFHGaw.s['89']++;bundle=this.bundleName;}else{__cov_FzLVi9Nvs4DhBtwIHFHGaw.b['26'][1]++;}__cov_FzLVi9Nvs4DhBtwIHFHGaw.s['90']++;return NodeCG.readReplicant(name,bundle,cb);};__cov_FzLVi9Nvs4DhBtwIHFHGaw.s['91']++;if(true){__cov_FzLVi9Nvs4DhBtwIHFHGaw.b['28'][0]++;__cov_FzLVi9Nvs4DhBtwIHFHGaw.s['92']++;window.NodeCG=NodeCG;__cov_FzLVi9Nvs4DhBtwIHFHGaw.s['93']++;NodeCG.nearestElementWithAttribute=function(startEl,attrName){__cov_FzLVi9Nvs4DhBtwIHFHGaw.f['17']++;__cov_FzLVi9Nvs4DhBtwIHFHGaw.s['94']++;var target=startEl;__cov_FzLVi9Nvs4DhBtwIHFHGaw.s['95']++;while(target){__cov_FzLVi9Nvs4DhBtwIHFHGaw.s['96']++;if(target.hasAttribute){__cov_FzLVi9Nvs4DhBtwIHFHGaw.b['29'][0]++;__cov_FzLVi9Nvs4DhBtwIHFHGaw.s['97']++;if(target.hasAttribute(attrName)){__cov_FzLVi9Nvs4DhBtwIHFHGaw.b['30'][0]++;__cov_FzLVi9Nvs4DhBtwIHFHGaw.s['98']++;return target;}else{__cov_FzLVi9Nvs4DhBtwIHFHGaw.b['30'][1]++;}}else{__cov_FzLVi9Nvs4DhBtwIHFHGaw.b['29'][1]++;}__cov_FzLVi9Nvs4DhBtwIHFHGaw.s['99']++;target=target.parentNode;}};__cov_FzLVi9Nvs4DhBtwIHFHGaw.s['100']++;NodeCG.prototype.getDialog=function(name,bundle){__cov_FzLVi9Nvs4DhBtwIHFHGaw.f['18']++;__cov_FzLVi9Nvs4DhBtwIHFHGaw.s['101']++;bundle=(__cov_FzLVi9Nvs4DhBtwIHFHGaw.b['31'][0]++,bundle)||(__cov_FzLVi9Nvs4DhBtwIHFHGaw.b['31'][1]++,this.bundleName);__cov_FzLVi9Nvs4DhBtwIHFHGaw.s['102']++;var topDoc=window.top.document;__cov_FzLVi9Nvs4DhBtwIHFHGaw.s['103']++;return topDoc.getElementById(bundle+'_'+name);};__cov_FzLVi9Nvs4DhBtwIHFHGaw.s['104']++;NodeCG.prototype.getDialogDocument=function(name,bundle){__cov_FzLVi9Nvs4DhBtwIHFHGaw.f['19']++;__cov_FzLVi9Nvs4DhBtwIHFHGaw.s['105']++;bundle=(__cov_FzLVi9Nvs4DhBtwIHFHGaw.b['32'][0]++,bundle)||(__cov_FzLVi9Nvs4DhBtwIHFHGaw.b['32'][1]++,this.bundleName);__cov_FzLVi9Nvs4DhBtwIHFHGaw.s['106']++;var dialog=this.getDialog(name,bundle);__cov_FzLVi9Nvs4DhBtwIHFHGaw.s['107']++;return dialog.querySelector('iframe').contentWindow.document;};}else{__cov_FzLVi9Nvs4DhBtwIHFHGaw.b['28'][1]++;__cov_FzLVi9Nvs4DhBtwIHFHGaw.s['108']++;NodeCG.prototype.getSocketIOServer=server.getIO;__cov_FzLVi9Nvs4DhBtwIHFHGaw.s['109']++;NodeCG.prototype.mount=server.mount;__cov_FzLVi9Nvs4DhBtwIHFHGaw.s['110']++;NodeCG.prototype.util={};__cov_FzLVi9Nvs4DhBtwIHFHGaw.s['111']++;NodeCG.prototype.util.authCheck=utils.authCheck;__cov_FzLVi9Nvs4DhBtwIHFHGaw.s['112']++;NodeCG.prototype.util.findSession=utils.findSession;__cov_FzLVi9Nvs4DhBtwIHFHGaw.s['113']++;Object.defineProperty(NodeCG.prototype,'extensions',{get:function(){__cov_FzLVi9Nvs4DhBtwIHFHGaw.f['20']++;__cov_FzLVi9Nvs4DhBtwIHFHGaw.s['114']++;return server.getExtensions();},enumerable:true});}__cov_FzLVi9Nvs4DhBtwIHFHGaw.s['115']++;module.exports=NodeCG;
+
+},{"./browser/config":2,"./browser/logger":3,"./browser/replicant":4,"./replicator":7,"./server":7,"./util":7}],2:[function(require,module,exports){
+"use strict";
+var __cov_t8T35jyutgKMsFmDi_hDtA = (Function('return this'))();
+if (!__cov_t8T35jyutgKMsFmDi_hDtA.__coverage__) { __cov_t8T35jyutgKMsFmDi_hDtA.__coverage__ = {}; }
+__cov_t8T35jyutgKMsFmDi_hDtA = __cov_t8T35jyutgKMsFmDi_hDtA.__coverage__;
+if (!(__cov_t8T35jyutgKMsFmDi_hDtA['G:\\Programming\\nodecg\\lib\\browser\\config.js'])) {
+   __cov_t8T35jyutgKMsFmDi_hDtA['G:\\Programming\\nodecg\\lib\\browser\\config.js'] = {"path":"G:\\Programming\\nodecg\\lib\\browser\\config.js","s":{"1":0},"b":{},"f":{},"fnMap":{},"statementMap":{"1":{"start":{"line":4,"column":0},"end":{"line":6,"column":2}}},"branchMap":{}};
+}
+__cov_t8T35jyutgKMsFmDi_hDtA = __cov_t8T35jyutgKMsFmDi_hDtA['G:\\Programming\\nodecg\\lib\\browser\\config.js'];
+__cov_t8T35jyutgKMsFmDi_hDtA.s['1']++;module.exports={filteredConfig:window.ncgConfig};
+
+},{}],3:[function(require,module,exports){
+"use strict";
+var __cov_AWAzZx1WbmKA1evEymwzNQ = (Function('return this'))();
+if (!__cov_AWAzZx1WbmKA1evEymwzNQ.__coverage__) { __cov_AWAzZx1WbmKA1evEymwzNQ.__coverage__ = {}; }
+__cov_AWAzZx1WbmKA1evEymwzNQ = __cov_AWAzZx1WbmKA1evEymwzNQ.__coverage__;
+if (!(__cov_AWAzZx1WbmKA1evEymwzNQ['G:\\Programming\\nodecg\\lib\\browser\\logger.js'])) {
+   __cov_AWAzZx1WbmKA1evEymwzNQ['G:\\Programming\\nodecg\\lib\\browser\\logger.js'] = {"path":"G:\\Programming\\nodecg\\lib\\browser\\logger.js","s":{"1":0,"2":0,"3":0},"b":{},"f":{"1":0},"fnMap":{"1":{"name":"(anonymous_1)","line":6,"loc":{"start":{"line":6,"column":17},"end":{"line":6,"column":33}}}},"statementMap":{"1":{"start":{"line":4,"column":0},"end":{"line":4,"column":65}},"2":{"start":{"line":6,"column":0},"end":{"line":8,"column":2}},"3":{"start":{"line":7,"column":1},"end":{"line":7,"column":25}}},"branchMap":{}};
+}
+__cov_AWAzZx1WbmKA1evEymwzNQ = __cov_AWAzZx1WbmKA1evEymwzNQ['G:\\Programming\\nodecg\\lib\\browser\\logger.js'];
+__cov_AWAzZx1WbmKA1evEymwzNQ.s['1']++;var Logger=require('@nodecg/logger')(window.ncgConfig.logging);__cov_AWAzZx1WbmKA1evEymwzNQ.s['2']++;module.exports=function(name){__cov_AWAzZx1WbmKA1evEymwzNQ.f['1']++;__cov_AWAzZx1WbmKA1evEymwzNQ.s['3']++;return new Logger(name);};
+
+},{"@nodecg/logger":5}],4:[function(require,module,exports){
+"use strict";
+var __cov_4fdV0JXec5cchqDTt_1vzw = (Function('return this'))();
+if (!__cov_4fdV0JXec5cchqDTt_1vzw.__coverage__) { __cov_4fdV0JXec5cchqDTt_1vzw.__coverage__ = {}; }
+__cov_4fdV0JXec5cchqDTt_1vzw = __cov_4fdV0JXec5cchqDTt_1vzw.__coverage__;
+if (!(__cov_4fdV0JXec5cchqDTt_1vzw['G:\\Programming\\nodecg\\lib\\browser\\replicant.js'])) {
+   __cov_4fdV0JXec5cchqDTt_1vzw['G:\\Programming\\nodecg\\lib\\browser\\replicant.js'] = {"path":"G:\\Programming\\nodecg\\lib\\browser\\replicant.js","s":{"1":0,"2":0,"3":0,"4":0,"5":0,"6":0,"7":0,"8":0,"9":0,"10":0,"11":0,"12":1,"13":0,"14":0,"15":0,"16":0,"17":0,"18":0,"19":0,"20":0,"21":0,"22":0,"23":0,"24":0,"25":0,"26":0,"27":0,"28":0,"29":0,"30":0,"31":0,"32":0,"33":0,"34":0,"35":0,"36":0,"37":0,"38":0,"39":1,"40":0,"41":1,"42":0,"43":0,"44":0,"45":0,"46":0,"47":0,"48":0,"49":0,"50":0,"51":0,"52":0,"53":0,"54":1,"55":0,"56":1,"57":0,"58":0,"59":0,"60":0,"61":0,"62":0,"63":0,"64":0,"65":0,"66":0,"67":0,"68":0,"69":0,"70":0,"71":0,"72":0,"73":0,"74":0,"75":0,"76":0,"77":1,"78":0,"79":0,"80":0,"81":0,"82":0,"83":0,"84":0,"85":1,"86":0,"87":0,"88":1,"89":0,"90":0,"91":0,"92":1,"93":0,"94":0,"95":0,"96":0,"97":0,"98":0,"99":0,"100":0,"101":0,"102":0,"103":0,"104":0,"105":0,"106":0,"107":0,"108":0,"109":0,"110":0,"111":0,"112":0,"113":1,"114":0,"115":0,"116":0,"117":0,"118":0,"119":0,"120":0,"121":0,"122":0,"123":0,"124":0,"125":0,"126":0,"127":0,"128":0,"129":0,"130":0,"131":0,"132":0,"133":0,"134":0,"135":0,"136":0,"137":0,"138":0,"139":0,"140":0,"141":0,"142":0,"143":0,"144":0,"145":0,"146":0,"147":0,"148":0,"149":0,"150":0,"151":0,"152":0,"153":0,"154":0,"155":0,"156":0,"157":0,"158":0,"159":0,"160":0,"161":0,"162":0,"163":0,"164":0,"165":0,"166":0,"167":0,"168":0,"169":0,"170":0,"171":0,"172":0,"173":0,"174":0,"175":0,"176":0,"177":1,"178":0,"179":0,"180":0,"181":0,"182":0,"183":0,"184":0},"b":{"1":[0,0],"2":[0,0],"3":[0,0],"4":[0,0],"5":[0,0],"6":[0,0],"7":[0,0],"8":[0,0],"9":[0,0],"10":[0,0],"11":[0,0],"12":[0,0],"13":[0,0],"14":[0,0],"15":[0,0],"16":[0,0],"17":[0,0],"18":[0,0],"19":[0,0],"20":[0,0],"21":[0,0],"22":[0,0],"23":[0,0],"24":[0,0,0,0,0],"25":[0,0],"26":[0,0],"27":[0,0],"28":[0,0],"29":[0,0],"30":[0,0],"31":[0,0],"32":[0,0],"33":[0,0],"34":[0,0],"35":[0,0,0,0,0],"36":[0,0],"37":[0,0],"38":[0,0],"39":[0,0,0,0,0]},"f":{"1":0,"2":0,"3":0,"4":0,"5":0,"6":0,"7":0,"8":0,"9":0,"10":0,"11":0,"12":0,"13":0,"14":0,"15":0,"16":0,"17":0,"18":0,"19":0,"20":0,"21":0,"22":0,"23":0,"24":0,"25":0,"26":0,"27":0,"28":0},"fnMap":{"1":{"name":"Replicant","line":18,"loc":{"start":{"line":18,"column":0},"end":{"line":18,"column":47}}},"2":{"name":"(anonymous_2)","line":60,"loc":{"start":{"line":60,"column":24},"end":{"line":60,"column":51}}},"3":{"name":"addToQueue","line":71,"loc":{"start":{"line":71,"column":1},"end":{"line":71,"column":31}}},"4":{"name":"processQueue","line":75,"loc":{"start":{"line":75,"column":1},"end":{"line":75,"column":25}}},"5":{"name":"(anonymous_5)","line":76,"loc":{"start":{"line":76,"column":16},"end":{"line":76,"column":32}}},"6":{"name":"(anonymous_6)","line":82,"loc":{"start":{"line":82,"column":7},"end":{"line":82,"column":19}}},"7":{"name":"(anonymous_7)","line":85,"loc":{"start":{"line":85,"column":7},"end":{"line":85,"column":27}}},"8":{"name":"doBrowserSetter","line":103,"loc":{"start":{"line":103,"column":1},"end":{"line":103,"column":36}}},"9":{"name":"doBrowserDeclare","line":112,"loc":{"start":{"line":112,"column":1},"end":{"line":112,"column":41}}},"10":{"name":"(anonymous_10)","line":118,"loc":{"start":{"line":118,"column":34},"end":{"line":118,"column":46}}},"11":{"name":"(anonymous_11)","line":124,"loc":{"start":{"line":124,"column":6},"end":{"line":124,"column":22}}},"12":{"name":"assignValue","line":149,"loc":{"start":{"line":149,"column":1},"end":{"line":149,"column":42}}},"13":{"name":"observeValue","line":160,"loc":{"start":{"line":160,"column":1},"end":{"line":160,"column":25}}},"14":{"name":"dispatchChanges","line":166,"loc":{"start":{"line":166,"column":1},"end":{"line":166,"column":35}}},"15":{"name":"(anonymous_15)","line":173,"loc":{"start":{"line":173,"column":5},"end":{"line":173,"column":32}}},"16":{"name":"onValueChange","line":181,"loc":{"start":{"line":181,"column":1},"end":{"line":181,"column":36}}},"17":{"name":"(anonymous_17)","line":183,"loc":{"start":{"line":183,"column":21},"end":{"line":183,"column":39}}},"18":{"name":"(anonymous_18)","line":184,"loc":{"start":{"line":184,"column":51},"end":{"line":184,"column":67}}},"19":{"name":"unobserveValue","line":245,"loc":{"start":{"line":245,"column":1},"end":{"line":245,"column":27}}},"20":{"name":"(anonymous_20)","line":252,"loc":{"start":{"line":252,"column":32},"end":{"line":252,"column":48}}},"21":{"name":"(anonymous_21)","line":268,"loc":{"start":{"line":268,"column":31},"end":{"line":268,"column":47}}},"22":{"name":"(anonymous_22)","line":287,"loc":{"start":{"line":287,"column":24},"end":{"line":287,"column":42}}},"23":{"name":"(anonymous_23)","line":318,"loc":{"start":{"line":318,"column":24},"end":{"line":318,"column":42}}},"24":{"name":"(anonymous_24)","line":329,"loc":{"start":{"line":329,"column":24},"end":{"line":329,"column":42}}},"25":{"name":"fullUpdate","line":361,"loc":{"start":{"line":361,"column":1},"end":{"line":361,"column":23}}},"26":{"name":"(anonymous_26)","line":362,"loc":{"start":{"line":362,"column":44},"end":{"line":362,"column":60}}},"27":{"name":"(anonymous_27)","line":369,"loc":{"start":{"line":369,"column":25},"end":{"line":369,"column":37}}},"28":{"name":"(anonymous_28)","line":372,"loc":{"start":{"line":372,"column":24},"end":{"line":372,"column":36}}}},"statementMap":{"1":{"start":{"line":4,"column":0},"end":{"line":4,"column":35}},"2":{"start":{"line":5,"column":0},"end":{"line":5,"column":50}},"3":{"start":{"line":6,"column":0},"end":{"line":6,"column":39}},"4":{"start":{"line":7,"column":0},"end":{"line":7,"column":40}},"5":{"start":{"line":8,"column":0},"end":{"line":8,"column":34}},"6":{"start":{"line":9,"column":0},"end":{"line":9,"column":29}},"7":{"start":{"line":10,"column":0},"end":{"line":10,"column":27}},"8":{"start":{"line":11,"column":0},"end":{"line":11,"column":28}},"9":{"start":{"line":14,"column":0},"end":{"line":14,"column":34}},"10":{"start":{"line":15,"column":0},"end":{"line":15,"column":27}},"11":{"start":{"line":16,"column":0},"end":{"line":16,"column":50}},"12":{"start":{"line":18,"column":0},"end":{"line":375,"column":1}},"13":{"start":{"line":19,"column":1},"end":{"line":21,"column":2}},"14":{"start":{"line":20,"column":2},"end":{"line":20,"column":71}},"15":{"start":{"line":23,"column":1},"end":{"line":25,"column":2}},"16":{"start":{"line":24,"column":2},"end":{"line":24,"column":78}},"17":{"start":{"line":28,"column":1},"end":{"line":28,"column":67}},"18":{"start":{"line":31,"column":1},"end":{"line":40,"column":2}},"19":{"start":{"line":32,"column":2},"end":{"line":34,"column":3}},"20":{"start":{"line":33,"column":3},"end":{"line":33,"column":43}},"21":{"start":{"line":36,"column":2},"end":{"line":36,"column":42}},"22":{"start":{"line":38,"column":2},"end":{"line":38,"column":34}},"23":{"start":{"line":39,"column":2},"end":{"line":39,"column":42}},"24":{"start":{"line":42,"column":1},"end":{"line":42,"column":17}},"25":{"start":{"line":43,"column":1},"end":{"line":43,"column":11}},"26":{"start":{"line":44,"column":1},"end":{"line":44,"column":19}},"27":{"start":{"line":45,"column":1},"end":{"line":45,"column":18}},"28":{"start":{"line":46,"column":1},"end":{"line":46,"column":22}},"29":{"start":{"line":47,"column":1},"end":{"line":47,"column":18}},"30":{"start":{"line":48,"column":1},"end":{"line":48,"column":19}},"31":{"start":{"line":49,"column":1},"end":{"line":49,"column":28}},"32":{"start":{"line":50,"column":1},"end":{"line":50,"column":21}},"33":{"start":{"line":51,"column":1},"end":{"line":53,"column":2}},"34":{"start":{"line":52,"column":2},"end":{"line":52,"column":25}},"35":{"start":{"line":60,"column":1},"end":{"line":64,"column":4}},"36":{"start":{"line":61,"column":2},"end":{"line":63,"column":3}},"37":{"start":{"line":62,"column":3},"end":{"line":62,"column":30}},"38":{"start":{"line":69,"column":1},"end":{"line":69,"column":16}},"39":{"start":{"line":71,"column":1},"end":{"line":73,"column":2}},"40":{"start":{"line":72,"column":2},"end":{"line":72,"column":35}},"41":{"start":{"line":75,"column":1},"end":{"line":79,"column":2}},"42":{"start":{"line":76,"column":2},"end":{"line":78,"column":5}},"43":{"start":{"line":77,"column":3},"end":{"line":77,"column":34}},"44":{"start":{"line":81,"column":1},"end":{"line":101,"column":4}},"45":{"start":{"line":83,"column":3},"end":{"line":83,"column":16}},"46":{"start":{"line":86,"column":3},"end":{"line":89,"column":4}},"47":{"start":{"line":87,"column":4},"end":{"line":87,"column":63}},"48":{"start":{"line":88,"column":4},"end":{"line":88,"column":17}},"49":{"start":{"line":91,"column":3},"end":{"line":91,"column":51}},"50":{"start":{"line":93,"column":3},"end":{"line":96,"column":4}},"51":{"start":{"line":94,"column":4},"end":{"line":94,"column":44}},"52":{"start":{"line":95,"column":4},"end":{"line":95,"column":21}},"53":{"start":{"line":98,"column":3},"end":{"line":98,"column":29}},"54":{"start":{"line":103,"column":1},"end":{"line":110,"column":2}},"55":{"start":{"line":104,"column":2},"end":{"line":109,"column":5}},"56":{"start":{"line":112,"column":1},"end":{"line":143,"column":2}},"57":{"start":{"line":113,"column":2},"end":{"line":115,"column":3}},"58":{"start":{"line":114,"column":3},"end":{"line":114,"column":10}},"59":{"start":{"line":117,"column":2},"end":{"line":117,"column":28}},"60":{"start":{"line":118,"column":2},"end":{"line":142,"column":5}},"61":{"start":{"line":119,"column":3},"end":{"line":141,"column":6}},"62":{"start":{"line":125,"column":4},"end":{"line":125,"column":101}},"63":{"start":{"line":126,"column":4},"end":{"line":126,"column":40}},"64":{"start":{"line":127,"column":4},"end":{"line":133,"column":5}},"65":{"start":{"line":128,"column":5},"end":{"line":128,"column":22}},"66":{"start":{"line":129,"column":5},"end":{"line":129,"column":26}},"67":{"start":{"line":130,"column":5},"end":{"line":130,"column":20}},"68":{"start":{"line":131,"column":5},"end":{"line":131,"column":44}},"69":{"start":{"line":132,"column":5},"end":{"line":132,"column":36}},"70":{"start":{"line":134,"column":4},"end":{"line":134,"column":29}},"71":{"start":{"line":135,"column":4},"end":{"line":135,"column":32}},"72":{"start":{"line":136,"column":4},"end":{"line":140,"column":5}},"73":{"start":{"line":137,"column":5},"end":{"line":137,"column":20}},"74":{"start":{"line":138,"column":11},"end":{"line":140,"column":5}},"75":{"start":{"line":139,"column":5},"end":{"line":139,"column":48}},"76":{"start":{"line":145,"column":1},"end":{"line":145,"column":37}},"77":{"start":{"line":149,"column":1},"end":{"line":158,"column":2}},"78":{"start":{"line":150,"column":2},"end":{"line":150,"column":19}},"79":{"start":{"line":151,"column":2},"end":{"line":151,"column":30}},"80":{"start":{"line":152,"column":2},"end":{"line":152,"column":19}},"81":{"start":{"line":153,"column":2},"end":{"line":153,"column":17}},"82":{"start":{"line":154,"column":2},"end":{"line":156,"column":3}},"83":{"start":{"line":155,"column":3},"end":{"line":155,"column":28}},"84":{"start":{"line":157,"column":2},"end":{"line":157,"column":39}},"85":{"start":{"line":160,"column":1},"end":{"line":164,"column":2}},"86":{"start":{"line":161,"column":2},"end":{"line":163,"column":3}},"87":{"start":{"line":162,"column":3},"end":{"line":162,"column":40}},"88":{"start":{"line":166,"column":1},"end":{"line":179,"column":2}},"89":{"start":{"line":167,"column":2},"end":{"line":178,"column":5}},"90":{"start":{"line":175,"column":3},"end":{"line":176,"column":29}},"91":{"start":{"line":177,"column":3},"end":{"line":177,"column":32}},"92":{"start":{"line":181,"column":1},"end":{"line":243,"column":2}},"93":{"start":{"line":182,"column":2},"end":{"line":182,"column":28}},"94":{"start":{"line":183,"column":2},"end":{"line":236,"column":5}},"95":{"start":{"line":184,"column":3},"end":{"line":187,"column":6}},"96":{"start":{"line":186,"column":4},"end":{"line":186,"column":37}},"97":{"start":{"line":191,"column":3},"end":{"line":193,"column":4}},"98":{"start":{"line":192,"column":4},"end":{"line":192,"column":14}},"99":{"start":{"line":195,"column":3},"end":{"line":195,"column":50}},"100":{"start":{"line":196,"column":3},"end":{"line":235,"column":4}},"101":{"start":{"line":198,"column":5},"end":{"line":202,"column":8}},"102":{"start":{"line":203,"column":5},"end":{"line":203,"column":11}},"103":{"start":{"line":205,"column":5},"end":{"line":210,"column":8}},"104":{"start":{"line":211,"column":5},"end":{"line":211,"column":11}},"105":{"start":{"line":213,"column":5},"end":{"line":221,"column":8}},"106":{"start":{"line":222,"column":5},"end":{"line":222,"column":11}},"107":{"start":{"line":224,"column":5},"end":{"line":228,"column":8}},"108":{"start":{"line":229,"column":5},"end":{"line":229,"column":11}},"109":{"start":{"line":231,"column":5},"end":{"line":234,"column":8}},"110":{"start":{"line":238,"column":2},"end":{"line":242,"column":3}},"111":{"start":{"line":239,"column":3},"end":{"line":239,"column":37}},"112":{"start":{"line":241,"column":3},"end":{"line":241,"column":51}},"113":{"start":{"line":245,"column":1},"end":{"line":249,"column":2}},"114":{"start":{"line":246,"column":2},"end":{"line":248,"column":3}},"115":{"start":{"line":247,"column":3},"end":{"line":247,"column":42}},"116":{"start":{"line":252,"column":1},"end":{"line":264,"column":4}},"117":{"start":{"line":253,"column":2},"end":{"line":255,"column":3}},"118":{"start":{"line":254,"column":3},"end":{"line":254,"column":10}},"119":{"start":{"line":257,"column":2},"end":{"line":257,"column":44}},"120":{"start":{"line":259,"column":2},"end":{"line":261,"column":3}},"121":{"start":{"line":260,"column":3},"end":{"line":260,"column":41}},"122":{"start":{"line":263,"column":2},"end":{"line":263,"column":44}},"123":{"start":{"line":268,"column":1},"end":{"line":359,"column":4}},"124":{"start":{"line":269,"column":2},"end":{"line":271,"column":3}},"125":{"start":{"line":270,"column":3},"end":{"line":270,"column":10}},"126":{"start":{"line":273,"column":2},"end":{"line":280,"column":3}},"127":{"start":{"line":274,"column":3},"end":{"line":274,"column":10}},"128":{"start":{"line":275,"column":9},"end":{"line":280,"column":3}},"129":{"start":{"line":276,"column":3},"end":{"line":277,"column":48}},"130":{"start":{"line":278,"column":3},"end":{"line":278,"column":16}},"131":{"start":{"line":279,"column":3},"end":{"line":279,"column":10}},"132":{"start":{"line":282,"column":2},"end":{"line":282,"column":43}},"133":{"start":{"line":284,"column":2},"end":{"line":284,"column":30}},"134":{"start":{"line":285,"column":2},"end":{"line":285,"column":42}},"135":{"start":{"line":286,"column":2},"end":{"line":286,"column":26}},"136":{"start":{"line":287,"column":2},"end":{"line":313,"column":5}},"137":{"start":{"line":288,"column":3},"end":{"line":312,"column":4}},"138":{"start":{"line":290,"column":5},"end":{"line":290,"column":43}},"139":{"start":{"line":291,"column":5},"end":{"line":291,"column":11}},"140":{"start":{"line":293,"column":5},"end":{"line":293,"column":60}},"141":{"start":{"line":294,"column":5},"end":{"line":294,"column":11}},"142":{"start":{"line":296,"column":5},"end":{"line":296,"column":53}},"143":{"start":{"line":297,"column":5},"end":{"line":299,"column":6}},"144":{"start":{"line":298,"column":6},"end":{"line":298,"column":15}},"145":{"start":{"line":301,"column":5},"end":{"line":301,"column":38}},"146":{"start":{"line":302,"column":5},"end":{"line":302,"column":37}},"147":{"start":{"line":303,"column":5},"end":{"line":303,"column":32}},"148":{"start":{"line":304,"column":5},"end":{"line":304,"column":45}},"149":{"start":{"line":305,"column":5},"end":{"line":305,"column":48}},"150":{"start":{"line":306,"column":5},"end":{"line":306,"column":11}},"151":{"start":{"line":308,"column":5},"end":{"line":308,"column":60}},"152":{"start":{"line":309,"column":5},"end":{"line":309,"column":11}},"153":{"start":{"line":311,"column":5},"end":{"line":311,"column":60}},"154":{"start":{"line":315,"column":2},"end":{"line":355,"column":3}},"155":{"start":{"line":318,"column":3},"end":{"line":326,"column":6}},"156":{"start":{"line":319,"column":4},"end":{"line":325,"column":5}},"157":{"start":{"line":321,"column":6},"end":{"line":321,"column":57}},"158":{"start":{"line":322,"column":6},"end":{"line":322,"column":12}},"159":{"start":{"line":328,"column":3},"end":{"line":328,"column":20}},"160":{"start":{"line":329,"column":3},"end":{"line":353,"column":6}},"161":{"start":{"line":330,"column":4},"end":{"line":352,"column":5}},"162":{"start":{"line":333,"column":6},"end":{"line":333,"column":58}},"163":{"start":{"line":334,"column":6},"end":{"line":334,"column":12}},"164":{"start":{"line":336,"column":6},"end":{"line":336,"column":51}},"165":{"start":{"line":337,"column":6},"end":{"line":337,"column":37}},"166":{"start":{"line":338,"column":6},"end":{"line":338,"column":40}},"167":{"start":{"line":339,"column":6},"end":{"line":339,"column":33}},"168":{"start":{"line":340,"column":6},"end":{"line":340,"column":46}},"169":{"start":{"line":341,"column":6},"end":{"line":341,"column":46}},"170":{"start":{"line":345,"column":6},"end":{"line":345,"column":26}},"171":{"start":{"line":346,"column":6},"end":{"line":346,"column":12}},"172":{"start":{"line":348,"column":6},"end":{"line":348,"column":41}},"173":{"start":{"line":349,"column":6},"end":{"line":349,"column":12}},"174":{"start":{"line":354,"column":3},"end":{"line":354,"column":18}},"175":{"start":{"line":357,"column":2},"end":{"line":357,"column":32}},"176":{"start":{"line":358,"column":2},"end":{"line":358,"column":53}},"177":{"start":{"line":361,"column":1},"end":{"line":366,"column":2}},"178":{"start":{"line":362,"column":2},"end":{"line":365,"column":5}},"179":{"start":{"line":363,"column":3},"end":{"line":363,"column":33}},"180":{"start":{"line":364,"column":3},"end":{"line":364,"column":42}},"181":{"start":{"line":369,"column":1},"end":{"line":371,"column":4}},"182":{"start":{"line":370,"column":2},"end":{"line":370,"column":29}},"183":{"start":{"line":372,"column":1},"end":{"line":374,"column":4}},"184":{"start":{"line":373,"column":2},"end":{"line":373,"column":26}}},"branchMap":{"1":{"line":19,"type":"if","locations":[{"start":{"line":19,"column":1},"end":{"line":19,"column":1}},{"start":{"line":19,"column":1},"end":{"line":19,"column":1}}]},"2":{"line":19,"type":"binary-expr","locations":[{"start":{"line":19,"column":5},"end":{"line":19,"column":10}},{"start":{"line":19,"column":14},"end":{"line":19,"column":38}}]},"3":{"line":23,"type":"if","locations":[{"start":{"line":23,"column":1},"end":{"line":23,"column":1}},{"start":{"line":23,"column":1},"end":{"line":23,"column":1}}]},"4":{"line":23,"type":"binary-expr","locations":[{"start":{"line":23,"column":5},"end":{"line":23,"column":12}},{"start":{"line":23,"column":16},"end":{"line":23,"column":42}}]},"5":{"line":31,"type":"if","locations":[{"start":{"line":31,"column":1},"end":{"line":31,"column":1}},{"start":{"line":31,"column":1},"end":{"line":31,"column":1}}]},"6":{"line":32,"type":"if","locations":[{"start":{"line":32,"column":2},"end":{"line":32,"column":2}},{"start":{"line":32,"column":2},"end":{"line":32,"column":2}}]},"7":{"line":44,"type":"binary-expr","locations":[{"start":{"line":44,"column":8},"end":{"line":44,"column":12}},{"start":{"line":44,"column":16},"end":{"line":44,"column":18}}]},"8":{"line":51,"type":"if","locations":[{"start":{"line":51,"column":1},"end":{"line":51,"column":1}},{"start":{"line":51,"column":1},"end":{"line":51,"column":1}}]},"9":{"line":61,"type":"if","locations":[{"start":{"line":61,"column":2},"end":{"line":61,"column":2}},{"start":{"line":61,"column":2},"end":{"line":61,"column":2}}]},"10":{"line":61,"type":"binary-expr","locations":[{"start":{"line":61,"column":6},"end":{"line":61,"column":24}},{"start":{"line":61,"column":28},"end":{"line":61,"column":54}}]},"11":{"line":86,"type":"if","locations":[{"start":{"line":86,"column":3},"end":{"line":86,"column":3}},{"start":{"line":86,"column":3},"end":{"line":86,"column":3}}]},"12":{"line":93,"type":"if","locations":[{"start":{"line":93,"column":3},"end":{"line":93,"column":3}},{"start":{"line":93,"column":3},"end":{"line":93,"column":3}}]},"13":{"line":113,"type":"if","locations":[{"start":{"line":113,"column":2},"end":{"line":113,"column":2}},{"start":{"line":113,"column":2},"end":{"line":113,"column":2}}]},"14":{"line":113,"type":"binary-expr","locations":[{"start":{"line":113,"column":6},"end":{"line":113,"column":32}},{"start":{"line":113,"column":36},"end":{"line":113,"column":63}}]},"15":{"line":127,"type":"if","locations":[{"start":{"line":127,"column":4},"end":{"line":127,"column":4}},{"start":{"line":127,"column":4},"end":{"line":127,"column":4}}]},"16":{"line":127,"type":"binary-expr","locations":[{"start":{"line":127,"column":8},"end":{"line":127,"column":39}},{"start":{"line":127,"column":43},"end":{"line":127,"column":68}}]},"17":{"line":136,"type":"if","locations":[{"start":{"line":136,"column":4},"end":{"line":136,"column":4}},{"start":{"line":136,"column":4},"end":{"line":136,"column":4}}]},"18":{"line":138,"type":"if","locations":[{"start":{"line":138,"column":11},"end":{"line":138,"column":11}},{"start":{"line":138,"column":11},"end":{"line":138,"column":11}}]},"19":{"line":154,"type":"if","locations":[{"start":{"line":154,"column":2},"end":{"line":154,"column":2}},{"start":{"line":154,"column":2},"end":{"line":154,"column":2}}]},"20":{"line":161,"type":"if","locations":[{"start":{"line":161,"column":2},"end":{"line":161,"column":2}},{"start":{"line":161,"column":2},"end":{"line":161,"column":2}}]},"21":{"line":161,"type":"binary-expr","locations":[{"start":{"line":161,"column":6},"end":{"line":161,"column":31}},{"start":{"line":161,"column":35},"end":{"line":161,"column":49}}]},"22":{"line":191,"type":"if","locations":[{"start":{"line":191,"column":3},"end":{"line":191,"column":3}},{"start":{"line":191,"column":3},"end":{"line":191,"column":3}}]},"23":{"line":191,"type":"binary-expr","locations":[{"start":{"line":191,"column":7},"end":{"line":191,"column":24}},{"start":{"line":191,"column":28},"end":{"line":191,"column":42}}]},"24":{"line":196,"type":"switch","locations":[{"start":{"line":197,"column":4},"end":{"line":203,"column":11}},{"start":{"line":204,"column":4},"end":{"line":211,"column":11}},{"start":{"line":212,"column":4},"end":{"line":222,"column":11}},{"start":{"line":223,"column":4},"end":{"line":229,"column":11}},{"start":{"line":230,"column":4},"end":{"line":234,"column":8}}]},"25":{"line":238,"type":"if","locations":[{"start":{"line":238,"column":2},"end":{"line":238,"column":2}},{"start":{"line":238,"column":2},"end":{"line":238,"column":2}}]},"26":{"line":246,"type":"if","locations":[{"start":{"line":246,"column":2},"end":{"line":246,"column":2}},{"start":{"line":246,"column":2},"end":{"line":246,"column":2}}]},"27":{"line":246,"type":"binary-expr","locations":[{"start":{"line":246,"column":6},"end":{"line":246,"column":31}},{"start":{"line":246,"column":35},"end":{"line":246,"column":49}}]},"28":{"line":253,"type":"if","locations":[{"start":{"line":253,"column":2},"end":{"line":253,"column":2}},{"start":{"line":253,"column":2},"end":{"line":253,"column":2}}]},"29":{"line":253,"type":"binary-expr","locations":[{"start":{"line":253,"column":6},"end":{"line":253,"column":24}},{"start":{"line":253,"column":28},"end":{"line":253,"column":50}}]},"30":{"line":259,"type":"if","locations":[{"start":{"line":259,"column":2},"end":{"line":259,"column":2}},{"start":{"line":259,"column":2},"end":{"line":259,"column":2}}]},"31":{"line":269,"type":"if","locations":[{"start":{"line":269,"column":2},"end":{"line":269,"column":2}},{"start":{"line":269,"column":2},"end":{"line":269,"column":2}}]},"32":{"line":273,"type":"if","locations":[{"start":{"line":273,"column":2},"end":{"line":273,"column":2}},{"start":{"line":273,"column":2},"end":{"line":273,"column":2}}]},"33":{"line":273,"type":"binary-expr","locations":[{"start":{"line":273,"column":6},"end":{"line":273,"column":24}},{"start":{"line":273,"column":28},"end":{"line":273,"column":50}}]},"34":{"line":275,"type":"if","locations":[{"start":{"line":275,"column":9},"end":{"line":275,"column":9}},{"start":{"line":275,"column":9},"end":{"line":275,"column":9}}]},"35":{"line":288,"type":"switch","locations":[{"start":{"line":289,"column":4},"end":{"line":291,"column":11}},{"start":{"line":292,"column":4},"end":{"line":294,"column":11}},{"start":{"line":295,"column":4},"end":{"line":306,"column":11}},{"start":{"line":307,"column":4},"end":{"line":309,"column":11}},{"start":{"line":310,"column":4},"end":{"line":311,"column":60}}]},"36":{"line":297,"type":"if","locations":[{"start":{"line":297,"column":5},"end":{"line":297,"column":5}},{"start":{"line":297,"column":5},"end":{"line":297,"column":5}}]},"37":{"line":315,"type":"if","locations":[{"start":{"line":315,"column":2},"end":{"line":315,"column":2}},{"start":{"line":315,"column":2},"end":{"line":315,"column":2}}]},"38":{"line":319,"type":"switch","locations":[{"start":{"line":320,"column":5},"end":{"line":322,"column":12}},{"start":{"line":323,"column":5},"end":{"line":323,"column":13}}]},"39":{"line":330,"type":"switch","locations":[{"start":{"line":331,"column":5},"end":{"line":331,"column":16}},{"start":{"line":332,"column":5},"end":{"line":334,"column":12}},{"start":{"line":335,"column":5},"end":{"line":346,"column":12}},{"start":{"line":347,"column":5},"end":{"line":349,"column":12}},{"start":{"line":350,"column":5},"end":{"line":350,"column":13}}]}}};
+}
+__cov_4fdV0JXec5cchqDTt_1vzw = __cov_4fdV0JXec5cchqDTt_1vzw['G:\\Programming\\nodecg\\lib\\browser\\replicant.js'];
+__cov_4fdV0JXec5cchqDTt_1vzw.s['1']++;var inherits=require('inherits');__cov_4fdV0JXec5cchqDTt_1vzw.s['2']++;var EventEmitter=require('events').EventEmitter;__cov_4fdV0JXec5cchqDTt_1vzw.s['3']++;var Nested=require('nested-observe');__cov_4fdV0JXec5cchqDTt_1vzw.s['4']++;var objectPath=require('object-path');__cov_4fdV0JXec5cchqDTt_1vzw.s['5']++;var equal=require('deep-equal');__cov_4fdV0JXec5cchqDTt_1vzw.s['6']++;var clone=require('clone');__cov_4fdV0JXec5cchqDTt_1vzw.s['7']++;var uuid=require('uuid');__cov_4fdV0JXec5cchqDTt_1vzw.s['8']++;var declaredReplicants={};__cov_4fdV0JXec5cchqDTt_1vzw.s['9']++;inherits(Replicant,EventEmitter);__cov_4fdV0JXec5cchqDTt_1vzw.s['10']++;module.exports=Replicant;__cov_4fdV0JXec5cchqDTt_1vzw.s['11']++;Replicant.declaredReplicants=declaredReplicants;function Replicant(name,bundle,opts,socket){__cov_4fdV0JXec5cchqDTt_1vzw.f['1']++;__cov_4fdV0JXec5cchqDTt_1vzw.s['13']++;if((__cov_4fdV0JXec5cchqDTt_1vzw.b['2'][0]++,!name)||(__cov_4fdV0JXec5cchqDTt_1vzw.b['2'][1]++,typeof name!=='string')){__cov_4fdV0JXec5cchqDTt_1vzw.b['1'][0]++;__cov_4fdV0JXec5cchqDTt_1vzw.s['14']++;throw new Error('Must supply a name when instantiating a Replicant');}else{__cov_4fdV0JXec5cchqDTt_1vzw.b['1'][1]++;}__cov_4fdV0JXec5cchqDTt_1vzw.s['15']++;if((__cov_4fdV0JXec5cchqDTt_1vzw.b['4'][0]++,!bundle)||(__cov_4fdV0JXec5cchqDTt_1vzw.b['4'][1]++,typeof bundle!=='string')){__cov_4fdV0JXec5cchqDTt_1vzw.b['3'][0]++;__cov_4fdV0JXec5cchqDTt_1vzw.s['16']++;throw new Error('Must supply a bundle name when instantiating a Replicant');}else{__cov_4fdV0JXec5cchqDTt_1vzw.b['3'][1]++;}__cov_4fdV0JXec5cchqDTt_1vzw.s['17']++;var log=require('./logger')('Replicant/'+bundle+'.'+name);__cov_4fdV0JXec5cchqDTt_1vzw.s['18']++;if(declaredReplicants.hasOwnProperty(bundle)){__cov_4fdV0JXec5cchqDTt_1vzw.b['5'][0]++;__cov_4fdV0JXec5cchqDTt_1vzw.s['19']++;if(declaredReplicants[bundle].hasOwnProperty(name)){__cov_4fdV0JXec5cchqDTt_1vzw.b['6'][0]++;__cov_4fdV0JXec5cchqDTt_1vzw.s['20']++;return declaredReplicants[bundle][name];}else{__cov_4fdV0JXec5cchqDTt_1vzw.b['6'][1]++;}__cov_4fdV0JXec5cchqDTt_1vzw.s['21']++;declaredReplicants[bundle][name]=this;}else{__cov_4fdV0JXec5cchqDTt_1vzw.b['5'][1]++;__cov_4fdV0JXec5cchqDTt_1vzw.s['22']++;declaredReplicants[bundle]={};__cov_4fdV0JXec5cchqDTt_1vzw.s['23']++;declaredReplicants[bundle][name]=this;}__cov_4fdV0JXec5cchqDTt_1vzw.s['24']++;var self=this;__cov_4fdV0JXec5cchqDTt_1vzw.s['25']++;var value;__cov_4fdV0JXec5cchqDTt_1vzw.s['26']++;opts=(__cov_4fdV0JXec5cchqDTt_1vzw.b['7'][0]++,opts)||(__cov_4fdV0JXec5cchqDTt_1vzw.b['7'][1]++,{});__cov_4fdV0JXec5cchqDTt_1vzw.s['27']++;this.name=name;__cov_4fdV0JXec5cchqDTt_1vzw.s['28']++;this.bundle=bundle;__cov_4fdV0JXec5cchqDTt_1vzw.s['29']++;this.opts=opts;__cov_4fdV0JXec5cchqDTt_1vzw.s['30']++;this.revision=0;__cov_4fdV0JXec5cchqDTt_1vzw.s['31']++;this.status='undeclared';__cov_4fdV0JXec5cchqDTt_1vzw.s['32']++;this.id=uuid.v4();__cov_4fdV0JXec5cchqDTt_1vzw.s['33']++;if(typeof opts.persistent==='undefined'){__cov_4fdV0JXec5cchqDTt_1vzw.b['8'][0]++;__cov_4fdV0JXec5cchqDTt_1vzw.s['34']++;opts.persistent=true;}else{__cov_4fdV0JXec5cchqDTt_1vzw.b['8'][1]++;}__cov_4fdV0JXec5cchqDTt_1vzw.s['35']++;this.on('newListener',function(event,listener){__cov_4fdV0JXec5cchqDTt_1vzw.f['2']++;__cov_4fdV0JXec5cchqDTt_1vzw.s['36']++;if((__cov_4fdV0JXec5cchqDTt_1vzw.b['10'][0]++,event==='change')&&(__cov_4fdV0JXec5cchqDTt_1vzw.b['10'][1]++,self.status==='declared')){__cov_4fdV0JXec5cchqDTt_1vzw.b['9'][0]++;__cov_4fdV0JXec5cchqDTt_1vzw.s['37']++;listener(undefined,value);}else{__cov_4fdV0JXec5cchqDTt_1vzw.b['9'][1]++;}});__cov_4fdV0JXec5cchqDTt_1vzw.s['38']++;var queue=[];function addToQueue(fn,args){__cov_4fdV0JXec5cchqDTt_1vzw.f['3']++;__cov_4fdV0JXec5cchqDTt_1vzw.s['40']++;queue.push({fn:fn,args:args});}function processQueue(){__cov_4fdV0JXec5cchqDTt_1vzw.f['4']++;__cov_4fdV0JXec5cchqDTt_1vzw.s['42']++;queue.forEach(function(item){__cov_4fdV0JXec5cchqDTt_1vzw.f['5']++;__cov_4fdV0JXec5cchqDTt_1vzw.s['43']++;item.fn.apply(this,item.args);});}__cov_4fdV0JXec5cchqDTt_1vzw.s['44']++;Object.defineProperty(this,'value',{get:function(){__cov_4fdV0JXec5cchqDTt_1vzw.f['6']++;__cov_4fdV0JXec5cchqDTt_1vzw.s['45']++;return value;},set:function(newValue){__cov_4fdV0JXec5cchqDTt_1vzw.f['7']++;__cov_4fdV0JXec5cchqDTt_1vzw.s['46']++;if(newValue===value){__cov_4fdV0JXec5cchqDTt_1vzw.b['11'][0]++;__cov_4fdV0JXec5cchqDTt_1vzw.s['47']++;log.replicants('value unchanged, no action will be taken');__cov_4fdV0JXec5cchqDTt_1vzw.s['48']++;return value;}else{__cov_4fdV0JXec5cchqDTt_1vzw.b['11'][1]++;}__cov_4fdV0JXec5cchqDTt_1vzw.s['49']++;log.replicants('running setter with',newValue);__cov_4fdV0JXec5cchqDTt_1vzw.s['50']++;if(self.status!=='declared'){__cov_4fdV0JXec5cchqDTt_1vzw.b['12'][0]++;__cov_4fdV0JXec5cchqDTt_1vzw.s['51']++;addToQueue(doBrowserSetter,[newValue]);__cov_4fdV0JXec5cchqDTt_1vzw.s['52']++;return undefined;}else{__cov_4fdV0JXec5cchqDTt_1vzw.b['12'][1]++;}__cov_4fdV0JXec5cchqDTt_1vzw.s['53']++;doBrowserSetter(newValue);},enumerable:true});function doBrowserSetter(newValue){__cov_4fdV0JXec5cchqDTt_1vzw.f['8']++;__cov_4fdV0JXec5cchqDTt_1vzw.s['55']++;socket.emit('assignReplicant',{name:name,bundle:bundle,value:newValue,originatorId:self.id});}function doBrowserDeclare(defaultValue){__cov_4fdV0JXec5cchqDTt_1vzw.f['9']++;__cov_4fdV0JXec5cchqDTt_1vzw.s['57']++;if((__cov_4fdV0JXec5cchqDTt_1vzw.b['14'][0]++,self.status==='declared')||(__cov_4fdV0JXec5cchqDTt_1vzw.b['14'][1]++,self.status==='declaring')){__cov_4fdV0JXec5cchqDTt_1vzw.b['13'][0]++;__cov_4fdV0JXec5cchqDTt_1vzw.s['58']++;return;}else{__cov_4fdV0JXec5cchqDTt_1vzw.b['13'][1]++;}__cov_4fdV0JXec5cchqDTt_1vzw.s['59']++;self.status='declaring';__cov_4fdV0JXec5cchqDTt_1vzw.s['60']++;socket.emit('joinRoom',bundle,function(){__cov_4fdV0JXec5cchqDTt_1vzw.f['10']++;__cov_4fdV0JXec5cchqDTt_1vzw.s['61']++;socket.emit('declareReplicant',{name:name,bundle:bundle,defaultValue:defaultValue,persistent:opts.persistent},function(data){__cov_4fdV0JXec5cchqDTt_1vzw.f['11']++;__cov_4fdV0JXec5cchqDTt_1vzw.s['62']++;log.replicants('declareReplicant callback (value: %s, revision: %s)',data.value,data.revision);__cov_4fdV0JXec5cchqDTt_1vzw.s['63']++;var didMismatchReassignment=false;__cov_4fdV0JXec5cchqDTt_1vzw.s['64']++;if((__cov_4fdV0JXec5cchqDTt_1vzw.b['16'][0]++,self.revision!==data.revision)||(__cov_4fdV0JXec5cchqDTt_1vzw.b['16'][1]++,!equal(value,data.value))){__cov_4fdV0JXec5cchqDTt_1vzw.b['15'][0]++;__cov_4fdV0JXec5cchqDTt_1vzw.s['65']++;unobserveValue();__cov_4fdV0JXec5cchqDTt_1vzw.s['66']++;value=defaultValue;__cov_4fdV0JXec5cchqDTt_1vzw.s['67']++;observeValue();__cov_4fdV0JXec5cchqDTt_1vzw.s['68']++;assignValue(data.value,data.revision);__cov_4fdV0JXec5cchqDTt_1vzw.s['69']++;didMismatchReassignment=true;}else{__cov_4fdV0JXec5cchqDTt_1vzw.b['15'][1]++;}__cov_4fdV0JXec5cchqDTt_1vzw.s['70']++;self.status='declared';__cov_4fdV0JXec5cchqDTt_1vzw.s['71']++;self.emit('declared',data);__cov_4fdV0JXec5cchqDTt_1vzw.s['72']++;if(queue.length>0){__cov_4fdV0JXec5cchqDTt_1vzw.b['17'][0]++;__cov_4fdV0JXec5cchqDTt_1vzw.s['73']++;processQueue();}else{__cov_4fdV0JXec5cchqDTt_1vzw.b['17'][1]++;__cov_4fdV0JXec5cchqDTt_1vzw.s['74']++;if(!didMismatchReassignment){__cov_4fdV0JXec5cchqDTt_1vzw.b['18'][0]++;__cov_4fdV0JXec5cchqDTt_1vzw.s['75']++;self.emit('change',undefined,data.value);}else{__cov_4fdV0JXec5cchqDTt_1vzw.b['18'][1]++;}}});});}__cov_4fdV0JXec5cchqDTt_1vzw.s['76']++;doBrowserDeclare(opts.defaultValue);function assignValue(newValue,revision){__cov_4fdV0JXec5cchqDTt_1vzw.f['12']++;__cov_4fdV0JXec5cchqDTt_1vzw.s['78']++;unobserveValue();__cov_4fdV0JXec5cchqDTt_1vzw.s['79']++;var oldValue=clone(value);__cov_4fdV0JXec5cchqDTt_1vzw.s['80']++;value=newValue;__cov_4fdV0JXec5cchqDTt_1vzw.s['81']++;observeValue();__cov_4fdV0JXec5cchqDTt_1vzw.s['82']++;if(typeof revision!=='undefined'){__cov_4fdV0JXec5cchqDTt_1vzw.b['19'][0]++;__cov_4fdV0JXec5cchqDTt_1vzw.s['83']++;self.revision=revision;}else{__cov_4fdV0JXec5cchqDTt_1vzw.b['19'][1]++;}__cov_4fdV0JXec5cchqDTt_1vzw.s['84']++;self.emit('change',oldValue,value);}function observeValue(){__cov_4fdV0JXec5cchqDTt_1vzw.f['13']++;__cov_4fdV0JXec5cchqDTt_1vzw.s['86']++;if((__cov_4fdV0JXec5cchqDTt_1vzw.b['21'][0]++,typeof value==='object')&&(__cov_4fdV0JXec5cchqDTt_1vzw.b['21'][1]++,value!==null)){__cov_4fdV0JXec5cchqDTt_1vzw.b['20'][0]++;__cov_4fdV0JXec5cchqDTt_1vzw.s['87']++;Nested.observe(value,onValueChange);}else{__cov_4fdV0JXec5cchqDTt_1vzw.b['20'][1]++;}}function dispatchChanges(changes){__cov_4fdV0JXec5cchqDTt_1vzw.f['14']++;__cov_4fdV0JXec5cchqDTt_1vzw.s['89']++;socket.emit('changeReplicant',{name:name,bundle:bundle,changes:changes,revision:self.revision,originatorId:self.id},function(value,revision){__cov_4fdV0JXec5cchqDTt_1vzw.f['15']++;__cov_4fdV0JXec5cchqDTt_1vzw.s['90']++;log.replicants('Not at head revision (ours %s, theirs %s). Change aborted & head revision applied.',self.revision,revision);__cov_4fdV0JXec5cchqDTt_1vzw.s['91']++;assignValue(value,revision);});}function onValueChange(rawChanges){__cov_4fdV0JXec5cchqDTt_1vzw.f['16']++;__cov_4fdV0JXec5cchqDTt_1vzw.s['93']++;var formattedChanges=[];__cov_4fdV0JXec5cchqDTt_1vzw.s['94']++;rawChanges.forEach(function(change){__cov_4fdV0JXec5cchqDTt_1vzw.f['17']++;__cov_4fdV0JXec5cchqDTt_1vzw.s['95']++;var path=change.path.substr(1).split('/').map(function(part){__cov_4fdV0JXec5cchqDTt_1vzw.f['18']++;__cov_4fdV0JXec5cchqDTt_1vzw.s['96']++;return part.replace(/\~1/g,'/');});__cov_4fdV0JXec5cchqDTt_1vzw.s['97']++;if((__cov_4fdV0JXec5cchqDTt_1vzw.b['23'][0]++,path.length===1)&&(__cov_4fdV0JXec5cchqDTt_1vzw.b['23'][1]++,path[0]==='')){__cov_4fdV0JXec5cchqDTt_1vzw.b['22'][0]++;__cov_4fdV0JXec5cchqDTt_1vzw.s['98']++;path=[];}else{__cov_4fdV0JXec5cchqDTt_1vzw.b['22'][1]++;}__cov_4fdV0JXec5cchqDTt_1vzw.s['99']++;var newVal=objectPath.get(change.root,path);__cov_4fdV0JXec5cchqDTt_1vzw.s['100']++;switch(change.type){case'add':__cov_4fdV0JXec5cchqDTt_1vzw.b['24'][0]++;__cov_4fdV0JXec5cchqDTt_1vzw.s['101']++;formattedChanges.push({type:'add',path:path,newValue:newVal});__cov_4fdV0JXec5cchqDTt_1vzw.s['102']++;break;case'update':__cov_4fdV0JXec5cchqDTt_1vzw.b['24'][1]++;__cov_4fdV0JXec5cchqDTt_1vzw.s['103']++;formattedChanges.push({type:'update',path:path,oldValue:change.oldValue,newValue:newVal});__cov_4fdV0JXec5cchqDTt_1vzw.s['104']++;break;case'splice':__cov_4fdV0JXec5cchqDTt_1vzw.b['24'][2]++;__cov_4fdV0JXec5cchqDTt_1vzw.s['105']++;formattedChanges.push({type:'splice',path:path,index:change.index,removed:change.removed,removedCount:change.removed.length,added:change.object.slice(change.index,change.index+change.addedCount),addedCount:change.addedCount});__cov_4fdV0JXec5cchqDTt_1vzw.s['106']++;break;case'delete':__cov_4fdV0JXec5cchqDTt_1vzw.b['24'][3]++;__cov_4fdV0JXec5cchqDTt_1vzw.s['107']++;formattedChanges.push({type:'delete',path:path,oldValue:change.oldValue});__cov_4fdV0JXec5cchqDTt_1vzw.s['108']++;break;default:__cov_4fdV0JXec5cchqDTt_1vzw.b['24'][4]++;__cov_4fdV0JXec5cchqDTt_1vzw.s['109']++;formattedChanges.push({type:'other',path:path});}});__cov_4fdV0JXec5cchqDTt_1vzw.s['110']++;if(self.status==='declared'){__cov_4fdV0JXec5cchqDTt_1vzw.b['25'][0]++;__cov_4fdV0JXec5cchqDTt_1vzw.s['111']++;dispatchChanges(formattedChanges);}else{__cov_4fdV0JXec5cchqDTt_1vzw.b['25'][1]++;__cov_4fdV0JXec5cchqDTt_1vzw.s['112']++;addToQueue(dispatchChanges,[formattedChanges]);}}function unobserveValue(){__cov_4fdV0JXec5cchqDTt_1vzw.f['19']++;__cov_4fdV0JXec5cchqDTt_1vzw.s['114']++;if((__cov_4fdV0JXec5cchqDTt_1vzw.b['27'][0]++,typeof value==='object')&&(__cov_4fdV0JXec5cchqDTt_1vzw.b['27'][1]++,value!==null)){__cov_4fdV0JXec5cchqDTt_1vzw.b['26'][0]++;__cov_4fdV0JXec5cchqDTt_1vzw.s['115']++;Nested.unobserve(value,onValueChange);}else{__cov_4fdV0JXec5cchqDTt_1vzw.b['26'][1]++;}}__cov_4fdV0JXec5cchqDTt_1vzw.s['116']++;socket.on('replicantAssigned',function(data){__cov_4fdV0JXec5cchqDTt_1vzw.f['20']++;__cov_4fdV0JXec5cchqDTt_1vzw.s['117']++;if((__cov_4fdV0JXec5cchqDTt_1vzw.b['29'][0]++,data.name!==name)||(__cov_4fdV0JXec5cchqDTt_1vzw.b['29'][1]++,data.bundle!==bundle)){__cov_4fdV0JXec5cchqDTt_1vzw.b['28'][0]++;__cov_4fdV0JXec5cchqDTt_1vzw.s['118']++;return;}else{__cov_4fdV0JXec5cchqDTt_1vzw.b['28'][1]++;}__cov_4fdV0JXec5cchqDTt_1vzw.s['119']++;log.replicants('replicantAssigned',data);__cov_4fdV0JXec5cchqDTt_1vzw.s['120']++;if(data.originatorId===self.id){__cov_4fdV0JXec5cchqDTt_1vzw.b['30'][0]++;__cov_4fdV0JXec5cchqDTt_1vzw.s['121']++;self.emit('assignmentAccepted',data);}else{__cov_4fdV0JXec5cchqDTt_1vzw.b['30'][1]++;}__cov_4fdV0JXec5cchqDTt_1vzw.s['122']++;assignValue(data.newValue,data.revision);});__cov_4fdV0JXec5cchqDTt_1vzw.s['123']++;socket.on('replicantChanged',function(data){__cov_4fdV0JXec5cchqDTt_1vzw.f['21']++;__cov_4fdV0JXec5cchqDTt_1vzw.s['124']++;if(self.status!=='declared'){__cov_4fdV0JXec5cchqDTt_1vzw.b['31'][0]++;__cov_4fdV0JXec5cchqDTt_1vzw.s['125']++;return;}else{__cov_4fdV0JXec5cchqDTt_1vzw.b['31'][1]++;}__cov_4fdV0JXec5cchqDTt_1vzw.s['126']++;if((__cov_4fdV0JXec5cchqDTt_1vzw.b['33'][0]++,data.name!==name)||(__cov_4fdV0JXec5cchqDTt_1vzw.b['33'][1]++,data.bundle!==bundle)){__cov_4fdV0JXec5cchqDTt_1vzw.b['32'][0]++;__cov_4fdV0JXec5cchqDTt_1vzw.s['127']++;return;}else{__cov_4fdV0JXec5cchqDTt_1vzw.b['32'][1]++;__cov_4fdV0JXec5cchqDTt_1vzw.s['128']++;if(data.revision!==self.revision+1){__cov_4fdV0JXec5cchqDTt_1vzw.b['34'][0]++;__cov_4fdV0JXec5cchqDTt_1vzw.s['129']++;log.replicants('[%s] Replicant "%s" not at head revision (ours %s, theirs %s), fetching latest...',bundle,name,self.revision,data.revision);__cov_4fdV0JXec5cchqDTt_1vzw.s['130']++;fullUpdate();__cov_4fdV0JXec5cchqDTt_1vzw.s['131']++;return;}else{__cov_4fdV0JXec5cchqDTt_1vzw.b['34'][1]++;}}__cov_4fdV0JXec5cchqDTt_1vzw.s['132']++;log.replicants('replicantChanged',data);__cov_4fdV0JXec5cchqDTt_1vzw.s['133']++;var oldValue=clone(value);__cov_4fdV0JXec5cchqDTt_1vzw.s['134']++;var replayChanges=clone(data.changes);__cov_4fdV0JXec5cchqDTt_1vzw.s['135']++;replayChanges.reverse();__cov_4fdV0JXec5cchqDTt_1vzw.s['136']++;replayChanges.forEach(function(change){__cov_4fdV0JXec5cchqDTt_1vzw.f['22']++;__cov_4fdV0JXec5cchqDTt_1vzw.s['137']++;switch(change.type){case'add':__cov_4fdV0JXec5cchqDTt_1vzw.b['35'][0]++;__cov_4fdV0JXec5cchqDTt_1vzw.s['138']++;objectPath.del(oldValue,change.path);__cov_4fdV0JXec5cchqDTt_1vzw.s['139']++;break;case'update':__cov_4fdV0JXec5cchqDTt_1vzw.b['35'][1]++;__cov_4fdV0JXec5cchqDTt_1vzw.s['140']++;objectPath.set(oldValue,change.path,change.oldValue);__cov_4fdV0JXec5cchqDTt_1vzw.s['141']++;break;case'splice':__cov_4fdV0JXec5cchqDTt_1vzw.b['35'][2]++;__cov_4fdV0JXec5cchqDTt_1vzw.s['142']++;var arr=objectPath.get(oldValue,change.path);__cov_4fdV0JXec5cchqDTt_1vzw.s['143']++;if(!arr){__cov_4fdV0JXec5cchqDTt_1vzw.b['36'][0]++;__cov_4fdV0JXec5cchqDTt_1vzw.s['144']++;arr=[];}else{__cov_4fdV0JXec5cchqDTt_1vzw.b['36'][1]++;}__cov_4fdV0JXec5cchqDTt_1vzw.s['145']++;var args=clone(change.removed);__cov_4fdV0JXec5cchqDTt_1vzw.s['146']++;args.unshift(change.addedCount);__cov_4fdV0JXec5cchqDTt_1vzw.s['147']++;args.unshift(change.index);__cov_4fdV0JXec5cchqDTt_1vzw.s['148']++;Array.prototype.splice.apply(arr,args);__cov_4fdV0JXec5cchqDTt_1vzw.s['149']++;objectPath.set(oldValue,change.path,arr);__cov_4fdV0JXec5cchqDTt_1vzw.s['150']++;break;case'delete':__cov_4fdV0JXec5cchqDTt_1vzw.b['35'][3]++;__cov_4fdV0JXec5cchqDTt_1vzw.s['151']++;objectPath.set(oldValue,change.path,change.oldValue);__cov_4fdV0JXec5cchqDTt_1vzw.s['152']++;break;default:__cov_4fdV0JXec5cchqDTt_1vzw.b['35'][4]++;__cov_4fdV0JXec5cchqDTt_1vzw.s['153']++;objectPath.set(oldValue,change.path,change.oldValue);}});__cov_4fdV0JXec5cchqDTt_1vzw.s['154']++;if(data.originatorId===self.id){__cov_4fdV0JXec5cchqDTt_1vzw.b['37'][0]++;__cov_4fdV0JXec5cchqDTt_1vzw.s['155']++;data.changes.forEach(function(change){__cov_4fdV0JXec5cchqDTt_1vzw.f['23']++;__cov_4fdV0JXec5cchqDTt_1vzw.s['156']++;switch(change.type){case'splice':__cov_4fdV0JXec5cchqDTt_1vzw.b['38'][0]++;__cov_4fdV0JXec5cchqDTt_1vzw.s['157']++;change.object=objectPath.get(value,change.path);__cov_4fdV0JXec5cchqDTt_1vzw.s['158']++;break;default:__cov_4fdV0JXec5cchqDTt_1vzw.b['38'][1]++;}});}else{__cov_4fdV0JXec5cchqDTt_1vzw.b['37'][1]++;__cov_4fdV0JXec5cchqDTt_1vzw.s['159']++;unobserveValue();__cov_4fdV0JXec5cchqDTt_1vzw.s['160']++;data.changes.forEach(function(change){__cov_4fdV0JXec5cchqDTt_1vzw.f['24']++;__cov_4fdV0JXec5cchqDTt_1vzw.s['161']++;switch(change.type){case'add':__cov_4fdV0JXec5cchqDTt_1vzw.b['39'][0]++;case'update':__cov_4fdV0JXec5cchqDTt_1vzw.b['39'][1]++;__cov_4fdV0JXec5cchqDTt_1vzw.s['162']++;objectPath.set(value,change.path,change.newValue);__cov_4fdV0JXec5cchqDTt_1vzw.s['163']++;break;case'splice':__cov_4fdV0JXec5cchqDTt_1vzw.b['39'][2]++;__cov_4fdV0JXec5cchqDTt_1vzw.s['164']++;var arr=objectPath.get(value,change.path);__cov_4fdV0JXec5cchqDTt_1vzw.s['165']++;var args=clone(change.added);__cov_4fdV0JXec5cchqDTt_1vzw.s['166']++;args.unshift(change.removedCount);__cov_4fdV0JXec5cchqDTt_1vzw.s['167']++;args.unshift(change.index);__cov_4fdV0JXec5cchqDTt_1vzw.s['168']++;Array.prototype.splice.apply(arr,args);__cov_4fdV0JXec5cchqDTt_1vzw.s['169']++;objectPath.set(value,change.path,arr);__cov_4fdV0JXec5cchqDTt_1vzw.s['170']++;change.object=arr;__cov_4fdV0JXec5cchqDTt_1vzw.s['171']++;break;case'delete':__cov_4fdV0JXec5cchqDTt_1vzw.b['39'][3]++;__cov_4fdV0JXec5cchqDTt_1vzw.s['172']++;objectPath.del(value,change.path);__cov_4fdV0JXec5cchqDTt_1vzw.s['173']++;break;default:__cov_4fdV0JXec5cchqDTt_1vzw.b['39'][4]++;}});__cov_4fdV0JXec5cchqDTt_1vzw.s['174']++;observeValue();}__cov_4fdV0JXec5cchqDTt_1vzw.s['175']++;self.revision=data.revision;__cov_4fdV0JXec5cchqDTt_1vzw.s['176']++;self.emit('change',oldValue,value,data.changes);});function fullUpdate(){__cov_4fdV0JXec5cchqDTt_1vzw.f['25']++;__cov_4fdV0JXec5cchqDTt_1vzw.s['178']++;window.NodeCG.readReplicant(name,bundle,function(data){__cov_4fdV0JXec5cchqDTt_1vzw.f['26']++;__cov_4fdV0JXec5cchqDTt_1vzw.s['179']++;self.emit('fullUpdate',data);__cov_4fdV0JXec5cchqDTt_1vzw.s['180']++;assignValue(data.value,data.revision);});}__cov_4fdV0JXec5cchqDTt_1vzw.s['181']++;socket.on('disconnect',function(){__cov_4fdV0JXec5cchqDTt_1vzw.f['27']++;__cov_4fdV0JXec5cchqDTt_1vzw.s['182']++;self.status='undeclared';});__cov_4fdV0JXec5cchqDTt_1vzw.s['183']++;socket.on('reconnect',function(){__cov_4fdV0JXec5cchqDTt_1vzw.f['28']++;__cov_4fdV0JXec5cchqDTt_1vzw.s['184']++;doBrowserDeclare(value);});}
+
+},{"./logger":3,"clone":10,"deep-equal":11,"events":14,"inherits":16,"nested-observe":17,"object-path":20,"uuid":22}],5:[function(require,module,exports){
+'use strict';
+
+var LOG_LEVELS = {
+    trace: 0,
+    debug: 1,
+    info: 2,
+    warn: 3,
+    error: 4,
+    _infinite: Infinity
+};
+
+/**
+ * Enum logging level values.
+ * @enum {String}
+ */
+var ENUM_LEVELS = { // jshint ignore:line
+    trace: 'The highest level of logging, logs everything.',
+    debug: 'Less spammy than trace, includes most info relevant for debugging.',
+    info: 'The default logging level. Logs useful info, warnings, and errors.',
+    warn: 'Only logs warnings and errors.',
+    error: 'Only logs errors.'
+};
+
+/**
+ * A factory that configures and returns a Logger constructor.
+ * @param [initialOpts] {Object} - Configuration for the logger.
+ *
+ * @param [initialOpts.console] {Object} - Configuration for the console logging.
+ * @param [initialOpts.console.enabled=false] {Boolean} - Whether to enable console logging.
+ * @param [initialOpts.console.level="info"] {ENUM_LEVELS} - The level of logging to output to the console.
+ *
+ * @param [initialOpts.replicants=false] {Boolean} - Whether to enable logging specifically for the Replicants system.
+ *
+ * @returns {function} - A constructor used to create discrete logger instances.
+ */
+module.exports = function(initialOpts) {
+    initialOpts = initialOpts || {};
+    initialOpts.console = initialOpts.console || {};
+
+    /**
+     * Constructs a new Logger instance that prefixes all output with the given name.
+     * @param name {String} - The label to prefix all output of this logger with.
+     * @returns {Object} - A Logger instance.
+     * @constructor
+     */
+    function Logger(name) {
+        this.name = name;
+    }
+
+    Logger.prototype = {
+        trace: function () {
+            if (Logger._silent) return;
+            if (LOG_LEVELS[Logger._level] > LOG_LEVELS.trace) return;
+            arguments[0] = '[' + this.name + '] ' + arguments[0];
+            console.info.apply(console, arguments);
+        },
+        debug: function () {
+            if (Logger._silent) return;
+            if (LOG_LEVELS[Logger._level] > LOG_LEVELS.debug) return;
+            arguments[0] = '[' + this.name + '] ' + arguments[0];
+            console.info.apply(console, arguments);
+        },
+        info: function() {
+            if (Logger._silent) return;
+            if (LOG_LEVELS[Logger._level] > LOG_LEVELS.info) return;
+            arguments[0] = '[' + this.name + '] ' + arguments[0];
+            console.info.apply(console, arguments);
+        },
+        warn: function() {
+            if (Logger._silent) return;
+            if (LOG_LEVELS[Logger._level] > LOG_LEVELS.warn) return;
+            arguments[0] = '[' + this.name + '] ' + arguments[0];
+            console.warn.apply(console, arguments);
+        },
+        error: function() {
+            if (Logger._silent) return;
+            if (LOG_LEVELS[Logger._level] > LOG_LEVELS.error) return;
+            arguments[0] = '[' + this.name + '] ' + arguments[0];
+            console.error.apply(console, arguments);
+        },
+        replicants: function() {
+            if (Logger._silent) return;
+            if (!Logger._shouldLogReplicants) return;
+            arguments[0] = '[' + this.name + '] ' + arguments[0];
+            console.info.apply(console, arguments);
+        }
+    };
+
+    Logger.globalReconfigure = function(opts) {
+        _configure(opts);
+    };
+
+    // Initialize with defaults
+    Logger._level = 'info';
+    Logger._silent = true;
+    Logger._shouldLogReplicants = false;
+
+    _configure(initialOpts);
+
+    function _configure(opts) {
+        // Initialize opts with empty objects, if nothing was provided.
+        opts = opts || {};
+        opts.console = opts.console || {};
+
+        if (typeof opts.console.enabled !== 'undefined') {
+            Logger._silent = !opts.console.enabled;
+        }
+
+        if (typeof opts.console.level !== 'undefined') {
+            Logger._level = opts.console.level;
+        }
+
+        if (typeof opts.replicants !== 'undefined') {
+            Logger._shouldLogReplicants = opts.replicants;
+        }
+    }
+
+    return Logger;
+};
+
+
+},{}],6:[function(require,module,exports){
+var lookup = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/';
+
+;(function (exports) {
+	'use strict';
+
+  var Arr = (typeof Uint8Array !== 'undefined')
+    ? Uint8Array
+    : Array
+
+	var PLUS   = '+'.charCodeAt(0)
+	var SLASH  = '/'.charCodeAt(0)
+	var NUMBER = '0'.charCodeAt(0)
+	var LOWER  = 'a'.charCodeAt(0)
+	var UPPER  = 'A'.charCodeAt(0)
+	var PLUS_URL_SAFE = '-'.charCodeAt(0)
+	var SLASH_URL_SAFE = '_'.charCodeAt(0)
+
+	function decode (elt) {
+		var code = elt.charCodeAt(0)
+		if (code === PLUS ||
+		    code === PLUS_URL_SAFE)
+			return 62 // '+'
+		if (code === SLASH ||
+		    code === SLASH_URL_SAFE)
+			return 63 // '/'
+		if (code < NUMBER)
+			return -1 //no match
+		if (code < NUMBER + 10)
+			return code - NUMBER + 26 + 26
+		if (code < UPPER + 26)
+			return code - UPPER
+		if (code < LOWER + 26)
+			return code - LOWER + 26
+	}
+
+	function b64ToByteArray (b64) {
+		var i, j, l, tmp, placeHolders, arr
+
+		if (b64.length % 4 > 0) {
+			throw new Error('Invalid string. Length must be a multiple of 4')
+		}
+
+		// the number of equal signs (place holders)
+		// if there are two placeholders, than the two characters before it
+		// represent one byte
+		// if there is only one, then the three characters before it represent 2 bytes
+		// this is just a cheap hack to not do indexOf twice
+		var len = b64.length
+		placeHolders = '=' === b64.charAt(len - 2) ? 2 : '=' === b64.charAt(len - 1) ? 1 : 0
+
+		// base64 is 4/3 + up to two characters of the original data
+		arr = new Arr(b64.length * 3 / 4 - placeHolders)
+
+		// if there are placeholders, only get up to the last complete 4 chars
+		l = placeHolders > 0 ? b64.length - 4 : b64.length
+
+		var L = 0
+
+		function push (v) {
+			arr[L++] = v
+		}
+
+		for (i = 0, j = 0; i < l; i += 4, j += 3) {
+			tmp = (decode(b64.charAt(i)) << 18) | (decode(b64.charAt(i + 1)) << 12) | (decode(b64.charAt(i + 2)) << 6) | decode(b64.charAt(i + 3))
+			push((tmp & 0xFF0000) >> 16)
+			push((tmp & 0xFF00) >> 8)
+			push(tmp & 0xFF)
+		}
+
+		if (placeHolders === 2) {
+			tmp = (decode(b64.charAt(i)) << 2) | (decode(b64.charAt(i + 1)) >> 4)
+			push(tmp & 0xFF)
+		} else if (placeHolders === 1) {
+			tmp = (decode(b64.charAt(i)) << 10) | (decode(b64.charAt(i + 1)) << 4) | (decode(b64.charAt(i + 2)) >> 2)
+			push((tmp >> 8) & 0xFF)
+			push(tmp & 0xFF)
+		}
+
+		return arr
+	}
+
+	function uint8ToBase64 (uint8) {
+		var i,
+			extraBytes = uint8.length % 3, // if we have 1 byte left, pad 2 bytes
+			output = "",
+			temp, length
+
+		function encode (num) {
+			return lookup.charAt(num)
+		}
+
+		function tripletToBase64 (num) {
+			return encode(num >> 18 & 0x3F) + encode(num >> 12 & 0x3F) + encode(num >> 6 & 0x3F) + encode(num & 0x3F)
+		}
+
+		// go through the array every three bytes, we'll deal with trailing stuff later
+		for (i = 0, length = uint8.length - extraBytes; i < length; i += 3) {
+			temp = (uint8[i] << 16) + (uint8[i + 1] << 8) + (uint8[i + 2])
+			output += tripletToBase64(temp)
+		}
+
+		// pad the end with zeros, but make sure to not forget the extra bytes
+		switch (extraBytes) {
+			case 1:
+				temp = uint8[uint8.length - 1]
+				output += encode(temp >> 2)
+				output += encode((temp << 4) & 0x3F)
+				output += '=='
+				break
+			case 2:
+				temp = (uint8[uint8.length - 2] << 8) + (uint8[uint8.length - 1])
+				output += encode(temp >> 10)
+				output += encode((temp >> 4) & 0x3F)
+				output += encode((temp << 2) & 0x3F)
+				output += '='
+				break
+		}
+
+		return output
+	}
+
+	exports.toByteArray = b64ToByteArray
+	exports.fromByteArray = uint8ToBase64
+}(typeof exports === 'undefined' ? (this.base64js = {}) : exports))
+
+},{}],7:[function(require,module,exports){
+
+},{}],8:[function(require,module,exports){
+(function (global){
+/*!
+ * The buffer module from node.js, for the browser.
+ *
+ * @author   Feross Aboukhadijeh <feross@feross.org> <http://feross.org>
+ * @license  MIT
+ */
+/* eslint-disable no-proto */
+
+'use strict'
+
+var base64 = require('base64-js')
+var ieee754 = require('ieee754')
+var isArray = require('isarray')
+
+exports.Buffer = Buffer
+exports.SlowBuffer = SlowBuffer
+exports.INSPECT_MAX_BYTES = 50
+Buffer.poolSize = 8192 // not used by this implementation
+
+var rootParent = {}
+
+/**
+ * If `Buffer.TYPED_ARRAY_SUPPORT`:
+ *   === true    Use Uint8Array implementation (fastest)
+ *   === false   Use Object implementation (most compatible, even IE6)
+ *
+ * Browsers that support typed arrays are IE 10+, Firefox 4+, Chrome 7+, Safari 5.1+,
+ * Opera 11.6+, iOS 4.2+.
+ *
+ * Due to various browser bugs, sometimes the Object implementation will be used even
+ * when the browser supports typed arrays.
+ *
+ * Note:
+ *
+ *   - Firefox 4-29 lacks support for adding new properties to `Uint8Array` instances,
+ *     See: https://bugzilla.mozilla.org/show_bug.cgi?id=695438.
+ *
+ *   - Safari 5-7 lacks support for changing the `Object.prototype.constructor` property
+ *     on objects.
+ *
+ *   - Chrome 9-10 is missing the `TypedArray.prototype.subarray` function.
+ *
+ *   - IE10 has a broken `TypedArray.prototype.subarray` function which returns arrays of
+ *     incorrect length in some situations.
+
+ * We detect these buggy browsers and set `Buffer.TYPED_ARRAY_SUPPORT` to `false` so they
+ * get the Object implementation, which is slower but behaves correctly.
+ */
+Buffer.TYPED_ARRAY_SUPPORT = global.TYPED_ARRAY_SUPPORT !== undefined
+  ? global.TYPED_ARRAY_SUPPORT
+  : typedArraySupport()
+
+function typedArraySupport () {
+  function Bar () {}
+  try {
+    var arr = new Uint8Array(1)
+    arr.foo = function () { return 42 }
+    arr.constructor = Bar
+    return arr.foo() === 42 && // typed array instances can be augmented
+        arr.constructor === Bar && // constructor can be set
+        typeof arr.subarray === 'function' && // chrome 9-10 lack `subarray`
+        arr.subarray(1, 1).byteLength === 0 // ie10 has broken `subarray`
+  } catch (e) {
+    return false
+  }
+}
+
+function kMaxLength () {
+  return Buffer.TYPED_ARRAY_SUPPORT
+    ? 0x7fffffff
+    : 0x3fffffff
+}
+
+/**
+ * Class: Buffer
+ * =============
+ *
+ * The Buffer constructor returns instances of `Uint8Array` that are augmented
+ * with function properties for all the node `Buffer` API functions. We use
+ * `Uint8Array` so that square bracket notation works as expected -- it returns
+ * a single octet.
+ *
+ * By augmenting the instances, we can avoid modifying the `Uint8Array`
+ * prototype.
+ */
+function Buffer (arg) {
+  if (!(this instanceof Buffer)) {
+    // Avoid going through an ArgumentsAdaptorTrampoline in the common case.
+    if (arguments.length > 1) return new Buffer(arg, arguments[1])
+    return new Buffer(arg)
+  }
+
+  if (!Buffer.TYPED_ARRAY_SUPPORT) {
+    this.length = 0
+    this.parent = undefined
+  }
+
+  // Common case.
+  if (typeof arg === 'number') {
+    return fromNumber(this, arg)
+  }
+
+  // Slightly less common case.
+  if (typeof arg === 'string') {
+    return fromString(this, arg, arguments.length > 1 ? arguments[1] : 'utf8')
+  }
+
+  // Unusual.
+  return fromObject(this, arg)
+}
+
+function fromNumber (that, length) {
+  that = allocate(that, length < 0 ? 0 : checked(length) | 0)
+  if (!Buffer.TYPED_ARRAY_SUPPORT) {
+    for (var i = 0; i < length; i++) {
+      that[i] = 0
+    }
+  }
+  return that
+}
+
+function fromString (that, string, encoding) {
+  if (typeof encoding !== 'string' || encoding === '') encoding = 'utf8'
+
+  // Assumption: byteLength() return value is always < kMaxLength.
+  var length = byteLength(string, encoding) | 0
+  that = allocate(that, length)
+
+  that.write(string, encoding)
+  return that
+}
+
+function fromObject (that, object) {
+  if (Buffer.isBuffer(object)) return fromBuffer(that, object)
+
+  if (isArray(object)) return fromArray(that, object)
+
+  if (object == null) {
+    throw new TypeError('must start with number, buffer, array or string')
+  }
+
+  if (typeof ArrayBuffer !== 'undefined') {
+    if (object.buffer instanceof ArrayBuffer) {
+      return fromTypedArray(that, object)
+    }
+    if (object instanceof ArrayBuffer) {
+      return fromArrayBuffer(that, object)
+    }
+  }
+
+  if (object.length) return fromArrayLike(that, object)
+
+  return fromJsonObject(that, object)
+}
+
+function fromBuffer (that, buffer) {
+  var length = checked(buffer.length) | 0
+  that = allocate(that, length)
+  buffer.copy(that, 0, 0, length)
+  return that
+}
+
+function fromArray (that, array) {
+  var length = checked(array.length) | 0
+  that = allocate(that, length)
+  for (var i = 0; i < length; i += 1) {
+    that[i] = array[i] & 255
+  }
+  return that
+}
+
+// Duplicate of fromArray() to keep fromArray() monomorphic.
+function fromTypedArray (that, array) {
+  var length = checked(array.length) | 0
+  that = allocate(that, length)
+  // Truncating the elements is probably not what people expect from typed
+  // arrays with BYTES_PER_ELEMENT > 1 but it's compatible with the behavior
+  // of the old Buffer constructor.
+  for (var i = 0; i < length; i += 1) {
+    that[i] = array[i] & 255
+  }
+  return that
+}
+
+function fromArrayBuffer (that, array) {
+  if (Buffer.TYPED_ARRAY_SUPPORT) {
+    // Return an augmented `Uint8Array` instance, for best performance
+    array.byteLength
+    that = Buffer._augment(new Uint8Array(array))
+  } else {
+    // Fallback: Return an object instance of the Buffer class
+    that = fromTypedArray(that, new Uint8Array(array))
+  }
+  return that
+}
+
+function fromArrayLike (that, array) {
+  var length = checked(array.length) | 0
+  that = allocate(that, length)
+  for (var i = 0; i < length; i += 1) {
+    that[i] = array[i] & 255
+  }
+  return that
+}
+
+// Deserialize { type: 'Buffer', data: [1,2,3,...] } into a Buffer object.
+// Returns a zero-length buffer for inputs that don't conform to the spec.
+function fromJsonObject (that, object) {
+  var array
+  var length = 0
+
+  if (object.type === 'Buffer' && isArray(object.data)) {
+    array = object.data
+    length = checked(array.length) | 0
+  }
+  that = allocate(that, length)
+
+  for (var i = 0; i < length; i += 1) {
+    that[i] = array[i] & 255
+  }
+  return that
+}
+
+if (Buffer.TYPED_ARRAY_SUPPORT) {
+  Buffer.prototype.__proto__ = Uint8Array.prototype
+  Buffer.__proto__ = Uint8Array
+} else {
+  // pre-set for values that may exist in the future
+  Buffer.prototype.length = undefined
+  Buffer.prototype.parent = undefined
+}
+
+function allocate (that, length) {
+  if (Buffer.TYPED_ARRAY_SUPPORT) {
+    // Return an augmented `Uint8Array` instance, for best performance
+    that = Buffer._augment(new Uint8Array(length))
+    that.__proto__ = Buffer.prototype
+  } else {
+    // Fallback: Return an object instance of the Buffer class
+    that.length = length
+    that._isBuffer = true
+  }
+
+  var fromPool = length !== 0 && length <= Buffer.poolSize >>> 1
+  if (fromPool) that.parent = rootParent
+
+  return that
+}
+
+function checked (length) {
+  // Note: cannot use `length < kMaxLength` here because that fails when
+  // length is NaN (which is otherwise coerced to zero.)
+  if (length >= kMaxLength()) {
+    throw new RangeError('Attempt to allocate Buffer larger than maximum ' +
+                         'size: 0x' + kMaxLength().toString(16) + ' bytes')
+  }
+  return length | 0
+}
+
+function SlowBuffer (subject, encoding) {
+  if (!(this instanceof SlowBuffer)) return new SlowBuffer(subject, encoding)
+
+  var buf = new Buffer(subject, encoding)
+  delete buf.parent
+  return buf
+}
+
+Buffer.isBuffer = function isBuffer (b) {
+  return !!(b != null && b._isBuffer)
+}
+
+Buffer.compare = function compare (a, b) {
+  if (!Buffer.isBuffer(a) || !Buffer.isBuffer(b)) {
+    throw new TypeError('Arguments must be Buffers')
+  }
+
+  if (a === b) return 0
+
+  var x = a.length
+  var y = b.length
+
+  var i = 0
+  var len = Math.min(x, y)
+  while (i < len) {
+    if (a[i] !== b[i]) break
+
+    ++i
+  }
+
+  if (i !== len) {
+    x = a[i]
+    y = b[i]
+  }
+
+  if (x < y) return -1
+  if (y < x) return 1
+  return 0
+}
+
+Buffer.isEncoding = function isEncoding (encoding) {
+  switch (String(encoding).toLowerCase()) {
+    case 'hex':
+    case 'utf8':
+    case 'utf-8':
+    case 'ascii':
+    case 'binary':
+    case 'base64':
+    case 'raw':
+    case 'ucs2':
+    case 'ucs-2':
+    case 'utf16le':
+    case 'utf-16le':
+      return true
+    default:
+      return false
+  }
+}
+
+Buffer.concat = function concat (list, length) {
+  if (!isArray(list)) throw new TypeError('list argument must be an Array of Buffers.')
+
+  if (list.length === 0) {
+    return new Buffer(0)
+  }
+
+  var i
+  if (length === undefined) {
+    length = 0
+    for (i = 0; i < list.length; i++) {
+      length += list[i].length
+    }
+  }
+
+  var buf = new Buffer(length)
+  var pos = 0
+  for (i = 0; i < list.length; i++) {
+    var item = list[i]
+    item.copy(buf, pos)
+    pos += item.length
+  }
+  return buf
+}
+
+function byteLength (string, encoding) {
+  if (typeof string !== 'string') string = '' + string
+
+  var len = string.length
+  if (len === 0) return 0
+
+  // Use a for loop to avoid recursion
+  var loweredCase = false
+  for (;;) {
+    switch (encoding) {
+      case 'ascii':
+      case 'binary':
+      // Deprecated
+      case 'raw':
+      case 'raws':
+        return len
+      case 'utf8':
+      case 'utf-8':
+        return utf8ToBytes(string).length
+      case 'ucs2':
+      case 'ucs-2':
+      case 'utf16le':
+      case 'utf-16le':
+        return len * 2
+      case 'hex':
+        return len >>> 1
+      case 'base64':
+        return base64ToBytes(string).length
+      default:
+        if (loweredCase) return utf8ToBytes(string).length // assume utf8
+        encoding = ('' + encoding).toLowerCase()
+        loweredCase = true
+    }
+  }
+}
+Buffer.byteLength = byteLength
+
+function slowToString (encoding, start, end) {
+  var loweredCase = false
+
+  start = start | 0
+  end = end === undefined || end === Infinity ? this.length : end | 0
+
+  if (!encoding) encoding = 'utf8'
+  if (start < 0) start = 0
+  if (end > this.length) end = this.length
+  if (end <= start) return ''
+
+  while (true) {
+    switch (encoding) {
+      case 'hex':
+        return hexSlice(this, start, end)
+
+      case 'utf8':
+      case 'utf-8':
+        return utf8Slice(this, start, end)
+
+      case 'ascii':
+        return asciiSlice(this, start, end)
+
+      case 'binary':
+        return binarySlice(this, start, end)
+
+      case 'base64':
+        return base64Slice(this, start, end)
+
+      case 'ucs2':
+      case 'ucs-2':
+      case 'utf16le':
+      case 'utf-16le':
+        return utf16leSlice(this, start, end)
+
+      default:
+        if (loweredCase) throw new TypeError('Unknown encoding: ' + encoding)
+        encoding = (encoding + '').toLowerCase()
+        loweredCase = true
+    }
+  }
+}
+
+Buffer.prototype.toString = function toString () {
+  var length = this.length | 0
+  if (length === 0) return ''
+  if (arguments.length === 0) return utf8Slice(this, 0, length)
+  return slowToString.apply(this, arguments)
+}
+
+Buffer.prototype.equals = function equals (b) {
+  if (!Buffer.isBuffer(b)) throw new TypeError('Argument must be a Buffer')
+  if (this === b) return true
+  return Buffer.compare(this, b) === 0
+}
+
+Buffer.prototype.inspect = function inspect () {
+  var str = ''
+  var max = exports.INSPECT_MAX_BYTES
+  if (this.length > 0) {
+    str = this.toString('hex', 0, max).match(/.{2}/g).join(' ')
+    if (this.length > max) str += ' ... '
+  }
+  return '<Buffer ' + str + '>'
+}
+
+Buffer.prototype.compare = function compare (b) {
+  if (!Buffer.isBuffer(b)) throw new TypeError('Argument must be a Buffer')
+  if (this === b) return 0
+  return Buffer.compare(this, b)
+}
+
+Buffer.prototype.indexOf = function indexOf (val, byteOffset) {
+  if (byteOffset > 0x7fffffff) byteOffset = 0x7fffffff
+  else if (byteOffset < -0x80000000) byteOffset = -0x80000000
+  byteOffset >>= 0
+
+  if (this.length === 0) return -1
+  if (byteOffset >= this.length) return -1
+
+  // Negative offsets start from the end of the buffer
+  if (byteOffset < 0) byteOffset = Math.max(this.length + byteOffset, 0)
+
+  if (typeof val === 'string') {
+    if (val.length === 0) return -1 // special case: looking for empty string always fails
+    return String.prototype.indexOf.call(this, val, byteOffset)
+  }
+  if (Buffer.isBuffer(val)) {
+    return arrayIndexOf(this, val, byteOffset)
+  }
+  if (typeof val === 'number') {
+    if (Buffer.TYPED_ARRAY_SUPPORT && Uint8Array.prototype.indexOf === 'function') {
+      return Uint8Array.prototype.indexOf.call(this, val, byteOffset)
+    }
+    return arrayIndexOf(this, [ val ], byteOffset)
+  }
+
+  function arrayIndexOf (arr, val, byteOffset) {
+    var foundIndex = -1
+    for (var i = 0; byteOffset + i < arr.length; i++) {
+      if (arr[byteOffset + i] === val[foundIndex === -1 ? 0 : i - foundIndex]) {
+        if (foundIndex === -1) foundIndex = i
+        if (i - foundIndex + 1 === val.length) return byteOffset + foundIndex
+      } else {
+        foundIndex = -1
+      }
+    }
+    return -1
+  }
+
+  throw new TypeError('val must be string, number or Buffer')
+}
+
+// `get` is deprecated
+Buffer.prototype.get = function get (offset) {
+  console.log('.get() is deprecated. Access using array indexes instead.')
+  return this.readUInt8(offset)
+}
+
+// `set` is deprecated
+Buffer.prototype.set = function set (v, offset) {
+  console.log('.set() is deprecated. Access using array indexes instead.')
+  return this.writeUInt8(v, offset)
+}
+
+function hexWrite (buf, string, offset, length) {
+  offset = Number(offset) || 0
+  var remaining = buf.length - offset
+  if (!length) {
+    length = remaining
+  } else {
+    length = Number(length)
+    if (length > remaining) {
+      length = remaining
+    }
+  }
+
+  // must be an even number of digits
+  var strLen = string.length
+  if (strLen % 2 !== 0) throw new Error('Invalid hex string')
+
+  if (length > strLen / 2) {
+    length = strLen / 2
+  }
+  for (var i = 0; i < length; i++) {
+    var parsed = parseInt(string.substr(i * 2, 2), 16)
+    if (isNaN(parsed)) throw new Error('Invalid hex string')
+    buf[offset + i] = parsed
+  }
+  return i
+}
+
+function utf8Write (buf, string, offset, length) {
+  return blitBuffer(utf8ToBytes(string, buf.length - offset), buf, offset, length)
+}
+
+function asciiWrite (buf, string, offset, length) {
+  return blitBuffer(asciiToBytes(string), buf, offset, length)
+}
+
+function binaryWrite (buf, string, offset, length) {
+  return asciiWrite(buf, string, offset, length)
+}
+
+function base64Write (buf, string, offset, length) {
+  return blitBuffer(base64ToBytes(string), buf, offset, length)
+}
+
+function ucs2Write (buf, string, offset, length) {
+  return blitBuffer(utf16leToBytes(string, buf.length - offset), buf, offset, length)
+}
+
+Buffer.prototype.write = function write (string, offset, length, encoding) {
+  // Buffer#write(string)
+  if (offset === undefined) {
+    encoding = 'utf8'
+    length = this.length
+    offset = 0
+  // Buffer#write(string, encoding)
+  } else if (length === undefined && typeof offset === 'string') {
+    encoding = offset
+    length = this.length
+    offset = 0
+  // Buffer#write(string, offset[, length][, encoding])
+  } else if (isFinite(offset)) {
+    offset = offset | 0
+    if (isFinite(length)) {
+      length = length | 0
+      if (encoding === undefined) encoding = 'utf8'
+    } else {
+      encoding = length
+      length = undefined
+    }
+  // legacy write(string, encoding, offset, length) - remove in v0.13
+  } else {
+    var swap = encoding
+    encoding = offset
+    offset = length | 0
+    length = swap
+  }
+
+  var remaining = this.length - offset
+  if (length === undefined || length > remaining) length = remaining
+
+  if ((string.length > 0 && (length < 0 || offset < 0)) || offset > this.length) {
+    throw new RangeError('attempt to write outside buffer bounds')
+  }
+
+  if (!encoding) encoding = 'utf8'
+
+  var loweredCase = false
+  for (;;) {
+    switch (encoding) {
+      case 'hex':
+        return hexWrite(this, string, offset, length)
+
+      case 'utf8':
+      case 'utf-8':
+        return utf8Write(this, string, offset, length)
+
+      case 'ascii':
+        return asciiWrite(this, string, offset, length)
+
+      case 'binary':
+        return binaryWrite(this, string, offset, length)
+
+      case 'base64':
+        // Warning: maxLength not taken into account in base64Write
+        return base64Write(this, string, offset, length)
+
+      case 'ucs2':
+      case 'ucs-2':
+      case 'utf16le':
+      case 'utf-16le':
+        return ucs2Write(this, string, offset, length)
+
+      default:
+        if (loweredCase) throw new TypeError('Unknown encoding: ' + encoding)
+        encoding = ('' + encoding).toLowerCase()
+        loweredCase = true
+    }
+  }
+}
+
+Buffer.prototype.toJSON = function toJSON () {
+  return {
+    type: 'Buffer',
+    data: Array.prototype.slice.call(this._arr || this, 0)
+  }
+}
+
+function base64Slice (buf, start, end) {
+  if (start === 0 && end === buf.length) {
+    return base64.fromByteArray(buf)
+  } else {
+    return base64.fromByteArray(buf.slice(start, end))
+  }
+}
+
+function utf8Slice (buf, start, end) {
+  end = Math.min(buf.length, end)
+  var res = []
+
+  var i = start
+  while (i < end) {
+    var firstByte = buf[i]
+    var codePoint = null
+    var bytesPerSequence = (firstByte > 0xEF) ? 4
+      : (firstByte > 0xDF) ? 3
+      : (firstByte > 0xBF) ? 2
+      : 1
+
+    if (i + bytesPerSequence <= end) {
+      var secondByte, thirdByte, fourthByte, tempCodePoint
+
+      switch (bytesPerSequence) {
+        case 1:
+          if (firstByte < 0x80) {
+            codePoint = firstByte
+          }
+          break
+        case 2:
+          secondByte = buf[i + 1]
+          if ((secondByte & 0xC0) === 0x80) {
+            tempCodePoint = (firstByte & 0x1F) << 0x6 | (secondByte & 0x3F)
+            if (tempCodePoint > 0x7F) {
+              codePoint = tempCodePoint
+            }
+          }
+          break
+        case 3:
+          secondByte = buf[i + 1]
+          thirdByte = buf[i + 2]
+          if ((secondByte & 0xC0) === 0x80 && (thirdByte & 0xC0) === 0x80) {
+            tempCodePoint = (firstByte & 0xF) << 0xC | (secondByte & 0x3F) << 0x6 | (thirdByte & 0x3F)
+            if (tempCodePoint > 0x7FF && (tempCodePoint < 0xD800 || tempCodePoint > 0xDFFF)) {
+              codePoint = tempCodePoint
+            }
+          }
+          break
+        case 4:
+          secondByte = buf[i + 1]
+          thirdByte = buf[i + 2]
+          fourthByte = buf[i + 3]
+          if ((secondByte & 0xC0) === 0x80 && (thirdByte & 0xC0) === 0x80 && (fourthByte & 0xC0) === 0x80) {
+            tempCodePoint = (firstByte & 0xF) << 0x12 | (secondByte & 0x3F) << 0xC | (thirdByte & 0x3F) << 0x6 | (fourthByte & 0x3F)
+            if (tempCodePoint > 0xFFFF && tempCodePoint < 0x110000) {
+              codePoint = tempCodePoint
+            }
+          }
+      }
+    }
+
+    if (codePoint === null) {
+      // we did not generate a valid codePoint so insert a
+      // replacement char (U+FFFD) and advance only 1 byte
+      codePoint = 0xFFFD
+      bytesPerSequence = 1
+    } else if (codePoint > 0xFFFF) {
+      // encode to utf16 (surrogate pair dance)
+      codePoint -= 0x10000
+      res.push(codePoint >>> 10 & 0x3FF | 0xD800)
+      codePoint = 0xDC00 | codePoint & 0x3FF
+    }
+
+    res.push(codePoint)
+    i += bytesPerSequence
+  }
+
+  return decodeCodePointsArray(res)
+}
+
+// Based on http://stackoverflow.com/a/22747272/680742, the browser with
+// the lowest limit is Chrome, with 0x10000 args.
+// We go 1 magnitude less, for safety
+var MAX_ARGUMENTS_LENGTH = 0x1000
+
+function decodeCodePointsArray (codePoints) {
+  var len = codePoints.length
+  if (len <= MAX_ARGUMENTS_LENGTH) {
+    return String.fromCharCode.apply(String, codePoints) // avoid extra slice()
+  }
+
+  // Decode in chunks to avoid "call stack size exceeded".
+  var res = ''
+  var i = 0
+  while (i < len) {
+    res += String.fromCharCode.apply(
+      String,
+      codePoints.slice(i, i += MAX_ARGUMENTS_LENGTH)
+    )
+  }
+  return res
+}
+
+function asciiSlice (buf, start, end) {
+  var ret = ''
+  end = Math.min(buf.length, end)
+
+  for (var i = start; i < end; i++) {
+    ret += String.fromCharCode(buf[i] & 0x7F)
+  }
+  return ret
+}
+
+function binarySlice (buf, start, end) {
+  var ret = ''
+  end = Math.min(buf.length, end)
+
+  for (var i = start; i < end; i++) {
+    ret += String.fromCharCode(buf[i])
+  }
+  return ret
+}
+
+function hexSlice (buf, start, end) {
+  var len = buf.length
+
+  if (!start || start < 0) start = 0
+  if (!end || end < 0 || end > len) end = len
+
+  var out = ''
+  for (var i = start; i < end; i++) {
+    out += toHex(buf[i])
+  }
+  return out
+}
+
+function utf16leSlice (buf, start, end) {
+  var bytes = buf.slice(start, end)
+  var res = ''
+  for (var i = 0; i < bytes.length; i += 2) {
+    res += String.fromCharCode(bytes[i] + bytes[i + 1] * 256)
+  }
+  return res
+}
+
+Buffer.prototype.slice = function slice (start, end) {
+  var len = this.length
+  start = ~~start
+  end = end === undefined ? len : ~~end
+
+  if (start < 0) {
+    start += len
+    if (start < 0) start = 0
+  } else if (start > len) {
+    start = len
+  }
+
+  if (end < 0) {
+    end += len
+    if (end < 0) end = 0
+  } else if (end > len) {
+    end = len
+  }
+
+  if (end < start) end = start
+
+  var newBuf
+  if (Buffer.TYPED_ARRAY_SUPPORT) {
+    newBuf = Buffer._augment(this.subarray(start, end))
+  } else {
+    var sliceLen = end - start
+    newBuf = new Buffer(sliceLen, undefined)
+    for (var i = 0; i < sliceLen; i++) {
+      newBuf[i] = this[i + start]
+    }
+  }
+
+  if (newBuf.length) newBuf.parent = this.parent || this
+
+  return newBuf
+}
+
+/*
+ * Need to make sure that buffer isn't trying to write out of bounds.
+ */
+function checkOffset (offset, ext, length) {
+  if ((offset % 1) !== 0 || offset < 0) throw new RangeError('offset is not uint')
+  if (offset + ext > length) throw new RangeError('Trying to access beyond buffer length')
+}
+
+Buffer.prototype.readUIntLE = function readUIntLE (offset, byteLength, noAssert) {
+  offset = offset | 0
+  byteLength = byteLength | 0
+  if (!noAssert) checkOffset(offset, byteLength, this.length)
+
+  var val = this[offset]
+  var mul = 1
+  var i = 0
+  while (++i < byteLength && (mul *= 0x100)) {
+    val += this[offset + i] * mul
+  }
+
+  return val
+}
+
+Buffer.prototype.readUIntBE = function readUIntBE (offset, byteLength, noAssert) {
+  offset = offset | 0
+  byteLength = byteLength | 0
+  if (!noAssert) {
+    checkOffset(offset, byteLength, this.length)
+  }
+
+  var val = this[offset + --byteLength]
+  var mul = 1
+  while (byteLength > 0 && (mul *= 0x100)) {
+    val += this[offset + --byteLength] * mul
+  }
+
+  return val
+}
+
+Buffer.prototype.readUInt8 = function readUInt8 (offset, noAssert) {
+  if (!noAssert) checkOffset(offset, 1, this.length)
+  return this[offset]
+}
+
+Buffer.prototype.readUInt16LE = function readUInt16LE (offset, noAssert) {
+  if (!noAssert) checkOffset(offset, 2, this.length)
+  return this[offset] | (this[offset + 1] << 8)
+}
+
+Buffer.prototype.readUInt16BE = function readUInt16BE (offset, noAssert) {
+  if (!noAssert) checkOffset(offset, 2, this.length)
+  return (this[offset] << 8) | this[offset + 1]
+}
+
+Buffer.prototype.readUInt32LE = function readUInt32LE (offset, noAssert) {
+  if (!noAssert) checkOffset(offset, 4, this.length)
+
+  return ((this[offset]) |
+      (this[offset + 1] << 8) |
+      (this[offset + 2] << 16)) +
+      (this[offset + 3] * 0x1000000)
+}
+
+Buffer.prototype.readUInt32BE = function readUInt32BE (offset, noAssert) {
+  if (!noAssert) checkOffset(offset, 4, this.length)
+
+  return (this[offset] * 0x1000000) +
+    ((this[offset + 1] << 16) |
+    (this[offset + 2] << 8) |
+    this[offset + 3])
+}
+
+Buffer.prototype.readIntLE = function readIntLE (offset, byteLength, noAssert) {
+  offset = offset | 0
+  byteLength = byteLength | 0
+  if (!noAssert) checkOffset(offset, byteLength, this.length)
+
+  var val = this[offset]
+  var mul = 1
+  var i = 0
+  while (++i < byteLength && (mul *= 0x100)) {
+    val += this[offset + i] * mul
+  }
+  mul *= 0x80
+
+  if (val >= mul) val -= Math.pow(2, 8 * byteLength)
+
+  return val
+}
+
+Buffer.prototype.readIntBE = function readIntBE (offset, byteLength, noAssert) {
+  offset = offset | 0
+  byteLength = byteLength | 0
+  if (!noAssert) checkOffset(offset, byteLength, this.length)
+
+  var i = byteLength
+  var mul = 1
+  var val = this[offset + --i]
+  while (i > 0 && (mul *= 0x100)) {
+    val += this[offset + --i] * mul
+  }
+  mul *= 0x80
+
+  if (val >= mul) val -= Math.pow(2, 8 * byteLength)
+
+  return val
+}
+
+Buffer.prototype.readInt8 = function readInt8 (offset, noAssert) {
+  if (!noAssert) checkOffset(offset, 1, this.length)
+  if (!(this[offset] & 0x80)) return (this[offset])
+  return ((0xff - this[offset] + 1) * -1)
+}
+
+Buffer.prototype.readInt16LE = function readInt16LE (offset, noAssert) {
+  if (!noAssert) checkOffset(offset, 2, this.length)
+  var val = this[offset] | (this[offset + 1] << 8)
+  return (val & 0x8000) ? val | 0xFFFF0000 : val
+}
+
+Buffer.prototype.readInt16BE = function readInt16BE (offset, noAssert) {
+  if (!noAssert) checkOffset(offset, 2, this.length)
+  var val = this[offset + 1] | (this[offset] << 8)
+  return (val & 0x8000) ? val | 0xFFFF0000 : val
+}
+
+Buffer.prototype.readInt32LE = function readInt32LE (offset, noAssert) {
+  if (!noAssert) checkOffset(offset, 4, this.length)
+
+  return (this[offset]) |
+    (this[offset + 1] << 8) |
+    (this[offset + 2] << 16) |
+    (this[offset + 3] << 24)
+}
+
+Buffer.prototype.readInt32BE = function readInt32BE (offset, noAssert) {
+  if (!noAssert) checkOffset(offset, 4, this.length)
+
+  return (this[offset] << 24) |
+    (this[offset + 1] << 16) |
+    (this[offset + 2] << 8) |
+    (this[offset + 3])
+}
+
+Buffer.prototype.readFloatLE = function readFloatLE (offset, noAssert) {
+  if (!noAssert) checkOffset(offset, 4, this.length)
+  return ieee754.read(this, offset, true, 23, 4)
+}
+
+Buffer.prototype.readFloatBE = function readFloatBE (offset, noAssert) {
+  if (!noAssert) checkOffset(offset, 4, this.length)
+  return ieee754.read(this, offset, false, 23, 4)
+}
+
+Buffer.prototype.readDoubleLE = function readDoubleLE (offset, noAssert) {
+  if (!noAssert) checkOffset(offset, 8, this.length)
+  return ieee754.read(this, offset, true, 52, 8)
+}
+
+Buffer.prototype.readDoubleBE = function readDoubleBE (offset, noAssert) {
+  if (!noAssert) checkOffset(offset, 8, this.length)
+  return ieee754.read(this, offset, false, 52, 8)
+}
+
+function checkInt (buf, value, offset, ext, max, min) {
+  if (!Buffer.isBuffer(buf)) throw new TypeError('buffer must be a Buffer instance')
+  if (value > max || value < min) throw new RangeError('value is out of bounds')
+  if (offset + ext > buf.length) throw new RangeError('index out of range')
+}
+
+Buffer.prototype.writeUIntLE = function writeUIntLE (value, offset, byteLength, noAssert) {
+  value = +value
+  offset = offset | 0
+  byteLength = byteLength | 0
+  if (!noAssert) checkInt(this, value, offset, byteLength, Math.pow(2, 8 * byteLength), 0)
+
+  var mul = 1
+  var i = 0
+  this[offset] = value & 0xFF
+  while (++i < byteLength && (mul *= 0x100)) {
+    this[offset + i] = (value / mul) & 0xFF
+  }
+
+  return offset + byteLength
+}
+
+Buffer.prototype.writeUIntBE = function writeUIntBE (value, offset, byteLength, noAssert) {
+  value = +value
+  offset = offset | 0
+  byteLength = byteLength | 0
+  if (!noAssert) checkInt(this, value, offset, byteLength, Math.pow(2, 8 * byteLength), 0)
+
+  var i = byteLength - 1
+  var mul = 1
+  this[offset + i] = value & 0xFF
+  while (--i >= 0 && (mul *= 0x100)) {
+    this[offset + i] = (value / mul) & 0xFF
+  }
+
+  return offset + byteLength
+}
+
+Buffer.prototype.writeUInt8 = function writeUInt8 (value, offset, noAssert) {
+  value = +value
+  offset = offset | 0
+  if (!noAssert) checkInt(this, value, offset, 1, 0xff, 0)
+  if (!Buffer.TYPED_ARRAY_SUPPORT) value = Math.floor(value)
+  this[offset] = (value & 0xff)
+  return offset + 1
+}
+
+function objectWriteUInt16 (buf, value, offset, littleEndian) {
+  if (value < 0) value = 0xffff + value + 1
+  for (var i = 0, j = Math.min(buf.length - offset, 2); i < j; i++) {
+    buf[offset + i] = (value & (0xff << (8 * (littleEndian ? i : 1 - i)))) >>>
+      (littleEndian ? i : 1 - i) * 8
+  }
+}
+
+Buffer.prototype.writeUInt16LE = function writeUInt16LE (value, offset, noAssert) {
+  value = +value
+  offset = offset | 0
+  if (!noAssert) checkInt(this, value, offset, 2, 0xffff, 0)
+  if (Buffer.TYPED_ARRAY_SUPPORT) {
+    this[offset] = (value & 0xff)
+    this[offset + 1] = (value >>> 8)
+  } else {
+    objectWriteUInt16(this, value, offset, true)
+  }
+  return offset + 2
+}
+
+Buffer.prototype.writeUInt16BE = function writeUInt16BE (value, offset, noAssert) {
+  value = +value
+  offset = offset | 0
+  if (!noAssert) checkInt(this, value, offset, 2, 0xffff, 0)
+  if (Buffer.TYPED_ARRAY_SUPPORT) {
+    this[offset] = (value >>> 8)
+    this[offset + 1] = (value & 0xff)
+  } else {
+    objectWriteUInt16(this, value, offset, false)
+  }
+  return offset + 2
+}
+
+function objectWriteUInt32 (buf, value, offset, littleEndian) {
+  if (value < 0) value = 0xffffffff + value + 1
+  for (var i = 0, j = Math.min(buf.length - offset, 4); i < j; i++) {
+    buf[offset + i] = (value >>> (littleEndian ? i : 3 - i) * 8) & 0xff
+  }
+}
+
+Buffer.prototype.writeUInt32LE = function writeUInt32LE (value, offset, noAssert) {
+  value = +value
+  offset = offset | 0
+  if (!noAssert) checkInt(this, value, offset, 4, 0xffffffff, 0)
+  if (Buffer.TYPED_ARRAY_SUPPORT) {
+    this[offset + 3] = (value >>> 24)
+    this[offset + 2] = (value >>> 16)
+    this[offset + 1] = (value >>> 8)
+    this[offset] = (value & 0xff)
+  } else {
+    objectWriteUInt32(this, value, offset, true)
+  }
+  return offset + 4
+}
+
+Buffer.prototype.writeUInt32BE = function writeUInt32BE (value, offset, noAssert) {
+  value = +value
+  offset = offset | 0
+  if (!noAssert) checkInt(this, value, offset, 4, 0xffffffff, 0)
+  if (Buffer.TYPED_ARRAY_SUPPORT) {
+    this[offset] = (value >>> 24)
+    this[offset + 1] = (value >>> 16)
+    this[offset + 2] = (value >>> 8)
+    this[offset + 3] = (value & 0xff)
+  } else {
+    objectWriteUInt32(this, value, offset, false)
+  }
+  return offset + 4
+}
+
+Buffer.prototype.writeIntLE = function writeIntLE (value, offset, byteLength, noAssert) {
+  value = +value
+  offset = offset | 0
+  if (!noAssert) {
+    var limit = Math.pow(2, 8 * byteLength - 1)
+
+    checkInt(this, value, offset, byteLength, limit - 1, -limit)
+  }
+
+  var i = 0
+  var mul = 1
+  var sub = value < 0 ? 1 : 0
+  this[offset] = value & 0xFF
+  while (++i < byteLength && (mul *= 0x100)) {
+    this[offset + i] = ((value / mul) >> 0) - sub & 0xFF
+  }
+
+  return offset + byteLength
+}
+
+Buffer.prototype.writeIntBE = function writeIntBE (value, offset, byteLength, noAssert) {
+  value = +value
+  offset = offset | 0
+  if (!noAssert) {
+    var limit = Math.pow(2, 8 * byteLength - 1)
+
+    checkInt(this, value, offset, byteLength, limit - 1, -limit)
+  }
+
+  var i = byteLength - 1
+  var mul = 1
+  var sub = value < 0 ? 1 : 0
+  this[offset + i] = value & 0xFF
+  while (--i >= 0 && (mul *= 0x100)) {
+    this[offset + i] = ((value / mul) >> 0) - sub & 0xFF
+  }
+
+  return offset + byteLength
+}
+
+Buffer.prototype.writeInt8 = function writeInt8 (value, offset, noAssert) {
+  value = +value
+  offset = offset | 0
+  if (!noAssert) checkInt(this, value, offset, 1, 0x7f, -0x80)
+  if (!Buffer.TYPED_ARRAY_SUPPORT) value = Math.floor(value)
+  if (value < 0) value = 0xff + value + 1
+  this[offset] = (value & 0xff)
+  return offset + 1
+}
+
+Buffer.prototype.writeInt16LE = function writeInt16LE (value, offset, noAssert) {
+  value = +value
+  offset = offset | 0
+  if (!noAssert) checkInt(this, value, offset, 2, 0x7fff, -0x8000)
+  if (Buffer.TYPED_ARRAY_SUPPORT) {
+    this[offset] = (value & 0xff)
+    this[offset + 1] = (value >>> 8)
+  } else {
+    objectWriteUInt16(this, value, offset, true)
+  }
+  return offset + 2
+}
+
+Buffer.prototype.writeInt16BE = function writeInt16BE (value, offset, noAssert) {
+  value = +value
+  offset = offset | 0
+  if (!noAssert) checkInt(this, value, offset, 2, 0x7fff, -0x8000)
+  if (Buffer.TYPED_ARRAY_SUPPORT) {
+    this[offset] = (value >>> 8)
+    this[offset + 1] = (value & 0xff)
+  } else {
+    objectWriteUInt16(this, value, offset, false)
+  }
+  return offset + 2
+}
+
+Buffer.prototype.writeInt32LE = function writeInt32LE (value, offset, noAssert) {
+  value = +value
+  offset = offset | 0
+  if (!noAssert) checkInt(this, value, offset, 4, 0x7fffffff, -0x80000000)
+  if (Buffer.TYPED_ARRAY_SUPPORT) {
+    this[offset] = (value & 0xff)
+    this[offset + 1] = (value >>> 8)
+    this[offset + 2] = (value >>> 16)
+    this[offset + 3] = (value >>> 24)
+  } else {
+    objectWriteUInt32(this, value, offset, true)
+  }
+  return offset + 4
+}
+
+Buffer.prototype.writeInt32BE = function writeInt32BE (value, offset, noAssert) {
+  value = +value
+  offset = offset | 0
+  if (!noAssert) checkInt(this, value, offset, 4, 0x7fffffff, -0x80000000)
+  if (value < 0) value = 0xffffffff + value + 1
+  if (Buffer.TYPED_ARRAY_SUPPORT) {
+    this[offset] = (value >>> 24)
+    this[offset + 1] = (value >>> 16)
+    this[offset + 2] = (value >>> 8)
+    this[offset + 3] = (value & 0xff)
+  } else {
+    objectWriteUInt32(this, value, offset, false)
+  }
+  return offset + 4
+}
+
+function checkIEEE754 (buf, value, offset, ext, max, min) {
+  if (value > max || value < min) throw new RangeError('value is out of bounds')
+  if (offset + ext > buf.length) throw new RangeError('index out of range')
+  if (offset < 0) throw new RangeError('index out of range')
+}
+
+function writeFloat (buf, value, offset, littleEndian, noAssert) {
+  if (!noAssert) {
+    checkIEEE754(buf, value, offset, 4, 3.4028234663852886e+38, -3.4028234663852886e+38)
+  }
+  ieee754.write(buf, value, offset, littleEndian, 23, 4)
+  return offset + 4
+}
+
+Buffer.prototype.writeFloatLE = function writeFloatLE (value, offset, noAssert) {
+  return writeFloat(this, value, offset, true, noAssert)
+}
+
+Buffer.prototype.writeFloatBE = function writeFloatBE (value, offset, noAssert) {
+  return writeFloat(this, value, offset, false, noAssert)
+}
+
+function writeDouble (buf, value, offset, littleEndian, noAssert) {
+  if (!noAssert) {
+    checkIEEE754(buf, value, offset, 8, 1.7976931348623157E+308, -1.7976931348623157E+308)
+  }
+  ieee754.write(buf, value, offset, littleEndian, 52, 8)
+  return offset + 8
+}
+
+Buffer.prototype.writeDoubleLE = function writeDoubleLE (value, offset, noAssert) {
+  return writeDouble(this, value, offset, true, noAssert)
+}
+
+Buffer.prototype.writeDoubleBE = function writeDoubleBE (value, offset, noAssert) {
+  return writeDouble(this, value, offset, false, noAssert)
+}
+
+// copy(targetBuffer, targetStart=0, sourceStart=0, sourceEnd=buffer.length)
+Buffer.prototype.copy = function copy (target, targetStart, start, end) {
+  if (!start) start = 0
+  if (!end && end !== 0) end = this.length
+  if (targetStart >= target.length) targetStart = target.length
+  if (!targetStart) targetStart = 0
+  if (end > 0 && end < start) end = start
+
+  // Copy 0 bytes; we're done
+  if (end === start) return 0
+  if (target.length === 0 || this.length === 0) return 0
+
+  // Fatal error conditions
+  if (targetStart < 0) {
+    throw new RangeError('targetStart out of bounds')
+  }
+  if (start < 0 || start >= this.length) throw new RangeError('sourceStart out of bounds')
+  if (end < 0) throw new RangeError('sourceEnd out of bounds')
+
+  // Are we oob?
+  if (end > this.length) end = this.length
+  if (target.length - targetStart < end - start) {
+    end = target.length - targetStart + start
+  }
+
+  var len = end - start
+  var i
+
+  if (this === target && start < targetStart && targetStart < end) {
+    // descending copy from end
+    for (i = len - 1; i >= 0; i--) {
+      target[i + targetStart] = this[i + start]
+    }
+  } else if (len < 1000 || !Buffer.TYPED_ARRAY_SUPPORT) {
+    // ascending copy from start
+    for (i = 0; i < len; i++) {
+      target[i + targetStart] = this[i + start]
+    }
+  } else {
+    target._set(this.subarray(start, start + len), targetStart)
+  }
+
+  return len
+}
+
+// fill(value, start=0, end=buffer.length)
+Buffer.prototype.fill = function fill (value, start, end) {
+  if (!value) value = 0
+  if (!start) start = 0
+  if (!end) end = this.length
+
+  if (end < start) throw new RangeError('end < start')
+
+  // Fill 0 bytes; we're done
+  if (end === start) return
+  if (this.length === 0) return
+
+  if (start < 0 || start >= this.length) throw new RangeError('start out of bounds')
+  if (end < 0 || end > this.length) throw new RangeError('end out of bounds')
+
+  var i
+  if (typeof value === 'number') {
+    for (i = start; i < end; i++) {
+      this[i] = value
+    }
+  } else {
+    var bytes = utf8ToBytes(value.toString())
+    var len = bytes.length
+    for (i = start; i < end; i++) {
+      this[i] = bytes[i % len]
+    }
+  }
+
+  return this
+}
+
+/**
+ * Creates a new `ArrayBuffer` with the *copied* memory of the buffer instance.
+ * Added in Node 0.12. Only available in browsers that support ArrayBuffer.
+ */
+Buffer.prototype.toArrayBuffer = function toArrayBuffer () {
+  if (typeof Uint8Array !== 'undefined') {
+    if (Buffer.TYPED_ARRAY_SUPPORT) {
+      return (new Buffer(this)).buffer
+    } else {
+      var buf = new Uint8Array(this.length)
+      for (var i = 0, len = buf.length; i < len; i += 1) {
+        buf[i] = this[i]
+      }
+      return buf.buffer
+    }
+  } else {
+    throw new TypeError('Buffer.toArrayBuffer not supported in this browser')
+  }
+}
+
+// HELPER FUNCTIONS
+// ================
+
+var BP = Buffer.prototype
+
+/**
+ * Augment a Uint8Array *instance* (not the Uint8Array class!) with Buffer methods
+ */
+Buffer._augment = function _augment (arr) {
+  arr.constructor = Buffer
+  arr._isBuffer = true
+
+  // save reference to original Uint8Array set method before overwriting
+  arr._set = arr.set
+
+  // deprecated
+  arr.get = BP.get
+  arr.set = BP.set
+
+  arr.write = BP.write
+  arr.toString = BP.toString
+  arr.toLocaleString = BP.toString
+  arr.toJSON = BP.toJSON
+  arr.equals = BP.equals
+  arr.compare = BP.compare
+  arr.indexOf = BP.indexOf
+  arr.copy = BP.copy
+  arr.slice = BP.slice
+  arr.readUIntLE = BP.readUIntLE
+  arr.readUIntBE = BP.readUIntBE
+  arr.readUInt8 = BP.readUInt8
+  arr.readUInt16LE = BP.readUInt16LE
+  arr.readUInt16BE = BP.readUInt16BE
+  arr.readUInt32LE = BP.readUInt32LE
+  arr.readUInt32BE = BP.readUInt32BE
+  arr.readIntLE = BP.readIntLE
+  arr.readIntBE = BP.readIntBE
+  arr.readInt8 = BP.readInt8
+  arr.readInt16LE = BP.readInt16LE
+  arr.readInt16BE = BP.readInt16BE
+  arr.readInt32LE = BP.readInt32LE
+  arr.readInt32BE = BP.readInt32BE
+  arr.readFloatLE = BP.readFloatLE
+  arr.readFloatBE = BP.readFloatBE
+  arr.readDoubleLE = BP.readDoubleLE
+  arr.readDoubleBE = BP.readDoubleBE
+  arr.writeUInt8 = BP.writeUInt8
+  arr.writeUIntLE = BP.writeUIntLE
+  arr.writeUIntBE = BP.writeUIntBE
+  arr.writeUInt16LE = BP.writeUInt16LE
+  arr.writeUInt16BE = BP.writeUInt16BE
+  arr.writeUInt32LE = BP.writeUInt32LE
+  arr.writeUInt32BE = BP.writeUInt32BE
+  arr.writeIntLE = BP.writeIntLE
+  arr.writeIntBE = BP.writeIntBE
+  arr.writeInt8 = BP.writeInt8
+  arr.writeInt16LE = BP.writeInt16LE
+  arr.writeInt16BE = BP.writeInt16BE
+  arr.writeInt32LE = BP.writeInt32LE
+  arr.writeInt32BE = BP.writeInt32BE
+  arr.writeFloatLE = BP.writeFloatLE
+  arr.writeFloatBE = BP.writeFloatBE
+  arr.writeDoubleLE = BP.writeDoubleLE
+  arr.writeDoubleBE = BP.writeDoubleBE
+  arr.fill = BP.fill
+  arr.inspect = BP.inspect
+  arr.toArrayBuffer = BP.toArrayBuffer
+
+  return arr
+}
+
+var INVALID_BASE64_RE = /[^+\/0-9A-Za-z-_]/g
+
+function base64clean (str) {
+  // Node strips out invalid characters like \n and \t from the string, base64-js does not
+  str = stringtrim(str).replace(INVALID_BASE64_RE, '')
+  // Node converts strings with length < 2 to ''
+  if (str.length < 2) return ''
+  // Node allows for non-padded base64 strings (missing trailing ===), base64-js does not
+  while (str.length % 4 !== 0) {
+    str = str + '='
+  }
+  return str
+}
+
+function stringtrim (str) {
+  if (str.trim) return str.trim()
+  return str.replace(/^\s+|\s+$/g, '')
+}
+
+function toHex (n) {
+  if (n < 16) return '0' + n.toString(16)
+  return n.toString(16)
+}
+
+function utf8ToBytes (string, units) {
+  units = units || Infinity
+  var codePoint
+  var length = string.length
+  var leadSurrogate = null
+  var bytes = []
+
+  for (var i = 0; i < length; i++) {
+    codePoint = string.charCodeAt(i)
+
+    // is surrogate component
+    if (codePoint > 0xD7FF && codePoint < 0xE000) {
+      // last char was a lead
+      if (!leadSurrogate) {
+        // no lead yet
+        if (codePoint > 0xDBFF) {
+          // unexpected trail
+          if ((units -= 3) > -1) bytes.push(0xEF, 0xBF, 0xBD)
+          continue
+        } else if (i + 1 === length) {
+          // unpaired lead
+          if ((units -= 3) > -1) bytes.push(0xEF, 0xBF, 0xBD)
+          continue
+        }
+
+        // valid lead
+        leadSurrogate = codePoint
+
+        continue
+      }
+
+      // 2 leads in a row
+      if (codePoint < 0xDC00) {
+        if ((units -= 3) > -1) bytes.push(0xEF, 0xBF, 0xBD)
+        leadSurrogate = codePoint
+        continue
+      }
+
+      // valid surrogate pair
+      codePoint = (leadSurrogate - 0xD800 << 10 | codePoint - 0xDC00) + 0x10000
+    } else if (leadSurrogate) {
+      // valid bmp char, but last char was a lead
+      if ((units -= 3) > -1) bytes.push(0xEF, 0xBF, 0xBD)
+    }
+
+    leadSurrogate = null
+
+    // encode utf8
+    if (codePoint < 0x80) {
+      if ((units -= 1) < 0) break
+      bytes.push(codePoint)
+    } else if (codePoint < 0x800) {
+      if ((units -= 2) < 0) break
+      bytes.push(
+        codePoint >> 0x6 | 0xC0,
+        codePoint & 0x3F | 0x80
+      )
+    } else if (codePoint < 0x10000) {
+      if ((units -= 3) < 0) break
+      bytes.push(
+        codePoint >> 0xC | 0xE0,
+        codePoint >> 0x6 & 0x3F | 0x80,
+        codePoint & 0x3F | 0x80
+      )
+    } else if (codePoint < 0x110000) {
+      if ((units -= 4) < 0) break
+      bytes.push(
+        codePoint >> 0x12 | 0xF0,
+        codePoint >> 0xC & 0x3F | 0x80,
+        codePoint >> 0x6 & 0x3F | 0x80,
+        codePoint & 0x3F | 0x80
+      )
+    } else {
+      throw new Error('Invalid code point')
+    }
+  }
+
+  return bytes
+}
+
+function asciiToBytes (str) {
+  var byteArray = []
+  for (var i = 0; i < str.length; i++) {
+    // Node's code seems to be doing this and not & 0x7F..
+    byteArray.push(str.charCodeAt(i) & 0xFF)
+  }
+  return byteArray
+}
+
+function utf16leToBytes (str, units) {
+  var c, hi, lo
+  var byteArray = []
+  for (var i = 0; i < str.length; i++) {
+    if ((units -= 2) < 0) break
+
+    c = str.charCodeAt(i)
+    hi = c >> 8
+    lo = c % 256
+    byteArray.push(lo)
+    byteArray.push(hi)
+  }
+
+  return byteArray
+}
+
+function base64ToBytes (str) {
+  return base64.toByteArray(base64clean(str))
+}
+
+function blitBuffer (src, dst, offset, length) {
+  for (var i = 0; i < length; i++) {
+    if ((i + offset >= dst.length) || (i >= src.length)) break
+    dst[i + offset] = src[i]
+  }
+  return i
+}
+
+}).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
+
+},{"base64-js":6,"ieee754":15,"isarray":9}],9:[function(require,module,exports){
+var toString = {}.toString;
+
+module.exports = Array.isArray || function (arr) {
+  return toString.call(arr) == '[object Array]';
+};
+
+},{}],10:[function(require,module,exports){
+(function (Buffer){
+var clone = (function() {
+'use strict';
+
+/**
+ * Clones (copies) an Object using deep copying.
+ *
+ * This function supports circular references by default, but if you are certain
+ * there are no circular references in your object, you can save some CPU time
+ * by calling clone(obj, false).
+ *
+ * Caution: if `circular` is false and `parent` contains circular references,
+ * your program may enter an infinite loop and crash.
+ *
+ * @param `parent` - the object to be cloned
+ * @param `circular` - set to true if the object to be cloned may contain
+ *    circular references. (optional - true by default)
+ * @param `depth` - set to a number if the object is only to be cloned to
+ *    a particular depth. (optional - defaults to Infinity)
+ * @param `prototype` - sets the prototype to be used when cloning an object.
+ *    (optional - defaults to parent prototype).
+*/
+function clone(parent, circular, depth, prototype) {
+  var filter;
+  if (typeof circular === 'object') {
+    depth = circular.depth;
+    prototype = circular.prototype;
+    filter = circular.filter;
+    circular = circular.circular
+  }
+  // maintain two arrays for circular references, where corresponding parents
+  // and children have the same index
+  var allParents = [];
+  var allChildren = [];
+
+  var useBuffer = typeof Buffer != 'undefined';
+
+  if (typeof circular == 'undefined')
+    circular = true;
+
+  if (typeof depth == 'undefined')
+    depth = Infinity;
+
+  // recurse this function so we don't reset allParents and allChildren
+  function _clone(parent, depth) {
+    // cloning null always returns null
+    if (parent === null)
+      return null;
+
+    if (depth == 0)
+      return parent;
+
+    var child;
+    var proto;
+    if (typeof parent != 'object') {
+      return parent;
+    }
+
+    if (clone.__isArray(parent)) {
+      child = [];
+    } else if (clone.__isRegExp(parent)) {
+      child = new RegExp(parent.source, __getRegExpFlags(parent));
+      if (parent.lastIndex) child.lastIndex = parent.lastIndex;
+    } else if (clone.__isDate(parent)) {
+      child = new Date(parent.getTime());
+    } else if (useBuffer && Buffer.isBuffer(parent)) {
+      child = new Buffer(parent.length);
+      parent.copy(child);
+      return child;
+    } else {
+      if (typeof prototype == 'undefined') {
+        proto = Object.getPrototypeOf(parent);
+        child = Object.create(proto);
+      }
+      else {
+        child = Object.create(prototype);
+        proto = prototype;
+      }
+    }
+
+    if (circular) {
+      var index = allParents.indexOf(parent);
+
+      if (index != -1) {
+        return allChildren[index];
+      }
+      allParents.push(parent);
+      allChildren.push(child);
+    }
+
+    for (var i in parent) {
+      var attrs;
+      if (proto) {
+        attrs = Object.getOwnPropertyDescriptor(proto, i);
+      }
+
+      if (attrs && attrs.set == null) {
+        continue;
+      }
+      child[i] = _clone(parent[i], depth - 1);
+    }
+
+    return child;
+  }
+
+  return _clone(parent, depth);
+}
+
+/**
+ * Simple flat clone using prototype, accepts only objects, usefull for property
+ * override on FLAT configuration object (no nested props).
+ *
+ * USE WITH CAUTION! This may not behave as you wish if you do not know how this
+ * works.
+ */
+clone.clonePrototype = function clonePrototype(parent) {
+  if (parent === null)
+    return null;
+
+  var c = function () {};
+  c.prototype = parent;
+  return new c();
+};
+
+// private utility functions
+
+function __objToStr(o) {
+  return Object.prototype.toString.call(o);
+};
+clone.__objToStr = __objToStr;
+
+function __isDate(o) {
+  return typeof o === 'object' && __objToStr(o) === '[object Date]';
+};
+clone.__isDate = __isDate;
+
+function __isArray(o) {
+  return typeof o === 'object' && __objToStr(o) === '[object Array]';
+};
+clone.__isArray = __isArray;
+
+function __isRegExp(o) {
+  return typeof o === 'object' && __objToStr(o) === '[object RegExp]';
+};
+clone.__isRegExp = __isRegExp;
+
+function __getRegExpFlags(re) {
+  var flags = '';
+  if (re.global) flags += 'g';
+  if (re.ignoreCase) flags += 'i';
+  if (re.multiline) flags += 'm';
+  return flags;
+};
+clone.__getRegExpFlags = __getRegExpFlags;
+
+return clone;
+})();
+
+if (typeof module === 'object' && module.exports) {
+  module.exports = clone;
+}
+
+}).call(this,require("buffer").Buffer)
+
+},{"buffer":8}],11:[function(require,module,exports){
+var pSlice = Array.prototype.slice;
+var objectKeys = require('./lib/keys.js');
+var isArguments = require('./lib/is_arguments.js');
+
+var deepEqual = module.exports = function (actual, expected, opts) {
+  if (!opts) opts = {};
+  // 7.1. All identical values are equivalent, as determined by ===.
+  if (actual === expected) {
+    return true;
+
+  } else if (actual instanceof Date && expected instanceof Date) {
+    return actual.getTime() === expected.getTime();
+
+  // 7.3. Other pairs that do not both pass typeof value == 'object',
+  // equivalence is determined by ==.
+  } else if (!actual || !expected || typeof actual != 'object' && typeof expected != 'object') {
+    return opts.strict ? actual === expected : actual == expected;
+
+  // 7.4. For all other Object pairs, including Array objects, equivalence is
+  // determined by having the same number of owned properties (as verified
+  // with Object.prototype.hasOwnProperty.call), the same set of keys
+  // (although not necessarily the same order), equivalent values for every
+  // corresponding key, and an identical 'prototype' property. Note: this
+  // accounts for both named and indexed properties on Arrays.
+  } else {
+    return objEquiv(actual, expected, opts);
+  }
+}
+
+function isUndefinedOrNull(value) {
+  return value === null || value === undefined;
+}
+
+function isBuffer (x) {
+  if (!x || typeof x !== 'object' || typeof x.length !== 'number') return false;
+  if (typeof x.copy !== 'function' || typeof x.slice !== 'function') {
+    return false;
+  }
+  if (x.length > 0 && typeof x[0] !== 'number') return false;
+  return true;
+}
+
+function objEquiv(a, b, opts) {
+  var i, key;
+  if (isUndefinedOrNull(a) || isUndefinedOrNull(b))
+    return false;
+  // an identical 'prototype' property.
+  if (a.prototype !== b.prototype) return false;
+  //~~~I've managed to break Object.keys through screwy arguments passing.
+  //   Converting to array solves the problem.
+  if (isArguments(a)) {
+    if (!isArguments(b)) {
+      return false;
+    }
+    a = pSlice.call(a);
+    b = pSlice.call(b);
+    return deepEqual(a, b, opts);
+  }
+  if (isBuffer(a)) {
+    if (!isBuffer(b)) {
+      return false;
+    }
+    if (a.length !== b.length) return false;
+    for (i = 0; i < a.length; i++) {
+      if (a[i] !== b[i]) return false;
+    }
+    return true;
+  }
+  try {
+    var ka = objectKeys(a),
+        kb = objectKeys(b);
+  } catch (e) {//happens when one is a string literal and the other isn't
+    return false;
+  }
+  // having the same number of owned properties (keys incorporates
+  // hasOwnProperty)
+  if (ka.length != kb.length)
+    return false;
+  //the same set of keys (although not necessarily the same order),
+  ka.sort();
+  kb.sort();
+  //~~~cheap key test
+  for (i = ka.length - 1; i >= 0; i--) {
+    if (ka[i] != kb[i])
+      return false;
+  }
+  //equivalent values for every corresponding key, and
+  //~~~possibly expensive deep test
+  for (i = ka.length - 1; i >= 0; i--) {
+    key = ka[i];
+    if (!deepEqual(a[key], b[key], opts)) return false;
+  }
+  return typeof a === typeof b;
+}
+
+},{"./lib/is_arguments.js":12,"./lib/keys.js":13}],12:[function(require,module,exports){
+var supportsArgumentsClass = (function(){
+  return Object.prototype.toString.call(arguments)
+})() == '[object Arguments]';
+
+exports = module.exports = supportsArgumentsClass ? supported : unsupported;
+
+exports.supported = supported;
+function supported(object) {
+  return Object.prototype.toString.call(object) == '[object Arguments]';
+};
+
+exports.unsupported = unsupported;
+function unsupported(object){
+  return object &&
+    typeof object == 'object' &&
+    typeof object.length == 'number' &&
+    Object.prototype.hasOwnProperty.call(object, 'callee') &&
+    !Object.prototype.propertyIsEnumerable.call(object, 'callee') ||
+    false;
+};
+
+},{}],13:[function(require,module,exports){
+exports = module.exports = typeof Object.keys === 'function'
+  ? Object.keys : shim;
+
+exports.shim = shim;
+function shim (obj) {
+  var keys = [];
+  for (var key in obj) keys.push(key);
+  return keys;
+}
+
+},{}],14:[function(require,module,exports){
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+function EventEmitter() {
+  this._events = this._events || {};
+  this._maxListeners = this._maxListeners || undefined;
+}
+module.exports = EventEmitter;
+
+// Backwards-compat with node 0.10.x
+EventEmitter.EventEmitter = EventEmitter;
+
+EventEmitter.prototype._events = undefined;
+EventEmitter.prototype._maxListeners = undefined;
+
+// By default EventEmitters will print a warning if more than 10 listeners are
+// added to it. This is a useful default which helps finding memory leaks.
+EventEmitter.defaultMaxListeners = 10;
+
+// Obviously not all Emitters should be limited to 10. This function allows
+// that to be increased. Set to zero for unlimited.
+EventEmitter.prototype.setMaxListeners = function(n) {
+  if (!isNumber(n) || n < 0 || isNaN(n))
+    throw TypeError('n must be a positive number');
+  this._maxListeners = n;
+  return this;
+};
+
+EventEmitter.prototype.emit = function(type) {
+  var er, handler, len, args, i, listeners;
+
+  if (!this._events)
+    this._events = {};
+
+  // If there is no 'error' event listener then throw.
+  if (type === 'error') {
+    if (!this._events.error ||
+        (isObject(this._events.error) && !this._events.error.length)) {
+      er = arguments[1];
+      if (er instanceof Error) {
+        throw er; // Unhandled 'error' event
+      }
+      throw TypeError('Uncaught, unspecified "error" event.');
+    }
+  }
+
+  handler = this._events[type];
+
+  if (isUndefined(handler))
+    return false;
+
+  if (isFunction(handler)) {
+    switch (arguments.length) {
+      // fast cases
+      case 1:
+        handler.call(this);
+        break;
+      case 2:
+        handler.call(this, arguments[1]);
+        break;
+      case 3:
+        handler.call(this, arguments[1], arguments[2]);
+        break;
+      // slower
+      default:
+        len = arguments.length;
+        args = new Array(len - 1);
+        for (i = 1; i < len; i++)
+          args[i - 1] = arguments[i];
+        handler.apply(this, args);
+    }
+  } else if (isObject(handler)) {
+    len = arguments.length;
+    args = new Array(len - 1);
+    for (i = 1; i < len; i++)
+      args[i - 1] = arguments[i];
+
+    listeners = handler.slice();
+    len = listeners.length;
+    for (i = 0; i < len; i++)
+      listeners[i].apply(this, args);
+  }
+
+  return true;
+};
+
+EventEmitter.prototype.addListener = function(type, listener) {
+  var m;
+
+  if (!isFunction(listener))
+    throw TypeError('listener must be a function');
+
+  if (!this._events)
+    this._events = {};
+
+  // To avoid recursion in the case that type === "newListener"! Before
+  // adding it to the listeners, first emit "newListener".
+  if (this._events.newListener)
+    this.emit('newListener', type,
+              isFunction(listener.listener) ?
+              listener.listener : listener);
+
+  if (!this._events[type])
+    // Optimize the case of one listener. Don't need the extra array object.
+    this._events[type] = listener;
+  else if (isObject(this._events[type]))
+    // If we've already got an array, just append.
+    this._events[type].push(listener);
+  else
+    // Adding the second element, need to change to array.
+    this._events[type] = [this._events[type], listener];
+
+  // Check for listener leak
+  if (isObject(this._events[type]) && !this._events[type].warned) {
+    var m;
+    if (!isUndefined(this._maxListeners)) {
+      m = this._maxListeners;
+    } else {
+      m = EventEmitter.defaultMaxListeners;
+    }
+
+    if (m && m > 0 && this._events[type].length > m) {
+      this._events[type].warned = true;
+      console.error('(node) warning: possible EventEmitter memory ' +
+                    'leak detected. %d listeners added. ' +
+                    'Use emitter.setMaxListeners() to increase limit.',
+                    this._events[type].length);
+      if (typeof console.trace === 'function') {
+        // not supported in IE 10
+        console.trace();
+      }
+    }
+  }
+
+  return this;
+};
+
+EventEmitter.prototype.on = EventEmitter.prototype.addListener;
+
+EventEmitter.prototype.once = function(type, listener) {
+  if (!isFunction(listener))
+    throw TypeError('listener must be a function');
+
+  var fired = false;
+
+  function g() {
+    this.removeListener(type, g);
+
+    if (!fired) {
+      fired = true;
+      listener.apply(this, arguments);
+    }
+  }
+
+  g.listener = listener;
+  this.on(type, g);
+
+  return this;
+};
+
+// emits a 'removeListener' event iff the listener was removed
+EventEmitter.prototype.removeListener = function(type, listener) {
+  var list, position, length, i;
+
+  if (!isFunction(listener))
+    throw TypeError('listener must be a function');
+
+  if (!this._events || !this._events[type])
+    return this;
+
+  list = this._events[type];
+  length = list.length;
+  position = -1;
+
+  if (list === listener ||
+      (isFunction(list.listener) && list.listener === listener)) {
+    delete this._events[type];
+    if (this._events.removeListener)
+      this.emit('removeListener', type, listener);
+
+  } else if (isObject(list)) {
+    for (i = length; i-- > 0;) {
+      if (list[i] === listener ||
+          (list[i].listener && list[i].listener === listener)) {
+        position = i;
+        break;
+      }
+    }
+
+    if (position < 0)
+      return this;
+
+    if (list.length === 1) {
+      list.length = 0;
+      delete this._events[type];
+    } else {
+      list.splice(position, 1);
+    }
+
+    if (this._events.removeListener)
+      this.emit('removeListener', type, listener);
+  }
+
+  return this;
+};
+
+EventEmitter.prototype.removeAllListeners = function(type) {
+  var key, listeners;
+
+  if (!this._events)
+    return this;
+
+  // not listening for removeListener, no need to emit
+  if (!this._events.removeListener) {
+    if (arguments.length === 0)
+      this._events = {};
+    else if (this._events[type])
+      delete this._events[type];
+    return this;
+  }
+
+  // emit removeListener for all listeners on all events
+  if (arguments.length === 0) {
+    for (key in this._events) {
+      if (key === 'removeListener') continue;
+      this.removeAllListeners(key);
+    }
+    this.removeAllListeners('removeListener');
+    this._events = {};
+    return this;
+  }
+
+  listeners = this._events[type];
+
+  if (isFunction(listeners)) {
+    this.removeListener(type, listeners);
+  } else {
+    // LIFO order
+    while (listeners.length)
+      this.removeListener(type, listeners[listeners.length - 1]);
+  }
+  delete this._events[type];
+
+  return this;
+};
+
+EventEmitter.prototype.listeners = function(type) {
+  var ret;
+  if (!this._events || !this._events[type])
+    ret = [];
+  else if (isFunction(this._events[type]))
+    ret = [this._events[type]];
+  else
+    ret = this._events[type].slice();
+  return ret;
+};
+
+EventEmitter.listenerCount = function(emitter, type) {
+  var ret;
+  if (!emitter._events || !emitter._events[type])
+    ret = 0;
+  else if (isFunction(emitter._events[type]))
+    ret = 1;
+  else
+    ret = emitter._events[type].length;
+  return ret;
+};
+
+function isFunction(arg) {
+  return typeof arg === 'function';
+}
+
+function isNumber(arg) {
+  return typeof arg === 'number';
+}
+
+function isObject(arg) {
+  return typeof arg === 'object' && arg !== null;
+}
+
+function isUndefined(arg) {
+  return arg === void 0;
+}
+
+},{}],15:[function(require,module,exports){
+exports.read = function (buffer, offset, isLE, mLen, nBytes) {
+  var e, m
+  var eLen = nBytes * 8 - mLen - 1
+  var eMax = (1 << eLen) - 1
+  var eBias = eMax >> 1
+  var nBits = -7
+  var i = isLE ? (nBytes - 1) : 0
+  var d = isLE ? -1 : 1
+  var s = buffer[offset + i]
+
+  i += d
+
+  e = s & ((1 << (-nBits)) - 1)
+  s >>= (-nBits)
+  nBits += eLen
+  for (; nBits > 0; e = e * 256 + buffer[offset + i], i += d, nBits -= 8) {}
+
+  m = e & ((1 << (-nBits)) - 1)
+  e >>= (-nBits)
+  nBits += mLen
+  for (; nBits > 0; m = m * 256 + buffer[offset + i], i += d, nBits -= 8) {}
+
+  if (e === 0) {
+    e = 1 - eBias
+  } else if (e === eMax) {
+    return m ? NaN : ((s ? -1 : 1) * Infinity)
+  } else {
+    m = m + Math.pow(2, mLen)
+    e = e - eBias
+  }
+  return (s ? -1 : 1) * m * Math.pow(2, e - mLen)
+}
+
+exports.write = function (buffer, value, offset, isLE, mLen, nBytes) {
+  var e, m, c
+  var eLen = nBytes * 8 - mLen - 1
+  var eMax = (1 << eLen) - 1
+  var eBias = eMax >> 1
+  var rt = (mLen === 23 ? Math.pow(2, -24) - Math.pow(2, -77) : 0)
+  var i = isLE ? 0 : (nBytes - 1)
+  var d = isLE ? 1 : -1
+  var s = value < 0 || (value === 0 && 1 / value < 0) ? 1 : 0
+
+  value = Math.abs(value)
+
+  if (isNaN(value) || value === Infinity) {
+    m = isNaN(value) ? 1 : 0
+    e = eMax
+  } else {
+    e = Math.floor(Math.log(value) / Math.LN2)
+    if (value * (c = Math.pow(2, -e)) < 1) {
+      e--
+      c *= 2
+    }
+    if (e + eBias >= 1) {
+      value += rt / c
+    } else {
+      value += rt * Math.pow(2, 1 - eBias)
+    }
+    if (value * c >= 2) {
+      e++
+      c /= 2
+    }
+
+    if (e + eBias >= eMax) {
+      m = 0
+      e = eMax
+    } else if (e + eBias >= 1) {
+      m = (value * c - 1) * Math.pow(2, mLen)
+      e = e + eBias
+    } else {
+      m = value * Math.pow(2, eBias - 1) * Math.pow(2, mLen)
+      e = 0
+    }
+  }
+
+  for (; mLen >= 8; buffer[offset + i] = m & 0xff, i += d, m /= 256, mLen -= 8) {}
+
+  e = (e << mLen) | m
+  eLen += mLen
+  for (; eLen > 0; buffer[offset + i] = e & 0xff, i += d, e /= 256, eLen -= 8) {}
+
+  buffer[offset + i - d] |= s * 128
+}
+
+},{}],16:[function(require,module,exports){
+if (typeof Object.create === 'function') {
+  // implementation from standard node.js 'util' module
+  module.exports = function inherits(ctor, superCtor) {
+    ctor.super_ = superCtor
+    ctor.prototype = Object.create(superCtor.prototype, {
+      constructor: {
+        value: ctor,
+        enumerable: false,
+        writable: true,
+        configurable: true
+      }
+    });
+  };
+} else {
+  // old school shim for old browsers
+  module.exports = function inherits(ctor, superCtor) {
+    ctor.super_ = superCtor
+    var TempCtor = function () {}
+    TempCtor.prototype = superCtor.prototype
+    ctor.prototype = new TempCtor()
+    ctor.prototype.constructor = ctor
+  }
+}
+
+},{}],17:[function(require,module,exports){
+module.exports = require('./lib')['default']
+},{"./lib":18}],18:[function(require,module,exports){
+"use strict";
+var utils$$ = require("./utils");
+
+// whether to log exceptions thrown during change record delivery
+var debug = false;
+
+// This weak map is used for `.deliverChangeRecords(callback)` calls, where the
+// provided callback has to mapped to its corresponding delegate.
+// <callback, delegate>
+var delegates = new WeakMap;
+
+// When using `.observe(obj, callback)`, instead of forwarding the provided
+// `callback` to `Object.observe(obj, callback)` directly, a delegate for the
+// `callback` is created. This delegate transforms changes before forwarding
+// them to the actual `callback`.
+var Delegate = function(callback) {
+  this.callback  = callback
+  this.observers = new utils$$.WeakMVMap
+
+  var self = this
+  this.handleChangeRecords = function(records) {
+    try {
+      var changes = records.map(self.transform, self)
+      changes = Array.prototype.concat.apply([], changes) // flatten
+      self.callback(changes)
+    } catch (err) {
+      if (debug) console.error(err.stack)
+    }
+  }
+}
+
+// This method transforms the received change record with using the
+// corresponding observer for the object that got changed.
+Delegate.prototype.transform = function(record) {
+  if (!this.observers.has(record.object)) {
+    return []
+  }
+
+  var observers = this.observers.get(record.object)
+  observers = observers.filter(function(value, index, self) {
+    return self.indexOf(value) === index
+  })
+  return observers.map(function(observer) {
+    return observer.transform(record)
+  })
+}
+
+// Each callback/object pair gets its own observer, which is used to track
+// positions of nested objects and transforms change records accordingly.
+var Observer = function(root, delegate, accept) {
+  this.root     = root
+  this.delegate = delegate
+  this.callback = delegate.handleChangeRecords
+  this.accept   = accept
+  this.parents  = new utils$$.ParentsMapping
+}
+
+// Recursively observe an object and its nested objects.
+Observer.prototype.observe = function(obj, parent, key, visited) {
+  if (!obj || typeof obj !== 'object') {
+    return
+  }
+
+  if (!visited) {
+    visited = new WeakMap
+  }
+
+  if (visited.has(obj)) {
+    return
+  }
+
+  visited.set(obj, true)
+
+  // if the object is already observed, i.e., already somewhere else in the
+  // nested structure -> do not observe it again
+  if (!this.delegate.observers.has(obj, this)) {
+    if (Array.isArray(obj) && !this.accept) {
+      Object.observe(obj, this.callback, ['add', 'update', 'delete', 'splice'])
+    } else {
+      Object.observe(obj, this.callback, this.accept)
+    }
+  }
+
+  // track parent and belonging
+  this.parents.add(obj, parent, key)
+  this.delegate.observers.add(obj, this)
+
+  // traverse the properties to find nested objects and observe them, too
+  var isArray = Array.isArray(obj)
+  for (var prop in obj) {
+    if (typeof obj[prop] === 'object') {
+      this.observe(obj[prop], obj, isArray ? Array : prop, visited)
+    }
+  }
+
+  if (typeof obj.entries === 'function') {
+    var entries = obj.entries()
+    if (typeof entries.next === 'function') {
+      // for (var pair of entries)
+      var pair
+      while ((pair = entries.next()).done === false) {
+        if (typeof pair.value[1] === 'object') {
+          this.observe(pair.value[1], obj, pair.value[0], visited)
+        }
+      }
+    }
+  }
+}
+
+// Recursively unobserve an object and its nested objects.
+Observer.prototype.unobserve = function(obj, parent, key) {
+  if (obj === undefined) obj = this.root
+  else if (!obj) return
+
+  if (!this.delegate.observers.has(obj, this)) {
+    return
+  }
+
+  // clean up
+  this.parents.remove(obj, parent, key)
+  this.delegate.observers.remove(obj, this)
+
+  if (!this.delegate.observers.has(obj)) {
+    Object.unobserve(obj, this.callback)
+  }
+
+  // traverse the properties to find nested objects and unobserve them, too
+  var isArray = Array.isArray(obj)
+  for (var prop in obj) {
+    if (typeof obj[prop] === 'object') {
+      this.unobserve(obj[prop], obj, isArray ? Array : prop)
+    }
+  }
+}
+
+// Transform a change record, ie., add the following properties:
+// - **root** - the root of the nested structure
+// - **path** - a [JSON Pointer](http://tools.ietf.org/html/rfc6901)
+//              (absolute from the root) to the changed property
+Observer.prototype.transform = function(change) {
+  var self = this
+
+  var record = {
+    root: this.root,
+    get path() {
+      var path = self.parents.path(change.object)
+      if (change.name) path.push(change.name)
+      return '/' + path.map(function(k) {
+        return k.toString().replace(/~/g, '~0').replace(/\//g, '~1')
+      }).join('/')
+    }
+  }
+
+  // the original change record ist not extensible -> copy
+  for (var prop in change) {
+    record[prop] = change[prop]
+  }
+
+  // unobserve deleted/replaced objects
+  var deleted = change.oldValue && [change.oldValue] || change.removed || []
+  deleted.forEach(function(oldValue, i) {
+    if (oldValue === null || typeof oldValue !== 'object') {
+      return
+    }
+
+    this.unobserve(oldValue, change.object, change.name || change.index + i)
+  }, this)
+
+  // observe added/updated objects
+  function handleChange(value, parent, key) {
+    if (typeof value === 'object') {
+      var desc = key !== Array && Object.getOwnPropertyDescriptor(parent, key)
+      if (!desc || desc.enumerable === true) {
+        self.observe(value, parent, key)
+      } else {
+        self.unobserve(value, parent, key)
+      }
+    }
+  }
+
+  if (change.name) {
+    if (change.name in change.object) {
+      handleChange(change.object[change.name], change.object, change.name)
+    } else if (typeof change.object.get === 'function') {
+      handleChange(change.object.get(change.name), change.object, change.name)
+    }
+  } else if (change.type === 'splice' && change.addedCount) {
+    var added = change.object.slice(change.index, change.index + change.addedCount)
+    added.forEach(function(value) {
+      handleChange(value, change.object, Array)
+    })
+  }
+
+  Object.preventExtensions(record)
+
+  return record
+}
+
+exports["default"] = {
+  // Corresponds to `Object.observe()` but for nested objects.
+  observe: function observe(obj, callback, accept) {
+    var delegate
+
+    if (!delegates.has(callback)) {
+      delegate = new Delegate(callback)
+      delegates.set(callback, delegate)
+    } else {
+      delegate = delegates.get(callback)
+    }
+
+    var observers = delegate.observers
+    if (observers.has(obj)) {
+      return
+    }
+
+    var observer = new Observer(obj, delegate, accept)
+    observer.observe(obj)
+  },
+
+  // Corresponds to `Object.unobserve()` but for nested objects.
+  unobserve: function unobserve(obj, callback) {
+    if (!delegates.has(callback)) return
+    var delegate = delegates.get(callback)
+
+    if (!delegate.observers.has(obj)) {
+      return
+    }
+
+    var observers = delegate.observers.get(obj)
+    observers.forEach(function(observer) {
+      observer.unobserve()
+    })
+  },
+
+  // Corresponds to `Object.deliverChangeRecords()` but for nested objects.
+  deliverChangeRecords: function deliverChangeRecords(callback) {
+    if (typeof callback !== 'function') {
+      throw new TypeError('Callback must be a function, given: ' + callback)
+    }
+
+    if (!delegates.has(callback)) return
+
+    var delegate = delegates.get(callback)
+    Object.deliverChangeRecords(delegate.handleChangeRecords)
+  },
+
+  get debug() {
+    return debug
+  },
+
+  set debug(val) {
+    debug = val
+  }
+};
+},{"./utils":19}],19:[function(require,module,exports){
+"use strict";
+var WeakMVMap = function() {
+  this.map = new WeakMap
+}
+
+WeakMVMap.prototype.get = function(key) {
+  return this.map.get(key)
+}
+
+WeakMVMap.prototype.has = function(key, value) {
+  if (!this.map.has(key)) return false
+  var values = this.map.get(key)
+  if (value === undefined && values.length) {
+    return true
+  }
+  return values.indexOf(value) > -1
+}
+
+WeakMVMap.prototype.add = function(key, value) {
+  if (!this.map.has(key)) {
+    this.map.set(key, [])
+  }
+
+  var values = this.map.get(key)
+  values.push(value)
+}
+
+WeakMVMap.prototype.remove = function(key, value) {
+  var values = this.map.get(key)
+
+  var index = values.indexOf(value)
+  values.splice(index, 1)
+
+  // if the set is empty, remove it from the WeakMap
+  if (!values.length) this.map.delete(key)
+}
+
+var ParentsMapping = function() {
+  this.mapping = new WeakMap
+}
+
+ParentsMapping.prototype.add = function(obj, parent, key) {
+  if (!parent || key === undefined) return
+
+  if (!this.mapping.has(obj)) {
+    this.mapping.set(obj, [])
+  }
+
+  var parents = this.mapping.get(obj)
+  parents.push({ obj: parent, key: key })
+}
+
+ParentsMapping.prototype.remove = function(obj, parent, key) {
+  if (!parent || !key === undefined) return
+
+  var parents = this.mapping.get(obj)
+
+  for (var i = 0, len = parents.length; i < len; ++i) {
+    if (parents[i].obj === parent && parents[i].key === key) {
+      parents.splice(i, 1)
+      break
+    }
+  }
+
+  if (!parents.length) this.mapping.delete(obj)
+}
+
+ParentsMapping.prototype.path = function(obj) {
+  var path = []
+  while (this.mapping.has(obj)) {
+    var parent = this.mapping.get(obj)[0]
+    var key = parent.key === Array ? parent.obj.indexOf(obj) : parent.key
+    path.unshift(key)
+    obj = parent.obj
+  }
+  return path
+}
+exports.WeakMVMap = WeakMVMap, exports.ParentsMapping = ParentsMapping;
+},{}],20:[function(require,module,exports){
+(function (root, factory){
+  'use strict';
+
+  /*istanbul ignore next:cant test*/
+  if (typeof module === 'object' && typeof module.exports === 'object') {
+    module.exports = factory();
+  } else if (typeof define === 'function' && define.amd) {
+    // AMD. Register as an anonymous module.
+    define([], factory);
+  } else {
+    // Browser globals
+    root.objectPath = factory();
+  }
+})(this, function(){
+  'use strict';
+
+  var
+    toStr = Object.prototype.toString,
+    _hasOwnProperty = Object.prototype.hasOwnProperty;
+
+  function isEmpty(value){
+    if (!value) {
+      return true;
+    }
+    if (isArray(value) && value.length === 0) {
+        return true;
+    } else if (!isString(value)) {
+        for (var i in value) {
+            if (_hasOwnProperty.call(value, i)) {
+                return false;
+            }
+        }
+        return true;
+    }
+    return false;
+  }
+
+  function toString(type){
+    return toStr.call(type);
+  }
+
+  function isNumber(value){
+    return typeof value === 'number' || toString(value) === "[object Number]";
+  }
+
+  function isString(obj){
+    return typeof obj === 'string' || toString(obj) === "[object String]";
+  }
+
+  function isObject(obj){
+    return typeof obj === 'object' && toString(obj) === "[object Object]";
+  }
+
+  function isArray(obj){
+    return typeof obj === 'object' && typeof obj.length === 'number' && toString(obj) === '[object Array]';
+  }
+
+  function isBoolean(obj){
+    return typeof obj === 'boolean' || toString(obj) === '[object Boolean]';
+  }
+
+  function getKey(key){
+    var intKey = parseInt(key);
+    if (intKey.toString() === key) {
+      return intKey;
+    }
+    return key;
+  }
+
+  function set(obj, path, value, doNotReplace){
+    if (isNumber(path)) {
+      path = [path];
+    }
+    if (isEmpty(path)) {
+      return obj;
+    }
+    if (isString(path)) {
+      return set(obj, path.split('.').map(getKey), value, doNotReplace);
+    }
+    var currentPath = path[0];
+
+    if (path.length === 1) {
+      var oldVal = obj[currentPath];
+      if (oldVal === void 0 || !doNotReplace) {
+        obj[currentPath] = value;
+      }
+      return oldVal;
+    }
+
+    if (obj[currentPath] === void 0) {
+      //check if we assume an array
+      if(isNumber(path[1])) {
+        obj[currentPath] = [];
+      } else {
+        obj[currentPath] = {};
+      }
+    }
+
+    return set(obj[currentPath], path.slice(1), value, doNotReplace);
+  }
+
+  function del(obj, path) {
+    if (isNumber(path)) {
+      path = [path];
+    }
+
+    if (isEmpty(obj)) {
+      return void 0;
+    }
+
+    if (isEmpty(path)) {
+      return obj;
+    }
+    if(isString(path)) {
+      return del(obj, path.split('.'));
+    }
+
+    var currentPath = getKey(path[0]);
+    var oldVal = obj[currentPath];
+
+    if(path.length === 1) {
+      if (oldVal !== void 0) {
+        if (isArray(obj)) {
+          obj.splice(currentPath, 1);
+        } else {
+          delete obj[currentPath];
+        }
+      }
+    } else {
+      if (obj[currentPath] !== void 0) {
+        return del(obj[currentPath], path.slice(1));
+      }
+    }
+
+    return obj;
+  }
+
+  var objectPath = function(obj) {
+    return Object.keys(objectPath).reduce(function(proxy, prop) {
+      if (typeof objectPath[prop] === 'function') {
+        proxy[prop] = objectPath[prop].bind(objectPath, obj);
+      }
+
+      return proxy;
+    }, {});
+  };
+
+  objectPath.has = function (obj, path) {
+    if (isEmpty(obj)) {
+      return false;
+    }
+
+    if (isNumber(path)) {
+      path = [path];
+    } else if (isString(path)) {
+      path = path.split('.');
+    }
+
+    if (isEmpty(path) || path.length === 0) {
+      return false;
+    }
+
+    for (var i = 0; i < path.length; i++) {
+      var j = path[i];
+      if ((isObject(obj) || isArray(obj)) && _hasOwnProperty.call(obj, j)) {
+        obj = obj[j];
+      } else {
+        return false;
+      }
+    }
+
+    return true;
+  };
+
+  objectPath.ensureExists = function (obj, path, value){
+    return set(obj, path, value, true);
+  };
+
+  objectPath.set = function (obj, path, value, doNotReplace){
+    return set(obj, path, value, doNotReplace);
+  };
+
+  objectPath.insert = function (obj, path, value, at){
+    var arr = objectPath.get(obj, path);
+    at = ~~at;
+    if (!isArray(arr)) {
+      arr = [];
+      objectPath.set(obj, path, arr);
+    }
+    arr.splice(at, 0, value);
+  };
+
+  objectPath.empty = function(obj, path) {
+    if (isEmpty(path)) {
+      return obj;
+    }
+    if (isEmpty(obj)) {
+      return void 0;
+    }
+
+    var value, i;
+    if (!(value = objectPath.get(obj, path))) {
+      return obj;
+    }
+
+    if (isString(value)) {
+      return objectPath.set(obj, path, '');
+    } else if (isBoolean(value)) {
+      return objectPath.set(obj, path, false);
+    } else if (isNumber(value)) {
+      return objectPath.set(obj, path, 0);
+    } else if (isArray(value)) {
+      value.length = 0;
+    } else if (isObject(value)) {
+      for (i in value) {
+        if (_hasOwnProperty.call(value, i)) {
+          delete value[i];
+        }
+      }
+    } else {
+      return objectPath.set(obj, path, null);
+    }
+  };
+
+  objectPath.push = function (obj, path /*, values */){
+    var arr = objectPath.get(obj, path);
+    if (!isArray(arr)) {
+      arr = [];
+      objectPath.set(obj, path, arr);
+    }
+
+    arr.push.apply(arr, Array.prototype.slice.call(arguments, 2));
+  };
+
+  objectPath.coalesce = function (obj, paths, defaultValue) {
+    var value;
+
+    for (var i = 0, len = paths.length; i < len; i++) {
+      if ((value = objectPath.get(obj, paths[i])) !== void 0) {
+        return value;
+      }
+    }
+
+    return defaultValue;
+  };
+
+  objectPath.get = function (obj, path, defaultValue){
+    if (isNumber(path)) {
+      path = [path];
+    }
+    if (isEmpty(path)) {
+      return obj;
+    }
+    if (isEmpty(obj)) {
+      return defaultValue;
+    }
+    if (isString(path)) {
+      return objectPath.get(obj, path.split('.'), defaultValue);
+    }
+
+    var currentPath = getKey(path[0]);
+
+    if (path.length === 1) {
+      if (obj[currentPath] === void 0) {
+        return defaultValue;
+      }
+      return obj[currentPath];
+    }
+
+    return objectPath.get(obj[currentPath], path.slice(1), defaultValue);
+  };
+
+  objectPath.del = function(obj, path) {
+    return del(obj, path);
+  };
+
+  return objectPath;
+});
+
+},{}],21:[function(require,module,exports){
+(function (global){
+
+var rng;
+
+if (global.crypto && crypto.getRandomValues) {
+  // WHATWG crypto-based RNG - http://wiki.whatwg.org/wiki/Crypto
+  // Moderately fast, high quality
+  var _rnds8 = new Uint8Array(16);
+  rng = function whatwgRNG() {
+    crypto.getRandomValues(_rnds8);
+    return _rnds8;
+  };
+}
+
+if (!rng) {
+  // Math.random()-based (RNG)
+  //
+  // If all else fails, use Math.random().  It's fast, but is of unspecified
+  // quality.
+  var  _rnds = new Array(16);
+  rng = function() {
+    for (var i = 0, r; i < 16; i++) {
+      if ((i & 0x03) === 0) r = Math.random() * 0x100000000;
+      _rnds[i] = r >>> ((i & 0x03) << 3) & 0xff;
+    }
+
+    return _rnds;
+  };
+}
+
+module.exports = rng;
+
+
+}).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
+
+},{}],22:[function(require,module,exports){
+//     uuid.js
+//
+//     Copyright (c) 2010-2012 Robert Kieffer
+//     MIT License - http://opensource.org/licenses/mit-license.php
+
+// Unique ID creation requires a high quality random # generator.  We feature
+// detect to determine the best RNG source, normalizing to a function that
+// returns 128-bits of randomness, since that's what's usually required
+var _rng = require('./rng');
+
+// Maps for number <-> hex string conversion
+var _byteToHex = [];
+var _hexToByte = {};
+for (var i = 0; i < 256; i++) {
+  _byteToHex[i] = (i + 0x100).toString(16).substr(1);
+  _hexToByte[_byteToHex[i]] = i;
+}
+
+// **`parse()` - Parse a UUID into it's component bytes**
+function parse(s, buf, offset) {
+  var i = (buf && offset) || 0, ii = 0;
+
+  buf = buf || [];
+  s.toLowerCase().replace(/[0-9a-f]{2}/g, function(oct) {
+    if (ii < 16) { // Don't overflow!
+      buf[i + ii++] = _hexToByte[oct];
+    }
+  });
+
+  // Zero out remaining bytes if string was short
+  while (ii < 16) {
+    buf[i + ii++] = 0;
+  }
+
+  return buf;
+}
+
+// **`unparse()` - Convert UUID byte array (ala parse()) into a string**
+function unparse(buf, offset) {
+  var i = offset || 0, bth = _byteToHex;
+  return  bth[buf[i++]] + bth[buf[i++]] +
+          bth[buf[i++]] + bth[buf[i++]] + '-' +
+          bth[buf[i++]] + bth[buf[i++]] + '-' +
+          bth[buf[i++]] + bth[buf[i++]] + '-' +
+          bth[buf[i++]] + bth[buf[i++]] + '-' +
+          bth[buf[i++]] + bth[buf[i++]] +
+          bth[buf[i++]] + bth[buf[i++]] +
+          bth[buf[i++]] + bth[buf[i++]];
+}
+
+// **`v1()` - Generate time-based UUID**
+//
+// Inspired by https://github.com/LiosK/UUID.js
+// and http://docs.python.org/library/uuid.html
+
+// random #'s we need to init node and clockseq
+var _seedBytes = _rng();
+
+// Per 4.5, create and 48-bit node id, (47 random bits + multicast bit = 1)
+var _nodeId = [
+  _seedBytes[0] | 0x01,
+  _seedBytes[1], _seedBytes[2], _seedBytes[3], _seedBytes[4], _seedBytes[5]
+];
+
+// Per 4.2.2, randomize (14 bit) clockseq
+var _clockseq = (_seedBytes[6] << 8 | _seedBytes[7]) & 0x3fff;
+
+// Previous uuid creation time
+var _lastMSecs = 0, _lastNSecs = 0;
+
+// See https://github.com/broofa/node-uuid for API details
+function v1(options, buf, offset) {
+  var i = buf && offset || 0;
+  var b = buf || [];
+
+  options = options || {};
+
+  var clockseq = options.clockseq !== undefined ? options.clockseq : _clockseq;
+
+  // UUID timestamps are 100 nano-second units since the Gregorian epoch,
+  // (1582-10-15 00:00).  JSNumbers aren't precise enough for this, so
+  // time is handled internally as 'msecs' (integer milliseconds) and 'nsecs'
+  // (100-nanoseconds offset from msecs) since unix epoch, 1970-01-01 00:00.
+  var msecs = options.msecs !== undefined ? options.msecs : new Date().getTime();
+
+  // Per 4.2.1.2, use count of uuid's generated during the current clock
+  // cycle to simulate higher resolution clock
+  var nsecs = options.nsecs !== undefined ? options.nsecs : _lastNSecs + 1;
+
+  // Time since last uuid creation (in msecs)
+  var dt = (msecs - _lastMSecs) + (nsecs - _lastNSecs)/10000;
+
+  // Per 4.2.1.2, Bump clockseq on clock regression
+  if (dt < 0 && options.clockseq === undefined) {
+    clockseq = clockseq + 1 & 0x3fff;
+  }
+
+  // Reset nsecs if clock regresses (new clockseq) or we've moved onto a new
+  // time interval
+  if ((dt < 0 || msecs > _lastMSecs) && options.nsecs === undefined) {
+    nsecs = 0;
+  }
+
+  // Per 4.2.1.2 Throw error if too many uuids are requested
+  if (nsecs >= 10000) {
+    throw new Error('uuid.v1(): Can\'t create more than 10M uuids/sec');
+  }
+
+  _lastMSecs = msecs;
+  _lastNSecs = nsecs;
+  _clockseq = clockseq;
+
+  // Per 4.1.4 - Convert from unix epoch to Gregorian epoch
+  msecs += 12219292800000;
+
+  // `time_low`
+  var tl = ((msecs & 0xfffffff) * 10000 + nsecs) % 0x100000000;
+  b[i++] = tl >>> 24 & 0xff;
+  b[i++] = tl >>> 16 & 0xff;
+  b[i++] = tl >>> 8 & 0xff;
+  b[i++] = tl & 0xff;
+
+  // `time_mid`
+  var tmh = (msecs / 0x100000000 * 10000) & 0xfffffff;
+  b[i++] = tmh >>> 8 & 0xff;
+  b[i++] = tmh & 0xff;
+
+  // `time_high_and_version`
+  b[i++] = tmh >>> 24 & 0xf | 0x10; // include version
+  b[i++] = tmh >>> 16 & 0xff;
+
+  // `clock_seq_hi_and_reserved` (Per 4.2.2 - include variant)
+  b[i++] = clockseq >>> 8 | 0x80;
+
+  // `clock_seq_low`
+  b[i++] = clockseq & 0xff;
+
+  // `node`
+  var node = options.node || _nodeId;
+  for (var n = 0; n < 6; n++) {
+    b[i + n] = node[n];
+  }
+
+  return buf ? buf : unparse(b);
+}
+
+// **`v4()` - Generate random UUID**
+
+// See https://github.com/broofa/node-uuid for API details
+function v4(options, buf, offset) {
+  // Deprecated - 'format' argument, as supported in v1.2
+  var i = buf && offset || 0;
+
+  if (typeof(options) == 'string') {
+    buf = options == 'binary' ? new Array(16) : null;
+    options = null;
+  }
+  options = options || {};
+
+  var rnds = options.random || (options.rng || _rng)();
+
+  // Per 4.4, set bits for version and `clock_seq_hi_and_reserved`
+  rnds[6] = (rnds[6] & 0x0f) | 0x40;
+  rnds[8] = (rnds[8] & 0x3f) | 0x80;
+
+  // Copy bytes to buffer, if provided
+  if (buf) {
+    for (var ii = 0; ii < 16; ii++) {
+      buf[i + ii] = rnds[ii];
+    }
+  }
+
+  return buf || unparse(rnds);
+}
+
+// Export public API
+var uuid = v4;
+uuid.v1 = v1;
+uuid.v4 = v4;
+uuid.parse = parse;
+uuid.unparse = unparse;
+
+module.exports = uuid;
+
+},{"./rng":21}]},{},[1])
+//# sourceMappingURL=data:application/json;charset:utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbIm5vZGVfbW9kdWxlcy9icm93c2VyLXBhY2svX3ByZWx1ZGUuanMiLCJsaWIvYXBpLmpzIiwibGliL2Jyb3dzZXIvY29uZmlnLmpzIiwibGliL2Jyb3dzZXIvbG9nZ2VyLmpzIiwibGliL2Jyb3dzZXIvcmVwbGljYW50LmpzIiwibm9kZV9tb2R1bGVzL0Bub2RlY2cvbG9nZ2VyL2Jyb3dzZXIuanMiLCJub2RlX21vZHVsZXMvYmFzZTY0LWpzL2xpYi9iNjQuanMiLCJub2RlX21vZHVsZXMvYnJvd3NlcmlmeS9saWIvX2VtcHR5LmpzIiwibm9kZV9tb2R1bGVzL2J1ZmZlci9pbmRleC5qcyIsIm5vZGVfbW9kdWxlcy9idWZmZXIvbm9kZV9tb2R1bGVzL2lzYXJyYXkvaW5kZXguanMiLCJub2RlX21vZHVsZXMvY2xvbmUvY2xvbmUuanMiLCJub2RlX21vZHVsZXMvZGVlcC1lcXVhbC9pbmRleC5qcyIsIm5vZGVfbW9kdWxlcy9kZWVwLWVxdWFsL2xpYi9pc19hcmd1bWVudHMuanMiLCJub2RlX21vZHVsZXMvZGVlcC1lcXVhbC9saWIva2V5cy5qcyIsIm5vZGVfbW9kdWxlcy9ldmVudHMvZXZlbnRzLmpzIiwibm9kZV9tb2R1bGVzL2llZWU3NTQvaW5kZXguanMiLCJub2RlX21vZHVsZXMvaW5oZXJpdHMvaW5oZXJpdHNfYnJvd3Nlci5qcyIsIm5vZGVfbW9kdWxlcy9uZXN0ZWQtb2JzZXJ2ZS9pbmRleC5qcyIsIm5vZGVfbW9kdWxlcy9uZXN0ZWQtb2JzZXJ2ZS9saWIvaW5kZXguanMiLCJub2RlX21vZHVsZXMvbmVzdGVkLW9ic2VydmUvbGliL3V0aWxzLmpzIiwibm9kZV9tb2R1bGVzL29iamVjdC1wYXRoL2luZGV4LmpzIiwibm9kZV9tb2R1bGVzL3V1aWQvcm5nLWJyb3dzZXIuanMiLCJub2RlX21vZHVsZXMvdXVpZC91dWlkLmpzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQUFBO0FDQUE7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7O0FDVEE7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7O0FDVEE7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7O0FDVEE7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7O0FDVEE7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7O0FDeEhBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7O0FDNUhBOzs7QUNBQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTs7OztBQzVnREE7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBOzs7QUNMQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBOzs7O0FDaEtBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7O0FDOUZBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTs7QUNwQkE7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7O0FDVEE7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTs7QUM3U0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7O0FDcEZBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTs7QUN2QkE7O0FDQUE7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTs7QUM3UEE7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBOztBQzdFQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7OztBQ3RSQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBOzs7O0FDL0JBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBIiwiZmlsZSI6ImdlbmVyYXRlZC5qcyIsInNvdXJjZVJvb3QiOiIiLCJzb3VyY2VzQ29udGVudCI6WyIoZnVuY3Rpb24gZSh0LG4scil7ZnVuY3Rpb24gcyhvLHUpe2lmKCFuW29dKXtpZighdFtvXSl7dmFyIGE9dHlwZW9mIHJlcXVpcmU9PVwiZnVuY3Rpb25cIiYmcmVxdWlyZTtpZighdSYmYSlyZXR1cm4gYShvLCEwKTtpZihpKXJldHVybiBpKG8sITApO3ZhciBmPW5ldyBFcnJvcihcIkNhbm5vdCBmaW5kIG1vZHVsZSAnXCIrbytcIidcIik7dGhyb3cgZi5jb2RlPVwiTU9EVUxFX05PVF9GT1VORFwiLGZ9dmFyIGw9bltvXT17ZXhwb3J0czp7fX07dFtvXVswXS5jYWxsKGwuZXhwb3J0cyxmdW5jdGlvbihlKXt2YXIgbj10W29dWzFdW2VdO3JldHVybiBzKG4/bjplKX0sbCxsLmV4cG9ydHMsZSx0LG4scil9cmV0dXJuIG5bb10uZXhwb3J0c312YXIgaT10eXBlb2YgcmVxdWlyZT09XCJmdW5jdGlvblwiJiZyZXF1aXJlO2Zvcih2YXIgbz0wO288ci5sZW5ndGg7bysrKXMocltvXSk7cmV0dXJuIHN9KSIsIlwidXNlIHN0cmljdFwiO1xudmFyIF9fY292X0Z6TFZpOU52czREaEJ0d0lIRkhHYXcgPSAoRnVuY3Rpb24oJ3JldHVybiB0aGlzJykpKCk7XG5pZiAoIV9fY292X0Z6TFZpOU52czREaEJ0d0lIRkhHYXcuX19jb3ZlcmFnZV9fKSB7IF9fY292X0Z6TFZpOU52czREaEJ0d0lIRkhHYXcuX19jb3ZlcmFnZV9fID0ge307IH1cbl9fY292X0Z6TFZpOU52czREaEJ0d0lIRkhHYXcgPSBfX2Nvdl9GekxWaTlOdnM0RGhCdHdJSEZIR2F3Ll9fY292ZXJhZ2VfXztcbmlmICghKF9fY292X0Z6TFZpOU52czREaEJ0d0lIRkhHYXdbJ0c6XFxcXFByb2dyYW1taW5nXFxcXG5vZGVjZ1xcXFxsaWJcXFxcYXBpLmpzJ10pKSB7XG4gICBfX2Nvdl9GekxWaTlOdnM0RGhCdHdJSEZIR2F3WydHOlxcXFxQcm9ncmFtbWluZ1xcXFxub2RlY2dcXFxcbGliXFxcXGFwaS5qcyddID0ge1wicGF0aFwiOlwiRzpcXFxcUHJvZ3JhbW1pbmdcXFxcbm9kZWNnXFxcXGxpYlxcXFxhcGkuanNcIixcInNcIjp7XCIxXCI6MCxcIjJcIjowLFwiM1wiOjAsXCI0XCI6MCxcIjVcIjowLFwiNlwiOjAsXCI3XCI6MSxcIjhcIjowLFwiOVwiOjAsXCIxMFwiOjAsXCIxMVwiOjAsXCIxMlwiOjAsXCIxM1wiOjAsXCIxNFwiOjAsXCIxNVwiOjAsXCIxNlwiOjAsXCIxN1wiOjAsXCIxOFwiOjAsXCIxOVwiOjAsXCIyMFwiOjAsXCIyMVwiOjAsXCIyMlwiOjAsXCIyM1wiOjAsXCIyNFwiOjAsXCIyNVwiOjAsXCIyNlwiOjAsXCIyN1wiOjAsXCIyOFwiOjAsXCIyOVwiOjAsXCIzMFwiOjAsXCIzMVwiOjAsXCIzMlwiOjAsXCIzM1wiOjAsXCIzNFwiOjAsXCIzNVwiOjAsXCIzNlwiOjAsXCIzN1wiOjAsXCIzOFwiOjAsXCIzOVwiOjAsXCI0MFwiOjAsXCI0MVwiOjAsXCI0MlwiOjAsXCI0M1wiOjAsXCI0NFwiOjAsXCI0NVwiOjAsXCI0NlwiOjAsXCI0N1wiOjAsXCI0OFwiOjAsXCI0OVwiOjAsXCI1MFwiOjAsXCI1MVwiOjAsXCI1MlwiOjAsXCI1M1wiOjAsXCI1NFwiOjAsXCI1NVwiOjAsXCI1NlwiOjAsXCI1N1wiOjAsXCI1OFwiOjAsXCI1OVwiOjAsXCI2MFwiOjAsXCI2MVwiOjAsXCI2MlwiOjAsXCI2M1wiOjAsXCI2NFwiOjAsXCI2NVwiOjAsXCI2NlwiOjAsXCI2N1wiOjAsXCI2OFwiOjAsXCI2OVwiOjAsXCI3MFwiOjAsXCI3MVwiOjAsXCI3MlwiOjAsXCI3M1wiOjAsXCI3NFwiOjAsXCI3NVwiOjAsXCI3NlwiOjAsXCI3N1wiOjAsXCI3OFwiOjAsXCI3OVwiOjAsXCI4MFwiOjAsXCI4MVwiOjAsXCI4MlwiOjAsXCI4M1wiOjAsXCI4NFwiOjAsXCI4NVwiOjAsXCI4NlwiOjAsXCI4N1wiOjAsXCI4OFwiOjAsXCI4OVwiOjAsXCI5MFwiOjAsXCI5MVwiOjAsXCI5MlwiOjAsXCI5M1wiOjAsXCI5NFwiOjAsXCI5NVwiOjAsXCI5NlwiOjAsXCI5N1wiOjAsXCI5OFwiOjAsXCI5OVwiOjAsXCIxMDBcIjowLFwiMTAxXCI6MCxcIjEwMlwiOjAsXCIxMDNcIjowLFwiMTA0XCI6MCxcIjEwNVwiOjAsXCIxMDZcIjowLFwiMTA3XCI6MCxcIjEwOFwiOjAsXCIxMDlcIjowLFwiMTEwXCI6MCxcIjExMVwiOjAsXCIxMTJcIjowLFwiMTEzXCI6MCxcIjExNFwiOjAsXCIxMTVcIjowfSxcImJcIjp7XCIxXCI6WzAsMF0sXCIyXCI6WzAsMF0sXCIzXCI6WzAsMF0sXCI0XCI6WzAsMF0sXCI1XCI6WzAsMF0sXCI2XCI6WzAsMF0sXCI3XCI6WzAsMF0sXCI4XCI6WzAsMF0sXCI5XCI6WzAsMF0sXCIxMFwiOlswLDBdLFwiMTFcIjpbMCwwXSxcIjEyXCI6WzAsMF0sXCIxM1wiOlswLDBdLFwiMTRcIjpbMCwwXSxcIjE1XCI6WzAsMF0sXCIxNlwiOlswLDBdLFwiMTdcIjpbMCwwXSxcIjE4XCI6WzAsMF0sXCIxOVwiOlswLDBdLFwiMjBcIjpbMCwwXSxcIjIxXCI6WzAsMF0sXCIyMlwiOlswLDBdLFwiMjNcIjpbMCwwXSxcIjI0XCI6WzAsMF0sXCIyNVwiOlswLDBdLFwiMjZcIjpbMCwwXSxcIjI3XCI6WzAsMF0sXCIyOFwiOlswLDBdLFwiMjlcIjpbMCwwXSxcIjMwXCI6WzAsMF0sXCIzMVwiOlswLDBdLFwiMzJcIjpbMCwwXX0sXCJmXCI6e1wiMVwiOjAsXCIyXCI6MCxcIjNcIjowLFwiNFwiOjAsXCI1XCI6MCxcIjZcIjowLFwiN1wiOjAsXCI4XCI6MCxcIjlcIjowLFwiMTBcIjowLFwiMTFcIjowLFwiMTJcIjowLFwiMTNcIjowLFwiMTRcIjowLFwiMTVcIjowLFwiMTZcIjowLFwiMTdcIjowLFwiMThcIjowLFwiMTlcIjowLFwiMjBcIjowfSxcImZuTWFwXCI6e1wiMVwiOntcIm5hbWVcIjpcIk5vZGVDR1wiLFwibGluZVwiOjE3LFwibG9jXCI6e1wic3RhcnRcIjp7XCJsaW5lXCI6MTcsXCJjb2x1bW5cIjowfSxcImVuZFwiOntcImxpbmVcIjoxNyxcImNvbHVtblwiOjMyfX19LFwiMlwiOntcIm5hbWVcIjpcIihhbm9ueW1vdXNfMilcIixcImxpbmVcIjo1NSxcImxvY1wiOntcInN0YXJ0XCI6e1wibGluZVwiOjU1LFwiY29sdW1uXCI6NDh9LFwiZW5kXCI6e1wibGluZVwiOjU1LFwiY29sdW1uXCI6NjB9fX0sXCIzXCI6e1wibmFtZVwiOlwib25NZXNzYWdlXCIsXCJsaW5lXCI6NjYsXCJsb2NcIjp7XCJzdGFydFwiOntcImxpbmVcIjo2NixcImNvbHVtblwiOjIzfSxcImVuZFwiOntcImxpbmVcIjo2NixcImNvbHVtblwiOjQ4fX19LFwiNFwiOntcIm5hbWVcIjpcIihhbm9ueW1vdXNfNClcIixcImxpbmVcIjo3MCxcImxvY1wiOntcInN0YXJ0XCI6e1wibGluZVwiOjcwLFwiY29sdW1uXCI6MzN9LFwiZW5kXCI6e1wibGluZVwiOjcwLFwiY29sdW1uXCI6NTJ9fX0sXCI1XCI6e1wibmFtZVwiOlwiKGFub255bW91c181KVwiLFwibGluZVwiOjc4LFwibG9jXCI6e1wic3RhcnRcIjp7XCJsaW5lXCI6NzgsXCJjb2x1bW5cIjoyMX0sXCJlbmRcIjp7XCJsaW5lXCI6NzgsXCJjb2x1bW5cIjozNn19fSxcIjZcIjp7XCJuYW1lXCI6XCJvbkNvbm5lY3Rpb25cIixcImxpbmVcIjo4OSxcImxvY1wiOntcInN0YXJ0XCI6e1wibGluZVwiOjg5LFwiY29sdW1uXCI6MjJ9LFwiZW5kXCI6e1wibGluZVwiOjg5LFwiY29sdW1uXCI6NTJ9fX0sXCI3XCI6e1wibmFtZVwiOlwib25NZXNzYWdlXCIsXCJsaW5lXCI6OTEsXCJsb2NcIjp7XCJzdGFydFwiOntcImxpbmVcIjo5MSxcImNvbHVtblwiOjI0fSxcImVuZFwiOntcImxpbmVcIjo5MSxcImNvbHVtblwiOjUzfX19LFwiOFwiOntcIm5hbWVcIjpcIihhbm9ueW1vdXNfOClcIixcImxpbmVcIjo5NSxcImxvY1wiOntcInN0YXJ0XCI6e1wibGluZVwiOjk1LFwiY29sdW1uXCI6MzR9LFwiZW5kXCI6e1wibGluZVwiOjk1LFwiY29sdW1uXCI6NTN9fX0sXCI5XCI6e1wibmFtZVwiOlwiKGFub255bW91c185KVwiLFwibGluZVwiOjE1MSxcImxvY1wiOntcInN0YXJ0XCI6e1wibGluZVwiOjE1MSxcImNvbHVtblwiOjMxfSxcImVuZFwiOntcImxpbmVcIjoxNTEsXCJjb2x1bW5cIjo2NH19fSxcIjEwXCI6e1wibmFtZVwiOlwiKGFub255bW91c18xMClcIixcImxpbmVcIjoxNjAsXCJsb2NcIjp7XCJzdGFydFwiOntcImxpbmVcIjoxNjAsXCJjb2x1bW5cIjoyOX0sXCJlbmRcIjp7XCJsaW5lXCI6MTYwLFwiY29sdW1uXCI6NzR9fX0sXCIxMVwiOntcIm5hbWVcIjpcIihhbm9ueW1vdXNfMTEpXCIsXCJsaW5lXCI6MTkxLFwibG9jXCI6e1wic3RhcnRcIjp7XCJsaW5lXCI6MTkxLFwiY29sdW1uXCI6Mzl9LFwiZW5kXCI6e1wibGluZVwiOjE5MSxcImNvbHVtblwiOjg0fX19LFwiMTJcIjp7XCJuYW1lXCI6XCIoYW5vbnltb3VzXzEyKVwiLFwibGluZVwiOjIyMCxcImxvY1wiOntcInN0YXJ0XCI6e1wibGluZVwiOjIyMCxcImNvbHVtblwiOjI5fSxcImVuZFwiOntcImxpbmVcIjoyMjAsXCJjb2x1bW5cIjo3M319fSxcIjEzXCI6e1wibmFtZVwiOlwiKGFub255bW91c18xMylcIixcImxpbmVcIjoyNTIsXCJsb2NcIjp7XCJzdGFydFwiOntcImxpbmVcIjoyNTIsXCJjb2x1bW5cIjoxOX0sXCJlbmRcIjp7XCJsaW5lXCI6MjUyLFwiY29sdW1uXCI6NDl9fX0sXCIxNFwiOntcIm5hbWVcIjpcIihhbm9ueW1vdXNfMTQpXCIsXCJsaW5lXCI6MjkzLFwibG9jXCI6e1wic3RhcnRcIjp7XCJsaW5lXCI6MjkzLFwiY29sdW1uXCI6Mjl9LFwiZW5kXCI6e1wibGluZVwiOjI5MyxcImNvbHVtblwiOjU5fX19LFwiMTVcIjp7XCJuYW1lXCI6XCIoYW5vbnltb3VzXzE1KVwiLFwibGluZVwiOjMwMixcImxvY1wiOntcInN0YXJ0XCI6e1wibGluZVwiOjMwMixcImNvbHVtblwiOjIzfSxcImVuZFwiOntcImxpbmVcIjozMDIsXCJjb2x1bW5cIjo1MX19fSxcIjE2XCI6e1wibmFtZVwiOlwiKGFub255bW91c18xNilcIixcImxpbmVcIjozNDAsXCJsb2NcIjp7XCJzdGFydFwiOntcImxpbmVcIjozNDAsXCJjb2x1bW5cIjozM30sXCJlbmRcIjp7XCJsaW5lXCI6MzQwLFwiY29sdW1uXCI6NjF9fX0sXCIxN1wiOntcIm5hbWVcIjpcIihhbm9ueW1vdXNfMTcpXCIsXCJsaW5lXCI6MzYxLFwibG9jXCI6e1wic3RhcnRcIjp7XCJsaW5lXCI6MzYxLFwiY29sdW1uXCI6Mzh9LFwiZW5kXCI6e1wibGluZVwiOjM2MSxcImNvbHVtblwiOjY3fX19LFwiMThcIjp7XCJuYW1lXCI6XCIoYW5vbnltb3VzXzE4KVwiLFwibGluZVwiOjM4MCxcImxvY1wiOntcInN0YXJ0XCI6e1wibGluZVwiOjM4MCxcImNvbHVtblwiOjMwfSxcImVuZFwiOntcImxpbmVcIjozODAsXCJjb2x1bW5cIjo1NH19fSxcIjE5XCI6e1wibmFtZVwiOlwiKGFub255bW91c18xOSlcIixcImxpbmVcIjozOTMsXCJsb2NcIjp7XCJzdGFydFwiOntcImxpbmVcIjozOTMsXCJjb2x1bW5cIjozOH0sXCJlbmRcIjp7XCJsaW5lXCI6MzkzLFwiY29sdW1uXCI6NjJ9fX0sXCIyMFwiOntcIm5hbWVcIjpcIihhbm9ueW1vdXNfMjApXCIsXCJsaW5lXCI6NDU3LFwibG9jXCI6e1wic3RhcnRcIjp7XCJsaW5lXCI6NDU3LFwiY29sdW1uXCI6N30sXCJlbmRcIjp7XCJsaW5lXCI6NDU3LFwiY29sdW1uXCI6MTl9fX19LFwic3RhdGVtZW50TWFwXCI6e1wiMVwiOntcInN0YXJ0XCI6e1wibGluZVwiOjQsXCJjb2x1bW5cIjowfSxcImVuZFwiOntcImxpbmVcIjo0LFwiY29sdW1uXCI6NDd9fSxcIjJcIjp7XCJzdGFydFwiOntcImxpbmVcIjo1LFwiY29sdW1uXCI6MH0sXCJlbmRcIjp7XCJsaW5lXCI6NSxcImNvbHVtblwiOjEyfX0sXCIzXCI6e1wic3RhcnRcIjp7XCJsaW5lXCI6NixcImNvbHVtblwiOjB9LFwiZW5kXCI6e1wibGluZVwiOjYsXCJjb2x1bW5cIjozM319LFwiNFwiOntcInN0YXJ0XCI6e1wibGluZVwiOjcsXCJjb2x1bW5cIjowfSxcImVuZFwiOntcImxpbmVcIjo3LFwiY29sdW1uXCI6NjR9fSxcIjVcIjp7XCJzdGFydFwiOntcImxpbmVcIjo4LFwiY29sdW1uXCI6MH0sXCJlbmRcIjp7XCJsaW5lXCI6OCxcImNvbHVtblwiOjMwfX0sXCI2XCI6e1wic3RhcnRcIjp7XCJsaW5lXCI6OSxcImNvbHVtblwiOjB9LFwiZW5kXCI6e1wibGluZVwiOjksXCJjb2x1bW5cIjo0MX19LFwiN1wiOntcInN0YXJ0XCI6e1wibGluZVwiOjE3LFwiY29sdW1uXCI6MH0sXCJlbmRcIjp7XCJsaW5lXCI6MTEzLFwiY29sdW1uXCI6MX19LFwiOFwiOntcInN0YXJ0XCI6e1wibGluZVwiOjE4LFwiY29sdW1uXCI6MX0sXCJlbmRcIjp7XCJsaW5lXCI6MTgsXCJjb2x1bW5cIjoxN319LFwiOVwiOntcInN0YXJ0XCI6e1wibGluZVwiOjIxLFwiY29sdW1uXCI6MX0sXCJlbmRcIjp7XCJsaW5lXCI6MjEsXCJjb2x1bW5cIjozMX19LFwiMTBcIjp7XCJzdGFydFwiOntcImxpbmVcIjoyOSxcImNvbHVtblwiOjF9LFwiZW5kXCI6e1wibGluZVwiOjI5LFwiY29sdW1uXCI6MzV9fSxcIjExXCI6e1wic3RhcnRcIjp7XCJsaW5lXCI6NDQsXCJjb2x1bW5cIjoxfSxcImVuZFwiOntcImxpbmVcIjo0NCxcImNvbHVtblwiOjUzfX0sXCIxMlwiOntcInN0YXJ0XCI6e1wibGluZVwiOjQ2LFwiY29sdW1uXCI6MX0sXCJlbmRcIjp7XCJsaW5lXCI6NDYsXCJjb2x1bW5cIjoyOH19LFwiMTNcIjp7XCJzdGFydFwiOntcImxpbmVcIjo0OCxcImNvbHVtblwiOjF9LFwiZW5kXCI6e1wibGluZVwiOjEwMyxcImNvbHVtblwiOjJ9fSxcIjE0XCI6e1wic3RhcnRcIjp7XCJsaW5lXCI6NTAsXCJjb2x1bW5cIjoyfSxcImVuZFwiOntcImxpbmVcIjo1MixcImNvbHVtblwiOjN9fSxcIjE1XCI6e1wic3RhcnRcIjp7XCJsaW5lXCI6NTEsXCJjb2x1bW5cIjozfSxcImVuZFwiOntcImxpbmVcIjo1MSxcImNvbHVtblwiOjg2fX0sXCIxNlwiOntcInN0YXJ0XCI6e1wibGluZVwiOjU1LFwiY29sdW1uXCI6Mn0sXCJlbmRcIjp7XCJsaW5lXCI6NTksXCJjb2x1bW5cIjoxMn19LFwiMTdcIjp7XCJzdGFydFwiOntcImxpbmVcIjo1NixcImNvbHVtblwiOjN9LFwiZW5kXCI6e1wibGluZVwiOjU4LFwiY29sdW1uXCI6NH19LFwiMThcIjp7XCJzdGFydFwiOntcImxpbmVcIjo1NyxcImNvbHVtblwiOjR9LFwiZW5kXCI6e1wibGluZVwiOjU3LFwiY29sdW1uXCI6Mzd9fSxcIjE5XCI6e1wic3RhcnRcIjp7XCJsaW5lXCI6NjIsXCJjb2x1bW5cIjoyfSxcImVuZFwiOntcImxpbmVcIjo2MixcImNvbHVtblwiOjIzfX0sXCIyMFwiOntcInN0YXJ0XCI6e1wibGluZVwiOjYzLFwiY29sdW1uXCI6Mn0sXCJlbmRcIjp7XCJsaW5lXCI6NjMsXCJjb2x1bW5cIjo0NH19LFwiMjFcIjp7XCJzdGFydFwiOntcImxpbmVcIjo2NixcImNvbHVtblwiOjJ9LFwiZW5kXCI6e1wibGluZVwiOjc2LFwiY29sdW1uXCI6NX19LFwiMjJcIjp7XCJzdGFydFwiOntcImxpbmVcIjo2NyxcImNvbHVtblwiOjN9LFwiZW5kXCI6e1wibGluZVwiOjY4LFwiY29sdW1uXCI6NzB9fSxcIjIzXCI6e1wic3RhcnRcIjp7XCJsaW5lXCI6NzAsXCJjb2x1bW5cIjozfSxcImVuZFwiOntcImxpbmVcIjo3NSxcImNvbHVtblwiOjZ9fSxcIjI0XCI6e1wic3RhcnRcIjp7XCJsaW5lXCI6NzEsXCJjb2x1bW5cIjo0fSxcImVuZFwiOntcImxpbmVcIjo3NCxcImNvbHVtblwiOjV9fSxcIjI1XCI6e1wic3RhcnRcIjp7XCJsaW5lXCI6NzMsXCJjb2x1bW5cIjo1fSxcImVuZFwiOntcImxpbmVcIjo3MyxcImNvbHVtblwiOjMyfX0sXCIyNlwiOntcInN0YXJ0XCI6e1wibGluZVwiOjc4LFwiY29sdW1uXCI6Mn0sXCJlbmRcIjp7XCJsaW5lXCI6ODUsXCJjb2x1bW5cIjo1fX0sXCIyN1wiOntcInN0YXJ0XCI6e1wibGluZVwiOjc5LFwiY29sdW1uXCI6M30sXCJlbmRcIjp7XCJsaW5lXCI6ODQsXCJjb2x1bW5cIjo0fX0sXCIyOFwiOntcInN0YXJ0XCI6e1wibGluZVwiOjgwLFwiY29sdW1uXCI6NH0sXCJlbmRcIjp7XCJsaW5lXCI6ODAsXCJjb2x1bW5cIjo4M319LFwiMjlcIjp7XCJzdGFydFwiOntcImxpbmVcIjo4MSxcImNvbHVtblwiOjR9LFwiZW5kXCI6e1wibGluZVwiOjgxLFwiY29sdW1uXCI6MTA1fX0sXCIzMFwiOntcInN0YXJ0XCI6e1wibGluZVwiOjgzLFwiY29sdW1uXCI6NH0sXCJlbmRcIjp7XCJsaW5lXCI6ODMsXCJjb2x1bW5cIjo1MX19LFwiMzFcIjp7XCJzdGFydFwiOntcImxpbmVcIjo4NyxcImNvbHVtblwiOjJ9LFwiZW5kXCI6e1wibGluZVwiOjg3LFwiY29sdW1uXCI6MjJ9fSxcIjMyXCI6e1wic3RhcnRcIjp7XCJsaW5lXCI6ODksXCJjb2x1bW5cIjoyfSxcImVuZFwiOntcImxpbmVcIjoxMDIsXCJjb2x1bW5cIjo1fX0sXCIzM1wiOntcInN0YXJ0XCI6e1wibGluZVwiOjkwLFwiY29sdW1uXCI6M30sXCJlbmRcIjp7XCJsaW5lXCI6OTAsXCJjb2x1bW5cIjozMH19LFwiMzRcIjp7XCJzdGFydFwiOntcImxpbmVcIjo5MSxcImNvbHVtblwiOjN9LFwiZW5kXCI6e1wibGluZVwiOjEwMSxcImNvbHVtblwiOjZ9fSxcIjM1XCI6e1wic3RhcnRcIjp7XCJsaW5lXCI6OTIsXCJjb2x1bW5cIjo0fSxcImVuZFwiOntcImxpbmVcIjo5MyxcImNvbHVtblwiOjcxfX0sXCIzNlwiOntcInN0YXJ0XCI6e1wibGluZVwiOjk1LFwiY29sdW1uXCI6NH0sXCJlbmRcIjp7XCJsaW5lXCI6MTAwLFwiY29sdW1uXCI6N319LFwiMzdcIjp7XCJzdGFydFwiOntcImxpbmVcIjo5NixcImNvbHVtblwiOjV9LFwiZW5kXCI6e1wibGluZVwiOjk5LFwiY29sdW1uXCI6Nn19LFwiMzhcIjp7XCJzdGFydFwiOntcImxpbmVcIjo5OCxcImNvbHVtblwiOjZ9LFwiZW5kXCI6e1wibGluZVwiOjk4LFwiY29sdW1uXCI6Mzd9fSxcIjM5XCI6e1wic3RhcnRcIjp7XCJsaW5lXCI6MTA2LFwiY29sdW1uXCI6MX0sXCJlbmRcIjp7XCJsaW5lXCI6MTEwLFwiY29sdW1uXCI6NH19LFwiNDBcIjp7XCJzdGFydFwiOntcImxpbmVcIjoxMTIsXCJjb2x1bW5cIjoxfSxcImVuZFwiOntcImxpbmVcIjoxMTIsXCJjb2x1bW5cIjoyOH19LFwiNDFcIjp7XCJzdGFydFwiOntcImxpbmVcIjoxNTEsXCJjb2x1bW5cIjowfSxcImVuZFwiOntcImxpbmVcIjoxNTgsXCJjb2x1bW5cIjoyfX0sXCI0MlwiOntcInN0YXJ0XCI6e1wibGluZVwiOjE1MixcImNvbHVtblwiOjF9LFwiZW5kXCI6e1wibGluZVwiOjE1NSxcImNvbHVtblwiOjJ9fSxcIjQzXCI6e1wic3RhcnRcIjp7XCJsaW5lXCI6MTUzLFwiY29sdW1uXCI6Mn0sXCJlbmRcIjp7XCJsaW5lXCI6MTUzLFwiY29sdW1uXCI6MTJ9fSxcIjQ0XCI6e1wic3RhcnRcIjp7XCJsaW5lXCI6MTU0LFwiY29sdW1uXCI6Mn0sXCJlbmRcIjp7XCJsaW5lXCI6MTU0LFwiY29sdW1uXCI6MTR9fSxcIjQ1XCI6e1wic3RhcnRcIjp7XCJsaW5lXCI6MTU3LFwiY29sdW1uXCI6MX0sXCJlbmRcIjp7XCJsaW5lXCI6MTU3LFwiY29sdW1uXCI6NjZ9fSxcIjQ2XCI6e1wic3RhcnRcIjp7XCJsaW5lXCI6MTYwLFwiY29sdW1uXCI6MH0sXCJlbmRcIjp7XCJsaW5lXCI6MTc5LFwiY29sdW1uXCI6Mn19LFwiNDdcIjp7XCJzdGFydFwiOntcImxpbmVcIjoxNjEsXCJjb2x1bW5cIjoxfSxcImVuZFwiOntcImxpbmVcIjoxNzgsXCJjb2x1bW5cIjoyfX0sXCI0OFwiOntcInN0YXJ0XCI6e1wibGluZVwiOjE2MixcImNvbHVtblwiOjJ9LFwiZW5kXCI6e1wibGluZVwiOjE2NSxcImNvbHVtblwiOjN9fSxcIjQ5XCI6e1wic3RhcnRcIjp7XCJsaW5lXCI6MTYzLFwiY29sdW1uXCI6M30sXCJlbmRcIjp7XCJsaW5lXCI6MTYzLFwiY29sdW1uXCI6MTN9fSxcIjUwXCI6e1wic3RhcnRcIjp7XCJsaW5lXCI6MTY0LFwiY29sdW1uXCI6M30sXCJlbmRcIjp7XCJsaW5lXCI6MTY0LFwiY29sdW1uXCI6MTV9fSxcIjUxXCI6e1wic3RhcnRcIjp7XCJsaW5lXCI6MTY3LFwiY29sdW1uXCI6Mn0sXCJlbmRcIjp7XCJsaW5lXCI6MTcxLFwiY29sdW1uXCI6OX19LFwiNTJcIjp7XCJzdGFydFwiOntcImxpbmVcIjoxNzMsXCJjb2x1bW5cIjoyfSxcImVuZFwiOntcImxpbmVcIjoxNzcsXCJjb2x1bW5cIjo1fX0sXCI1M1wiOntcInN0YXJ0XCI6e1wibGluZVwiOjE5MSxcImNvbHVtblwiOjB9LFwiZW5kXCI6e1wibGluZVwiOjE5NixcImNvbHVtblwiOjJ9fSxcIjU0XCI6e1wic3RhcnRcIjp7XCJsaW5lXCI6MTkyLFwiY29sdW1uXCI6MX0sXCJlbmRcIjp7XCJsaW5lXCI6MTkzLFwiY29sdW1uXCI6NTB9fSxcIjU1XCI6e1wic3RhcnRcIjp7XCJsaW5lXCI6MTk1LFwiY29sdW1uXCI6MX0sXCJlbmRcIjp7XCJsaW5lXCI6MTk1LFwiY29sdW1uXCI6NTN9fSxcIjU2XCI6e1wic3RhcnRcIjp7XCJsaW5lXCI6MjIwLFwiY29sdW1uXCI6MH0sXCJlbmRcIjp7XCJsaW5lXCI6MjQ0LFwiY29sdW1uXCI6Mn19LFwiNTdcIjp7XCJzdGFydFwiOntcImxpbmVcIjoyMjEsXCJjb2x1bW5cIjoxfSxcImVuZFwiOntcImxpbmVcIjoyMjQsXCJjb2x1bW5cIjoyfX0sXCI1OFwiOntcInN0YXJ0XCI6e1wibGluZVwiOjIyMixcImNvbHVtblwiOjJ9LFwiZW5kXCI6e1wibGluZVwiOjIyMixcImNvbHVtblwiOjIzfX0sXCI1OVwiOntcInN0YXJ0XCI6e1wibGluZVwiOjIyMyxcImNvbHVtblwiOjJ9LFwiZW5kXCI6e1wibGluZVwiOjIyMyxcImNvbHVtblwiOjMxfX0sXCI2MFwiOntcInN0YXJ0XCI6e1wibGluZVwiOjIyNixcImNvbHVtblwiOjF9LFwiZW5kXCI6e1wibGluZVwiOjIyNixcImNvbHVtblwiOjk4fX0sXCI2MVwiOntcInN0YXJ0XCI6e1wibGluZVwiOjIyOSxcImNvbHVtblwiOjF9LFwiZW5kXCI6e1wibGluZVwiOjIyOSxcImNvbHVtblwiOjQwfX0sXCI2MlwiOntcInN0YXJ0XCI6e1wibGluZVwiOjIzMCxcImNvbHVtblwiOjF9LFwiZW5kXCI6e1wibGluZVwiOjIzNyxcImNvbHVtblwiOjJ9fSxcIjYzXCI6e1wic3RhcnRcIjp7XCJsaW5lXCI6MjMxLFwiY29sdW1uXCI6Mn0sXCJlbmRcIjp7XCJsaW5lXCI6MjMxLFwiY29sdW1uXCI6NDl9fSxcIjY0XCI6e1wic3RhcnRcIjp7XCJsaW5lXCI6MjMyLFwiY29sdW1uXCI6Mn0sXCJlbmRcIjp7XCJsaW5lXCI6MjM2LFwiY29sdW1uXCI6M319LFwiNjVcIjp7XCJzdGFydFwiOntcImxpbmVcIjoyMzMsXCJjb2x1bW5cIjozfSxcImVuZFwiOntcImxpbmVcIjoyMzQsXCJjb2x1bW5cIjo0Nn19LFwiNjZcIjp7XCJzdGFydFwiOntcImxpbmVcIjoyMzUsXCJjb2x1bW5cIjozfSxcImVuZFwiOntcImxpbmVcIjoyMzUsXCJjb2x1bW5cIjoxMH19LFwiNjdcIjp7XCJzdGFydFwiOntcImxpbmVcIjoyMzksXCJjb2x1bW5cIjoxfSxcImVuZFwiOntcImxpbmVcIjoyNDMsXCJjb2x1bW5cIjo0fX0sXCI2OFwiOntcInN0YXJ0XCI6e1wibGluZVwiOjI1MCxcImNvbHVtblwiOjB9LFwiZW5kXCI6e1wibGluZVwiOjI1MCxcImNvbHVtblwiOjU3fX0sXCI2OVwiOntcInN0YXJ0XCI6e1wibGluZVwiOjI1MixcImNvbHVtblwiOjB9LFwiZW5kXCI6e1wibGluZVwiOjI1NCxcImNvbHVtblwiOjJ9fSxcIjcwXCI6e1wic3RhcnRcIjp7XCJsaW5lXCI6MjUzLFwiY29sdW1uXCI6MX0sXCJlbmRcIjp7XCJsaW5lXCI6MjUzLFwiY29sdW1uXCI6NzF9fSxcIjcxXCI6e1wic3RhcnRcIjp7XCJsaW5lXCI6MjkzLFwiY29sdW1uXCI6MH0sXCJlbmRcIjp7XCJsaW5lXCI6MzAwLFwiY29sdW1uXCI6Mn19LFwiNzJcIjp7XCJzdGFydFwiOntcImxpbmVcIjoyOTQsXCJjb2x1bW5cIjoxfSxcImVuZFwiOntcImxpbmVcIjoyOTcsXCJjb2x1bW5cIjoyfX0sXCI3M1wiOntcInN0YXJ0XCI6e1wibGluZVwiOjI5NSxcImNvbHVtblwiOjJ9LFwiZW5kXCI6e1wibGluZVwiOjI5NSxcImNvbHVtblwiOjE2fX0sXCI3NFwiOntcInN0YXJ0XCI6e1wibGluZVwiOjI5NixcImNvbHVtblwiOjJ9LFwiZW5kXCI6e1wibGluZVwiOjI5NixcImNvbHVtblwiOjI3fX0sXCI3NVwiOntcInN0YXJ0XCI6e1wibGluZVwiOjI5OSxcImNvbHVtblwiOjF9LFwiZW5kXCI6e1wibGluZVwiOjI5OSxcImNvbHVtblwiOjQ5fX0sXCI3NlwiOntcInN0YXJ0XCI6e1wibGluZVwiOjMwMixcImNvbHVtblwiOjB9LFwiZW5kXCI6e1wibGluZVwiOjMxOSxcImNvbHVtblwiOjJ9fSxcIjc3XCI6e1wic3RhcnRcIjp7XCJsaW5lXCI6MzAzLFwiY29sdW1uXCI6MX0sXCJlbmRcIjp7XCJsaW5lXCI6MzA1LFwiY29sdW1uXCI6Mn19LFwiNzhcIjp7XCJzdGFydFwiOntcImxpbmVcIjozMDQsXCJjb2x1bW5cIjoyfSxcImVuZFwiOntcImxpbmVcIjozMDQsXCJjb2x1bW5cIjo2NX19LFwiNzlcIjp7XCJzdGFydFwiOntcImxpbmVcIjozMDcsXCJjb2x1bW5cIjoxfSxcImVuZFwiOntcImxpbmVcIjozMDksXCJjb2x1bW5cIjoyfX0sXCI4MFwiOntcInN0YXJ0XCI6e1wibGluZVwiOjMwOCxcImNvbHVtblwiOjJ9LFwiZW5kXCI6e1wibGluZVwiOjMwOCxcImNvbHVtblwiOjcyfX0sXCI4MVwiOntcInN0YXJ0XCI6e1wibGluZVwiOjMxMSxcImNvbHVtblwiOjF9LFwiZW5kXCI6e1wibGluZVwiOjMxOCxcImNvbHVtblwiOjJ9fSxcIjgyXCI6e1wic3RhcnRcIjp7XCJsaW5lXCI6MzEyLFwiY29sdW1uXCI6Mn0sXCJlbmRcIjp7XCJsaW5lXCI6MzEyLFwiY29sdW1uXCI6NzJ9fSxcIjgzXCI6e1wic3RhcnRcIjp7XCJsaW5lXCI6MzE0LFwiY29sdW1uXCI6Mn0sXCJlbmRcIjp7XCJsaW5lXCI6MzE0LFwiY29sdW1uXCI6NDh9fSxcIjg0XCI6e1wic3RhcnRcIjp7XCJsaW5lXCI6MzE1LFwiY29sdW1uXCI6Mn0sXCJlbmRcIjp7XCJsaW5lXCI6MzE3LFwiY29sdW1uXCI6M319LFwiODVcIjp7XCJzdGFydFwiOntcImxpbmVcIjozMTYsXCJjb2x1bW5cIjozfSxcImVuZFwiOntcImxpbmVcIjozMTYsXCJjb2x1bW5cIjoyNn19LFwiODZcIjp7XCJzdGFydFwiOntcImxpbmVcIjozNDAsXCJjb2x1bW5cIjowfSxcImVuZFwiOntcImxpbmVcIjozNDcsXCJjb2x1bW5cIjoyfX0sXCI4N1wiOntcInN0YXJ0XCI6e1wibGluZVwiOjM0MSxcImNvbHVtblwiOjF9LFwiZW5kXCI6e1wibGluZVwiOjM0NCxcImNvbHVtblwiOjJ9fSxcIjg4XCI6e1wic3RhcnRcIjp7XCJsaW5lXCI6MzQyLFwiY29sdW1uXCI6Mn0sXCJlbmRcIjp7XCJsaW5lXCI6MzQyLFwiY29sdW1uXCI6MTR9fSxcIjg5XCI6e1wic3RhcnRcIjp7XCJsaW5lXCI6MzQzLFwiY29sdW1uXCI6Mn0sXCJlbmRcIjp7XCJsaW5lXCI6MzQzLFwiY29sdW1uXCI6Mjd9fSxcIjkwXCI6e1wic3RhcnRcIjp7XCJsaW5lXCI6MzQ2LFwiY29sdW1uXCI6MX0sXCJlbmRcIjp7XCJsaW5lXCI6MzQ2LFwiY29sdW1uXCI6NDd9fSxcIjkxXCI6e1wic3RhcnRcIjp7XCJsaW5lXCI6MzQ5LFwiY29sdW1uXCI6MH0sXCJlbmRcIjp7XCJsaW5lXCI6NDYyLFwiY29sdW1uXCI6MX19LFwiOTJcIjp7XCJzdGFydFwiOntcImxpbmVcIjozNTAsXCJjb2x1bW5cIjoxfSxcImVuZFwiOntcImxpbmVcIjozNTAsXCJjb2x1bW5cIjoyNH19LFwiOTNcIjp7XCJzdGFydFwiOntcImxpbmVcIjozNjEsXCJjb2x1bW5cIjoxfSxcImVuZFwiOntcImxpbmVcIjozNzEsXCJjb2x1bW5cIjozfX0sXCI5NFwiOntcInN0YXJ0XCI6e1wibGluZVwiOjM2MixcImNvbHVtblwiOjJ9LFwiZW5kXCI6e1wibGluZVwiOjM2MixcImNvbHVtblwiOjIzfX0sXCI5NVwiOntcInN0YXJ0XCI6e1wibGluZVwiOjM2MyxcImNvbHVtblwiOjJ9LFwiZW5kXCI6e1wibGluZVwiOjM3MCxcImNvbHVtblwiOjN9fSxcIjk2XCI6e1wic3RhcnRcIjp7XCJsaW5lXCI6MzY0LFwiY29sdW1uXCI6M30sXCJlbmRcIjp7XCJsaW5lXCI6MzY4LFwiY29sdW1uXCI6NH19LFwiOTdcIjp7XCJzdGFydFwiOntcImxpbmVcIjozNjUsXCJjb2x1bW5cIjo0fSxcImVuZFwiOntcImxpbmVcIjozNjcsXCJjb2x1bW5cIjo1fX0sXCI5OFwiOntcInN0YXJ0XCI6e1wibGluZVwiOjM2NixcImNvbHVtblwiOjV9LFwiZW5kXCI6e1wibGluZVwiOjM2NixcImNvbHVtblwiOjE5fX0sXCI5OVwiOntcInN0YXJ0XCI6e1wibGluZVwiOjM2OSxcImNvbHVtblwiOjN9LFwiZW5kXCI6e1wibGluZVwiOjM2OSxcImNvbHVtblwiOjMwfX0sXCIxMDBcIjp7XCJzdGFydFwiOntcImxpbmVcIjozODAsXCJjb2x1bW5cIjoxfSxcImVuZFwiOntcImxpbmVcIjozODQsXCJjb2x1bW5cIjozfX0sXCIxMDFcIjp7XCJzdGFydFwiOntcImxpbmVcIjozODEsXCJjb2x1bW5cIjoyfSxcImVuZFwiOntcImxpbmVcIjozODEsXCJjb2x1bW5cIjozN319LFwiMTAyXCI6e1wic3RhcnRcIjp7XCJsaW5lXCI6MzgyLFwiY29sdW1uXCI6Mn0sXCJlbmRcIjp7XCJsaW5lXCI6MzgyLFwiY29sdW1uXCI6MzV9fSxcIjEwM1wiOntcInN0YXJ0XCI6e1wibGluZVwiOjM4MyxcImNvbHVtblwiOjJ9LFwiZW5kXCI6e1wibGluZVwiOjM4MyxcImNvbHVtblwiOjUyfX0sXCIxMDRcIjp7XCJzdGFydFwiOntcImxpbmVcIjozOTMsXCJjb2x1bW5cIjoxfSxcImVuZFwiOntcImxpbmVcIjozOTcsXCJjb2x1bW5cIjozfX0sXCIxMDVcIjp7XCJzdGFydFwiOntcImxpbmVcIjozOTQsXCJjb2x1bW5cIjoyfSxcImVuZFwiOntcImxpbmVcIjozOTQsXCJjb2x1bW5cIjozN319LFwiMTA2XCI6e1wic3RhcnRcIjp7XCJsaW5lXCI6Mzk1LFwiY29sdW1uXCI6Mn0sXCJlbmRcIjp7XCJsaW5lXCI6Mzk1LFwiY29sdW1uXCI6NDR9fSxcIjEwN1wiOntcInN0YXJ0XCI6e1wibGluZVwiOjM5NixcImNvbHVtblwiOjJ9LFwiZW5kXCI6e1wibGluZVwiOjM5NixcImNvbHVtblwiOjYzfX0sXCIxMDhcIjp7XCJzdGFydFwiOntcImxpbmVcIjo0MDQsXCJjb2x1bW5cIjoxfSxcImVuZFwiOntcImxpbmVcIjo0MDQsXCJjb2x1bW5cIjo1MX19LFwiMTA5XCI6e1wic3RhcnRcIjp7XCJsaW5lXCI6NDEyLFwiY29sdW1uXCI6MX0sXCJlbmRcIjp7XCJsaW5lXCI6NDEyLFwiY29sdW1uXCI6Mzl9fSxcIjExMFwiOntcInN0YXJ0XCI6e1wibGluZVwiOjQxNCxcImNvbHVtblwiOjF9LFwiZW5kXCI6e1wibGluZVwiOjQxNCxcImNvbHVtblwiOjI4fX0sXCIxMTFcIjp7XCJzdGFydFwiOntcImxpbmVcIjo0MjMsXCJjb2x1bW5cIjoxfSxcImVuZFwiOntcImxpbmVcIjo0MjMsXCJjb2x1bW5cIjo1MX19LFwiMTEyXCI6e1wic3RhcnRcIjp7XCJsaW5lXCI6NDMxLFwiY29sdW1uXCI6MX0sXCJlbmRcIjp7XCJsaW5lXCI6NDMxLFwiY29sdW1uXCI6NTV9fSxcIjExM1wiOntcInN0YXJ0XCI6e1wibGluZVwiOjQ1NixcImNvbHVtblwiOjF9LFwiZW5kXCI6e1wibGluZVwiOjQ2MSxcImNvbHVtblwiOjR9fSxcIjExNFwiOntcInN0YXJ0XCI6e1wibGluZVwiOjQ1OCxcImNvbHVtblwiOjN9LFwiZW5kXCI6e1wibGluZVwiOjQ1OCxcImNvbHVtblwiOjMzfX0sXCIxMTVcIjp7XCJzdGFydFwiOntcImxpbmVcIjo0NjQsXCJjb2x1bW5cIjowfSxcImVuZFwiOntcImxpbmVcIjo0NjQsXCJjb2x1bW5cIjoyNH19fSxcImJyYW5jaE1hcFwiOntcIjFcIjp7XCJsaW5lXCI6NDgsXCJ0eXBlXCI6XCJpZlwiLFwibG9jYXRpb25zXCI6W3tcInN0YXJ0XCI6e1wibGluZVwiOjQ4LFwiY29sdW1uXCI6MX0sXCJlbmRcIjp7XCJsaW5lXCI6NDgsXCJjb2x1bW5cIjoxfX0se1wic3RhcnRcIjp7XCJsaW5lXCI6NDgsXCJjb2x1bW5cIjoxfSxcImVuZFwiOntcImxpbmVcIjo0OCxcImNvbHVtblwiOjF9fV19LFwiMlwiOntcImxpbmVcIjo1MCxcInR5cGVcIjpcImlmXCIsXCJsb2NhdGlvbnNcIjpbe1wic3RhcnRcIjp7XCJsaW5lXCI6NTAsXCJjb2x1bW5cIjoyfSxcImVuZFwiOntcImxpbmVcIjo1MCxcImNvbHVtblwiOjJ9fSx7XCJzdGFydFwiOntcImxpbmVcIjo1MCxcImNvbHVtblwiOjJ9LFwiZW5kXCI6e1wibGluZVwiOjUwLFwiY29sdW1uXCI6Mn19XX0sXCIzXCI6e1wibGluZVwiOjU2LFwidHlwZVwiOlwiaWZcIixcImxvY2F0aW9uc1wiOlt7XCJzdGFydFwiOntcImxpbmVcIjo1NixcImNvbHVtblwiOjN9LFwiZW5kXCI6e1wibGluZVwiOjU2LFwiY29sdW1uXCI6M319LHtcInN0YXJ0XCI6e1wibGluZVwiOjU2LFwiY29sdW1uXCI6M30sXCJlbmRcIjp7XCJsaW5lXCI6NTYsXCJjb2x1bW5cIjozfX1dfSxcIjRcIjp7XCJsaW5lXCI6NzEsXCJ0eXBlXCI6XCJpZlwiLFwibG9jYXRpb25zXCI6W3tcInN0YXJ0XCI6e1wibGluZVwiOjcxLFwiY29sdW1uXCI6NH0sXCJlbmRcIjp7XCJsaW5lXCI6NzEsXCJjb2x1bW5cIjo0fX0se1wic3RhcnRcIjp7XCJsaW5lXCI6NzEsXCJjb2x1bW5cIjo0fSxcImVuZFwiOntcImxpbmVcIjo3MSxcImNvbHVtblwiOjR9fV19LFwiNVwiOntcImxpbmVcIjo3MSxcInR5cGVcIjpcImJpbmFyeS1leHByXCIsXCJsb2NhdGlvbnNcIjpbe1wic3RhcnRcIjp7XCJsaW5lXCI6NzEsXCJjb2x1bW5cIjo4fSxcImVuZFwiOntcImxpbmVcIjo3MSxcImNvbHVtblwiOjQ4fX0se1wic3RhcnRcIjp7XCJsaW5lXCI6NzIsXCJjb2x1bW5cIjo1fSxcImVuZFwiOntcImxpbmVcIjo3MixcImNvbHVtblwiOjQzfX1dfSxcIjZcIjp7XCJsaW5lXCI6NzksXCJ0eXBlXCI6XCJpZlwiLFwibG9jYXRpb25zXCI6W3tcInN0YXJ0XCI6e1wibGluZVwiOjc5LFwiY29sdW1uXCI6M30sXCJlbmRcIjp7XCJsaW5lXCI6NzksXCJjb2x1bW5cIjozfX0se1wic3RhcnRcIjp7XCJsaW5lXCI6NzksXCJjb2x1bW5cIjozfSxcImVuZFwiOntcImxpbmVcIjo3OSxcImNvbHVtblwiOjN9fV19LFwiN1wiOntcImxpbmVcIjo5NixcInR5cGVcIjpcImlmXCIsXCJsb2NhdGlvbnNcIjpbe1wic3RhcnRcIjp7XCJsaW5lXCI6OTYsXCJjb2x1bW5cIjo1fSxcImVuZFwiOntcImxpbmVcIjo5NixcImNvbHVtblwiOjV9fSx7XCJzdGFydFwiOntcImxpbmVcIjo5NixcImNvbHVtblwiOjV9LFwiZW5kXCI6e1wibGluZVwiOjk2LFwiY29sdW1uXCI6NX19XX0sXCI4XCI6e1wibGluZVwiOjk2LFwidHlwZVwiOlwiYmluYXJ5LWV4cHJcIixcImxvY2F0aW9uc1wiOlt7XCJzdGFydFwiOntcImxpbmVcIjo5NixcImNvbHVtblwiOjl9LFwiZW5kXCI6e1wibGluZVwiOjk2LFwiY29sdW1uXCI6NDl9fSx7XCJzdGFydFwiOntcImxpbmVcIjo5NyxcImNvbHVtblwiOjZ9LFwiZW5kXCI6e1wibGluZVwiOjk3LFwiY29sdW1uXCI6NDR9fV19LFwiOVwiOntcImxpbmVcIjoxNTIsXCJ0eXBlXCI6XCJpZlwiLFwibG9jYXRpb25zXCI6W3tcInN0YXJ0XCI6e1wibGluZVwiOjE1MixcImNvbHVtblwiOjF9LFwiZW5kXCI6e1wibGluZVwiOjE1MixcImNvbHVtblwiOjF9fSx7XCJzdGFydFwiOntcImxpbmVcIjoxNTIsXCJjb2x1bW5cIjoxfSxcImVuZFwiOntcImxpbmVcIjoxNTIsXCJjb2x1bW5cIjoxfX1dfSxcIjEwXCI6e1wibGluZVwiOjE1MixcInR5cGVcIjpcImJpbmFyeS1leHByXCIsXCJsb2NhdGlvbnNcIjpbe1wic3RhcnRcIjp7XCJsaW5lXCI6MTUyLFwiY29sdW1uXCI6NX0sXCJlbmRcIjp7XCJsaW5lXCI6MTUyLFwiY29sdW1uXCI6MzB9fSx7XCJzdGFydFwiOntcImxpbmVcIjoxNTIsXCJjb2x1bW5cIjozNH0sXCJlbmRcIjp7XCJsaW5lXCI6MTUyLFwiY29sdW1uXCI6NjB9fV19LFwiMTFcIjp7XCJsaW5lXCI6MTYxLFwidHlwZVwiOlwiaWZcIixcImxvY2F0aW9uc1wiOlt7XCJzdGFydFwiOntcImxpbmVcIjoxNjEsXCJjb2x1bW5cIjoxfSxcImVuZFwiOntcImxpbmVcIjoxNjEsXCJjb2x1bW5cIjoxfX0se1wic3RhcnRcIjp7XCJsaW5lXCI6MTYxLFwiY29sdW1uXCI6MX0sXCJlbmRcIjp7XCJsaW5lXCI6MTYxLFwiY29sdW1uXCI6MX19XX0sXCIxMlwiOntcImxpbmVcIjoxNjIsXCJ0eXBlXCI6XCJpZlwiLFwibG9jYXRpb25zXCI6W3tcInN0YXJ0XCI6e1wibGluZVwiOjE2MixcImNvbHVtblwiOjJ9LFwiZW5kXCI6e1wibGluZVwiOjE2MixcImNvbHVtblwiOjJ9fSx7XCJzdGFydFwiOntcImxpbmVcIjoxNjIsXCJjb2x1bW5cIjoyfSxcImVuZFwiOntcImxpbmVcIjoxNjIsXCJjb2x1bW5cIjoyfX1dfSxcIjEzXCI6e1wibGluZVwiOjE2MixcInR5cGVcIjpcImJpbmFyeS1leHByXCIsXCJsb2NhdGlvbnNcIjpbe1wic3RhcnRcIjp7XCJsaW5lXCI6MTYyLFwiY29sdW1uXCI6Nn0sXCJlbmRcIjp7XCJsaW5lXCI6MTYyLFwiY29sdW1uXCI6MzF9fSx7XCJzdGFydFwiOntcImxpbmVcIjoxNjIsXCJjb2x1bW5cIjozNX0sXCJlbmRcIjp7XCJsaW5lXCI6MTYyLFwiY29sdW1uXCI6NjF9fV19LFwiMTRcIjp7XCJsaW5lXCI6MjIxLFwidHlwZVwiOlwiaWZcIixcImxvY2F0aW9uc1wiOlt7XCJzdGFydFwiOntcImxpbmVcIjoyMjEsXCJjb2x1bW5cIjoxfSxcImVuZFwiOntcImxpbmVcIjoyMjEsXCJjb2x1bW5cIjoxfX0se1wic3RhcnRcIjp7XCJsaW5lXCI6MjIxLFwiY29sdW1uXCI6MX0sXCJlbmRcIjp7XCJsaW5lXCI6MjIxLFwiY29sdW1uXCI6MX19XX0sXCIxNVwiOntcImxpbmVcIjoyMzIsXCJ0eXBlXCI6XCJpZlwiLFwibG9jYXRpb25zXCI6W3tcInN0YXJ0XCI6e1wibGluZVwiOjIzMixcImNvbHVtblwiOjJ9LFwiZW5kXCI6e1wibGluZVwiOjIzMixcImNvbHVtblwiOjJ9fSx7XCJzdGFydFwiOntcImxpbmVcIjoyMzIsXCJjb2x1bW5cIjoyfSxcImVuZFwiOntcImxpbmVcIjoyMzIsXCJjb2x1bW5cIjoyfX1dfSxcIjE2XCI6e1wibGluZVwiOjIzMixcInR5cGVcIjpcImJpbmFyeS1leHByXCIsXCJsb2NhdGlvbnNcIjpbe1wic3RhcnRcIjp7XCJsaW5lXCI6MjMyLFwiY29sdW1uXCI6Nn0sXCJlbmRcIjp7XCJsaW5lXCI6MjMyLFwiY29sdW1uXCI6NDl9fSx7XCJzdGFydFwiOntcImxpbmVcIjoyMzIsXCJjb2x1bW5cIjo1M30sXCJlbmRcIjp7XCJsaW5lXCI6MjMyLFwiY29sdW1uXCI6OTR9fV19LFwiMTdcIjp7XCJsaW5lXCI6MjUzLFwidHlwZVwiOlwiY29uZC1leHByXCIsXCJsb2NhdGlvbnNcIjpbe1wic3RhcnRcIjp7XCJsaW5lXCI6MjUzLFwiY29sdW1uXCI6NDl9LFwiZW5kXCI6e1wibGluZVwiOjI1MyxcImNvbHVtblwiOjYyfX0se1wic3RhcnRcIjp7XCJsaW5lXCI6MjUzLFwiY29sdW1uXCI6NjV9LFwiZW5kXCI6e1wibGluZVwiOjI1MyxcImNvbHVtblwiOjY5fX1dfSxcIjE4XCI6e1wibGluZVwiOjI5NCxcInR5cGVcIjpcImlmXCIsXCJsb2NhdGlvbnNcIjpbe1wic3RhcnRcIjp7XCJsaW5lXCI6Mjk0LFwiY29sdW1uXCI6MX0sXCJlbmRcIjp7XCJsaW5lXCI6Mjk0LFwiY29sdW1uXCI6MX19LHtcInN0YXJ0XCI6e1wibGluZVwiOjI5NCxcImNvbHVtblwiOjF9LFwiZW5kXCI6e1wibGluZVwiOjI5NCxcImNvbHVtblwiOjF9fV19LFwiMTlcIjp7XCJsaW5lXCI6Mjk0LFwidHlwZVwiOlwiYmluYXJ5LWV4cHJcIixcImxvY2F0aW9uc1wiOlt7XCJzdGFydFwiOntcImxpbmVcIjoyOTQsXCJjb2x1bW5cIjo1fSxcImVuZFwiOntcImxpbmVcIjoyOTQsXCJjb2x1bW5cIjoxMn19LHtcInN0YXJ0XCI6e1wibGluZVwiOjI5NCxcImNvbHVtblwiOjE2fSxcImVuZFwiOntcImxpbmVcIjoyOTQsXCJjb2x1bW5cIjo0Mn19XX0sXCIyMFwiOntcImxpbmVcIjozMDMsXCJ0eXBlXCI6XCJpZlwiLFwibG9jYXRpb25zXCI6W3tcInN0YXJ0XCI6e1wibGluZVwiOjMwMyxcImNvbHVtblwiOjF9LFwiZW5kXCI6e1wibGluZVwiOjMwMyxcImNvbHVtblwiOjF9fSx7XCJzdGFydFwiOntcImxpbmVcIjozMDMsXCJjb2x1bW5cIjoxfSxcImVuZFwiOntcImxpbmVcIjozMDMsXCJjb2x1bW5cIjoxfX1dfSxcIjIxXCI6e1wibGluZVwiOjMwMyxcInR5cGVcIjpcImJpbmFyeS1leHByXCIsXCJsb2NhdGlvbnNcIjpbe1wic3RhcnRcIjp7XCJsaW5lXCI6MzAzLFwiY29sdW1uXCI6NX0sXCJlbmRcIjp7XCJsaW5lXCI6MzAzLFwiY29sdW1uXCI6MTB9fSx7XCJzdGFydFwiOntcImxpbmVcIjozMDMsXCJjb2x1bW5cIjoxNH0sXCJlbmRcIjp7XCJsaW5lXCI6MzAzLFwiY29sdW1uXCI6Mzh9fV19LFwiMjJcIjp7XCJsaW5lXCI6MzA3LFwidHlwZVwiOlwiaWZcIixcImxvY2F0aW9uc1wiOlt7XCJzdGFydFwiOntcImxpbmVcIjozMDcsXCJjb2x1bW5cIjoxfSxcImVuZFwiOntcImxpbmVcIjozMDcsXCJjb2x1bW5cIjoxfX0se1wic3RhcnRcIjp7XCJsaW5lXCI6MzA3LFwiY29sdW1uXCI6MX0sXCJlbmRcIjp7XCJsaW5lXCI6MzA3LFwiY29sdW1uXCI6MX19XX0sXCIyM1wiOntcImxpbmVcIjozMDcsXCJ0eXBlXCI6XCJiaW5hcnktZXhwclwiLFwibG9jYXRpb25zXCI6W3tcInN0YXJ0XCI6e1wibGluZVwiOjMwNyxcImNvbHVtblwiOjV9LFwiZW5kXCI6e1wibGluZVwiOjMwNyxcImNvbHVtblwiOjEyfX0se1wic3RhcnRcIjp7XCJsaW5lXCI6MzA3LFwiY29sdW1uXCI6MTZ9LFwiZW5kXCI6e1wibGluZVwiOjMwNyxcImNvbHVtblwiOjQyfX1dfSxcIjI0XCI6e1wibGluZVwiOjMxMSxcInR5cGVcIjpcImlmXCIsXCJsb2NhdGlvbnNcIjpbe1wic3RhcnRcIjp7XCJsaW5lXCI6MzExLFwiY29sdW1uXCI6MX0sXCJlbmRcIjp7XCJsaW5lXCI6MzExLFwiY29sdW1uXCI6MX19LHtcInN0YXJ0XCI6e1wibGluZVwiOjMxMSxcImNvbHVtblwiOjF9LFwiZW5kXCI6e1wibGluZVwiOjMxMSxcImNvbHVtblwiOjF9fV19LFwiMjVcIjp7XCJsaW5lXCI6MzE1LFwidHlwZVwiOlwiaWZcIixcImxvY2F0aW9uc1wiOlt7XCJzdGFydFwiOntcImxpbmVcIjozMTUsXCJjb2x1bW5cIjoyfSxcImVuZFwiOntcImxpbmVcIjozMTUsXCJjb2x1bW5cIjoyfX0se1wic3RhcnRcIjp7XCJsaW5lXCI6MzE1LFwiY29sdW1uXCI6Mn0sXCJlbmRcIjp7XCJsaW5lXCI6MzE1LFwiY29sdW1uXCI6Mn19XX0sXCIyNlwiOntcImxpbmVcIjozNDEsXCJ0eXBlXCI6XCJpZlwiLFwibG9jYXRpb25zXCI6W3tcInN0YXJ0XCI6e1wibGluZVwiOjM0MSxcImNvbHVtblwiOjF9LFwiZW5kXCI6e1wibGluZVwiOjM0MSxcImNvbHVtblwiOjF9fSx7XCJzdGFydFwiOntcImxpbmVcIjozNDEsXCJjb2x1bW5cIjoxfSxcImVuZFwiOntcImxpbmVcIjozNDEsXCJjb2x1bW5cIjoxfX1dfSxcIjI3XCI6e1wibGluZVwiOjM0MSxcInR5cGVcIjpcImJpbmFyeS1leHByXCIsXCJsb2NhdGlvbnNcIjpbe1wic3RhcnRcIjp7XCJsaW5lXCI6MzQxLFwiY29sdW1uXCI6NX0sXCJlbmRcIjp7XCJsaW5lXCI6MzQxLFwiY29sdW1uXCI6MTJ9fSx7XCJzdGFydFwiOntcImxpbmVcIjozNDEsXCJjb2x1bW5cIjoxNn0sXCJlbmRcIjp7XCJsaW5lXCI6MzQxLFwiY29sdW1uXCI6NDJ9fV19LFwiMjhcIjp7XCJsaW5lXCI6MzQ5LFwidHlwZVwiOlwiaWZcIixcImxvY2F0aW9uc1wiOlt7XCJzdGFydFwiOntcImxpbmVcIjozNDksXCJjb2x1bW5cIjowfSxcImVuZFwiOntcImxpbmVcIjozNDksXCJjb2x1bW5cIjowfX0se1wic3RhcnRcIjp7XCJsaW5lXCI6MzQ5LFwiY29sdW1uXCI6MH0sXCJlbmRcIjp7XCJsaW5lXCI6MzQ5LFwiY29sdW1uXCI6MH19XX0sXCIyOVwiOntcImxpbmVcIjozNjQsXCJ0eXBlXCI6XCJpZlwiLFwibG9jYXRpb25zXCI6W3tcInN0YXJ0XCI6e1wibGluZVwiOjM2NCxcImNvbHVtblwiOjN9LFwiZW5kXCI6e1wibGluZVwiOjM2NCxcImNvbHVtblwiOjN9fSx7XCJzdGFydFwiOntcImxpbmVcIjozNjQsXCJjb2x1bW5cIjozfSxcImVuZFwiOntcImxpbmVcIjozNjQsXCJjb2x1bW5cIjozfX1dfSxcIjMwXCI6e1wibGluZVwiOjM2NSxcInR5cGVcIjpcImlmXCIsXCJsb2NhdGlvbnNcIjpbe1wic3RhcnRcIjp7XCJsaW5lXCI6MzY1LFwiY29sdW1uXCI6NH0sXCJlbmRcIjp7XCJsaW5lXCI6MzY1LFwiY29sdW1uXCI6NH19LHtcInN0YXJ0XCI6e1wibGluZVwiOjM2NSxcImNvbHVtblwiOjR9LFwiZW5kXCI6e1wibGluZVwiOjM2NSxcImNvbHVtblwiOjR9fV19LFwiMzFcIjp7XCJsaW5lXCI6MzgxLFwidHlwZVwiOlwiYmluYXJ5LWV4cHJcIixcImxvY2F0aW9uc1wiOlt7XCJzdGFydFwiOntcImxpbmVcIjozODEsXCJjb2x1bW5cIjoxMX0sXCJlbmRcIjp7XCJsaW5lXCI6MzgxLFwiY29sdW1uXCI6MTd9fSx7XCJzdGFydFwiOntcImxpbmVcIjozODEsXCJjb2x1bW5cIjoyMX0sXCJlbmRcIjp7XCJsaW5lXCI6MzgxLFwiY29sdW1uXCI6MzZ9fV19LFwiMzJcIjp7XCJsaW5lXCI6Mzk0LFwidHlwZVwiOlwiYmluYXJ5LWV4cHJcIixcImxvY2F0aW9uc1wiOlt7XCJzdGFydFwiOntcImxpbmVcIjozOTQsXCJjb2x1bW5cIjoxMX0sXCJlbmRcIjp7XCJsaW5lXCI6Mzk0LFwiY29sdW1uXCI6MTd9fSx7XCJzdGFydFwiOntcImxpbmVcIjozOTQsXCJjb2x1bW5cIjoyMX0sXCJlbmRcIjp7XCJsaW5lXCI6Mzk0LFwiY29sdW1uXCI6MzZ9fV19fX07XG59XG5fX2Nvdl9GekxWaTlOdnM0RGhCdHdJSEZIR2F3ID0gX19jb3ZfRnpMVmk5TnZzNERoQnR3SUhGSEdhd1snRzpcXFxcUHJvZ3JhbW1pbmdcXFxcbm9kZWNnXFxcXGxpYlxcXFxhcGkuanMnXTtcbl9fY292X0Z6TFZpOU52czREaEJ0d0lIRkhHYXcuc1snMSddKys7dmFyIFJlcGxpY2FudD1yZXF1aXJlKCcuL2Jyb3dzZXIvcmVwbGljYW50Jyk7X19jb3ZfRnpMVmk5TnZzNERoQnR3SUhGSEdhdy5zWycyJ10rKzt2YXIgaW89e307X19jb3ZfRnpMVmk5TnZzNERoQnR3SUhGSEdhdy5zWyczJ10rKzt2YXIgc2VydmVyPXJlcXVpcmUoJy4vc2VydmVyJyk7X19jb3ZfRnpMVmk5TnZzNERoQnR3SUhGSEdhdy5zWyc0J10rKzt2YXIgZmlsdGVyZWRDb25maWc9cmVxdWlyZSgnLi9icm93c2VyL2NvbmZpZycpLmZpbHRlcmVkQ29uZmlnO19fY292X0Z6TFZpOU52czREaEJ0d0lIRkhHYXcuc1snNSddKys7dmFyIHV0aWxzPXJlcXVpcmUoJy4vdXRpbCcpO19fY292X0Z6TFZpOU52czREaEJ0d0lIRkhHYXcuc1snNiddKys7dmFyIHJlcGxpY2F0b3I9cmVxdWlyZSgnLi9yZXBsaWNhdG9yJyk7ZnVuY3Rpb24gTm9kZUNHKGJ1bmRsZSxzb2NrZXQpe19fY292X0Z6TFZpOU52czREaEJ0d0lIRkhHYXcuZlsnMSddKys7X19jb3ZfRnpMVmk5TnZzNERoQnR3SUhGSEdhdy5zWyc4J10rKzt2YXIgc2VsZj10aGlzO19fY292X0Z6TFZpOU52czREaEJ0d0lIRkhHYXcuc1snOSddKys7dGhpcy5idW5kbGVOYW1lPWJ1bmRsZS5uYW1lO19fY292X0Z6TFZpOU52czREaEJ0d0lIRkhHYXcuc1snMTAnXSsrO3RoaXMuYnVuZGxlQ29uZmlnPWJ1bmRsZS5jb25maWc7X19jb3ZfRnpMVmk5TnZzNERoQnR3SUhGSEdhdy5zWycxMSddKys7dGhpcy5sb2c9cmVxdWlyZSgnLi9icm93c2VyL2xvZ2dlcicpKGJ1bmRsZS5uYW1lKTtfX2Nvdl9GekxWaTlOdnM0RGhCdHdJSEZIR2F3LnNbJzEyJ10rKzt0aGlzLl9tZXNzYWdlSGFuZGxlcnM9W107X19jb3ZfRnpMVmk5TnZzNERoQnR3SUhGSEdhdy5zWycxMyddKys7aWYodHJ1ZSl7X19jb3ZfRnpMVmk5TnZzNERoQnR3SUhGSEdhdy5iWycxJ11bMF0rKztfX2Nvdl9GekxWaTlOdnM0RGhCdHdJSEZIR2F3LnNbJzE0J10rKztpZih0eXBlb2YgaW89PT0ndW5kZWZpbmVkJyl7X19jb3ZfRnpMVmk5TnZzNERoQnR3SUhGSEdhdy5iWycyJ11bMF0rKztfX2Nvdl9GekxWaTlOdnM0RGhCdHdJSEZIR2F3LnNbJzE1J10rKzt0aHJvdyBuZXcgRXJyb3IoJ1tub2RlY2VnXSBTb2NrZXQuSU8gbXVzdCBiZSBsb2FkZWQgYmVmb3JlIGluc3RhbnRpYXRpbmcgdGhlIEFQSScpO31lbHNle19fY292X0Z6TFZpOU52czREaEJ0d0lIRkhHYXcuYlsnMiddWzFdKys7fV9fY292X0Z6TFZpOU52czREaEJ0d0lIRkhHYXcuc1snMTYnXSsrO2RvY3VtZW50LmFkZEV2ZW50TGlzdGVuZXIoJ0RPTUNvbnRlbnRMb2FkZWQnLGZ1bmN0aW9uKCl7X19jb3ZfRnpMVmk5TnZzNERoQnR3SUhGSEdhdy5mWycyJ10rKztfX2Nvdl9GekxWaTlOdnM0RGhCdHdJSEZIR2F3LnNbJzE3J10rKztpZihkb2N1bWVudC50aXRsZT09PScnKXtfX2Nvdl9GekxWaTlOdnM0RGhCdHdJSEZIR2F3LmJbJzMnXVswXSsrO19fY292X0Z6TFZpOU52czREaEJ0d0lIRkhHYXcuc1snMTgnXSsrO2RvY3VtZW50LnRpdGxlPXNlbGYuYnVuZGxlTmFtZTt9ZWxzZXtfX2Nvdl9GekxWaTlOdnM0RGhCdHdJSEZIR2F3LmJbJzMnXVsxXSsrO319LGZhbHNlKTtfX2Nvdl9GekxWaTlOdnM0RGhCdHdJSEZIR2F3LnNbJzE5J10rKzt0aGlzLnNvY2tldD1zb2NrZXQ7X19jb3ZfRnpMVmk5TnZzNERoQnR3SUhGSEdhdy5zWycyMCddKys7dGhpcy5zb2NrZXQuZW1pdCgnam9pblJvb20nLGJ1bmRsZS5uYW1lKTtfX2Nvdl9GekxWaTlOdnM0RGhCdHdJSEZIR2F3LnNbJzIxJ10rKztzb2NrZXQub24oJ21lc3NhZ2UnLGZ1bmN0aW9uIG9uTWVzc2FnZShkYXRhKXtfX2Nvdl9GekxWaTlOdnM0RGhCdHdJSEZIR2F3LmZbJzMnXSsrO19fY292X0Z6TFZpOU52czREaEJ0d0lIRkhHYXcuc1snMjInXSsrO3NlbGYubG9nLnRyYWNlKCdSZWNlaXZlZCBtZXNzYWdlICVzIChzZW50IHRvIGJ1bmRsZSAlcykgd2l0aCBkYXRhOicsc2VsZi5idW5kbGVOYW1lLGRhdGEubWVzc2FnZU5hbWUsZGF0YS5idW5kbGVOYW1lLGRhdGEuY29udGVudCk7X19jb3ZfRnpMVmk5TnZzNERoQnR3SUhGSEdhdy5zWycyMyddKys7c2VsZi5fbWVzc2FnZUhhbmRsZXJzLmZvckVhY2goZnVuY3Rpb24oaGFuZGxlcil7X19jb3ZfRnpMVmk5TnZzNERoQnR3SUhGSEdhdy5mWyc0J10rKztfX2Nvdl9GekxWaTlOdnM0RGhCdHdJSEZIR2F3LnNbJzI0J10rKztpZigoX19jb3ZfRnpMVmk5TnZzNERoQnR3SUhGSEdhdy5iWyc1J11bMF0rKyxkYXRhLm1lc3NhZ2VOYW1lPT09aGFuZGxlci5tZXNzYWdlTmFtZSkmJihfX2Nvdl9GekxWaTlOdnM0RGhCdHdJSEZIR2F3LmJbJzUnXVsxXSsrLGRhdGEuYnVuZGxlTmFtZT09PWhhbmRsZXIuYnVuZGxlTmFtZSkpe19fY292X0Z6TFZpOU52czREaEJ0d0lIRkhHYXcuYlsnNCddWzBdKys7X19jb3ZfRnpMVmk5TnZzNERoQnR3SUhGSEdhdy5zWycyNSddKys7aGFuZGxlci5mdW5jKGRhdGEuY29udGVudCk7fWVsc2V7X19jb3ZfRnpMVmk5TnZzNERoQnR3SUhGSEdhdy5iWyc0J11bMV0rKzt9fSk7fSk7X19jb3ZfRnpMVmk5TnZzNERoQnR3SUhGSEdhdy5zWycyNiddKys7c29ja2V0Lm9uKCdlcnJvcicsZnVuY3Rpb24oZXJyKXtfX2Nvdl9GekxWaTlOdnM0RGhCdHdJSEZIR2F3LmZbJzUnXSsrO19fY292X0Z6TFZpOU52czREaEJ0d0lIRkhHYXcuc1snMjcnXSsrO2lmKGVyci50eXBlPT09J1VuYXV0aG9yaXplZEVycm9yJyl7X19jb3ZfRnpMVmk5TnZzNERoQnR3SUhGSEdhdy5iWyc2J11bMF0rKztfX2Nvdl9GekxWaTlOdnM0RGhCdHdJSEZIR2F3LnNbJzI4J10rKzt2YXIgdXJsPVtsb2NhdGlvbi5wcm90b2NvbCwnLy8nLGxvY2F0aW9uLmhvc3QsbG9jYXRpb24ucGF0aG5hbWVdLmpvaW4oJycpO19fY292X0Z6TFZpOU52czREaEJ0d0lIRkhHYXcuc1snMjknXSsrO3dpbmRvdy5sb2NhdGlvbi5ocmVmPScvYXV0aEVycm9yP2NvZGU9JytlcnIuY29kZSsnJm1lc3NhZ2U9JytlcnIubWVzc2FnZSsnJnZpZXdVcmw9Jyt1cmw7fWVsc2V7X19jb3ZfRnpMVmk5TnZzNERoQnR3SUhGSEdhdy5iWyc2J11bMV0rKztfX2Nvdl9GekxWaTlOdnM0RGhCdHdJSEZIR2F3LnNbJzMwJ10rKztzZWxmLmxvZy5lcnJvcignVW5oYW5kbGVkIHNvY2tldCBlcnJvcjonLGVycik7fX0pO31lbHNle19fY292X0Z6TFZpOU52czREaEJ0d0lIRkhHYXcuYlsnMSddWzFdKys7X19jb3ZfRnpMVmk5TnZzNERoQnR3SUhGSEdhdy5zWyczMSddKys7aW89c2VydmVyLmdldElPKCk7X19jb3ZfRnpMVmk5TnZzNERoQnR3SUhGSEdhdy5zWyczMiddKys7aW8ub24oJ2Nvbm5lY3Rpb24nLGZ1bmN0aW9uIG9uQ29ubmVjdGlvbihzb2NrZXQpe19fY292X0Z6TFZpOU52czREaEJ0d0lIRkhHYXcuZlsnNiddKys7X19jb3ZfRnpMVmk5TnZzNERoQnR3SUhGSEdhdy5zWyczMyddKys7c29ja2V0LnNldE1heExpc3RlbmVycyg2NCk7X19jb3ZfRnpMVmk5TnZzNERoQnR3SUhGSEdhdy5zWyczNCddKys7c29ja2V0Lm9uKCdtZXNzYWdlJyxmdW5jdGlvbiBvbk1lc3NhZ2UoZGF0YSxjYil7X19jb3ZfRnpMVmk5TnZzNERoQnR3SUhGSEdhdy5mWyc3J10rKztfX2Nvdl9GekxWaTlOdnM0RGhCdHdJSEZIR2F3LnNbJzM1J10rKztzZWxmLmxvZy50cmFjZSgnWyVzXSBSZWNlaXZlZCBtZXNzYWdlICVzIChzZW50IHRvIGJ1bmRsZSAlcykgd2l0aCBkYXRhOicsc2VsZi5idW5kbGVOYW1lLGRhdGEubWVzc2FnZU5hbWUsZGF0YS5idW5kbGVOYW1lLGRhdGEuY29udGVudCk7X19jb3ZfRnpMVmk5TnZzNERoQnR3SUhGSEdhdy5zWyczNiddKys7c2VsZi5fbWVzc2FnZUhhbmRsZXJzLmZvckVhY2goZnVuY3Rpb24oaGFuZGxlcil7X19jb3ZfRnpMVmk5TnZzNERoQnR3SUhGSEdhdy5mWyc4J10rKztfX2Nvdl9GekxWaTlOdnM0RGhCdHdJSEZIR2F3LnNbJzM3J10rKztpZigoX19jb3ZfRnpMVmk5TnZzNERoQnR3SUhGSEdhdy5iWyc4J11bMF0rKyxkYXRhLm1lc3NhZ2VOYW1lPT09aGFuZGxlci5tZXNzYWdlTmFtZSkmJihfX2Nvdl9GekxWaTlOdnM0RGhCdHdJSEZIR2F3LmJbJzgnXVsxXSsrLGRhdGEuYnVuZGxlTmFtZT09PWhhbmRsZXIuYnVuZGxlTmFtZSkpe19fY292X0Z6TFZpOU52czREaEJ0d0lIRkhHYXcuYlsnNyddWzBdKys7X19jb3ZfRnpMVmk5TnZzNERoQnR3SUhGSEdhdy5zWyczOCddKys7aGFuZGxlci5mdW5jKGRhdGEuY29udGVudCxjYik7fWVsc2V7X19jb3ZfRnpMVmk5TnZzNERoQnR3SUhGSEdhdy5iWyc3J11bMV0rKzt9fSk7fSk7fSk7fV9fY292X0Z6TFZpOU52czREaEJ0d0lIRkhHYXcuc1snMzknXSsrO09iamVjdC5kZWZpbmVQcm9wZXJ0eSh0aGlzLCdjb25maWcnLHt2YWx1ZTpmaWx0ZXJlZENvbmZpZyx3cml0YWJsZTpmYWxzZSxlbnVtZXJhYmxlOnRydWV9KTtfX2Nvdl9GekxWaTlOdnM0RGhCdHdJSEZIR2F3LnNbJzQwJ10rKztPYmplY3QuZnJlZXplKHRoaXMuY29uZmlnKTt9X19jb3ZfRnpMVmk5TnZzNERoQnR3SUhGSEdhdy5zWyc0MSddKys7Tm9kZUNHLnByb3RvdHlwZS5zZW5kTWVzc2FnZT1mdW5jdGlvbihtZXNzYWdlTmFtZSxkYXRhLGNiKXtfX2Nvdl9GekxWaTlOdnM0RGhCdHdJSEZIR2F3LmZbJzknXSsrO19fY292X0Z6TFZpOU52czREaEJ0d0lIRkhHYXcuc1snNDInXSsrO2lmKChfX2Nvdl9GekxWaTlOdnM0RGhCdHdJSEZIR2F3LmJbJzEwJ11bMF0rKyx0eXBlb2YgY2I9PT0ndW5kZWZpbmVkJykmJihfX2Nvdl9GekxWaTlOdnM0RGhCdHdJSEZIR2F3LmJbJzEwJ11bMV0rKyx0eXBlb2YgZGF0YT09PSdmdW5jdGlvbicpKXtfX2Nvdl9GekxWaTlOdnM0RGhCdHdJSEZIR2F3LmJbJzknXVswXSsrO19fY292X0Z6TFZpOU52czREaEJ0d0lIRkhHYXcuc1snNDMnXSsrO2NiPWRhdGE7X19jb3ZfRnpMVmk5TnZzNERoQnR3SUhGSEdhdy5zWyc0NCddKys7ZGF0YT1udWxsO31lbHNle19fY292X0Z6TFZpOU52czREaEJ0d0lIRkhHYXcuYlsnOSddWzFdKys7fV9fY292X0Z6TFZpOU52czREaEJ0d0lIRkhHYXcuc1snNDUnXSsrO3RoaXMuc2VuZE1lc3NhZ2VUb0J1bmRsZShtZXNzYWdlTmFtZSx0aGlzLmJ1bmRsZU5hbWUsZGF0YSxjYik7fTtfX2Nvdl9GekxWaTlOdnM0RGhCdHdJSEZIR2F3LnNbJzQ2J10rKztOb2RlQ0cuc2VuZE1lc3NhZ2VUb0J1bmRsZT1mdW5jdGlvbihtZXNzYWdlTmFtZSxidW5kbGVOYW1lLGRhdGEsY2Ipe19fY292X0Z6TFZpOU52czREaEJ0d0lIRkhHYXcuZlsnMTAnXSsrO19fY292X0Z6TFZpOU52czREaEJ0d0lIRkhHYXcuc1snNDcnXSsrO2lmKHRydWUpe19fY292X0Z6TFZpOU52czREaEJ0d0lIRkhHYXcuYlsnMTEnXVswXSsrO19fY292X0Z6TFZpOU52czREaEJ0d0lIRkhHYXcuc1snNDgnXSsrO2lmKChfX2Nvdl9GekxWaTlOdnM0RGhCdHdJSEZIR2F3LmJbJzEzJ11bMF0rKyx0eXBlb2YgY2I9PT0ndW5kZWZpbmVkJykmJihfX2Nvdl9GekxWaTlOdnM0RGhCdHdJSEZIR2F3LmJbJzEzJ11bMV0rKyx0eXBlb2YgZGF0YT09PSdmdW5jdGlvbicpKXtfX2Nvdl9GekxWaTlOdnM0RGhCdHdJSEZIR2F3LmJbJzEyJ11bMF0rKztfX2Nvdl9GekxWaTlOdnM0RGhCdHdJSEZIR2F3LnNbJzQ5J10rKztjYj1kYXRhO19fY292X0Z6TFZpOU52czREaEJ0d0lIRkhHYXcuc1snNTAnXSsrO2RhdGE9bnVsbDt9ZWxzZXtfX2Nvdl9GekxWaTlOdnM0RGhCdHdJSEZIR2F3LmJbJzEyJ11bMV0rKzt9X19jb3ZfRnpMVmk5TnZzNERoQnR3SUhGSEdhdy5zWyc1MSddKys7d2luZG93LnNvY2tldC5lbWl0KCdtZXNzYWdlJyx7YnVuZGxlTmFtZTpidW5kbGVOYW1lLG1lc3NhZ2VOYW1lOm1lc3NhZ2VOYW1lLGNvbnRlbnQ6ZGF0YX0sY2IpO31lbHNle19fY292X0Z6TFZpOU52czREaEJ0d0lIRkhHYXcuYlsnMTEnXVsxXSsrO19fY292X0Z6TFZpOU52czREaEJ0d0lIRkhHYXcuc1snNTInXSsrO2lvLmVtaXQoJ21lc3NhZ2UnLHtidW5kbGVOYW1lOmJ1bmRsZU5hbWUsbWVzc2FnZU5hbWU6bWVzc2FnZU5hbWUsY29udGVudDpkYXRhfSk7fX07X19jb3ZfRnpMVmk5TnZzNERoQnR3SUhGSEdhdy5zWyc1MyddKys7Tm9kZUNHLnByb3RvdHlwZS5zZW5kTWVzc2FnZVRvQnVuZGxlPWZ1bmN0aW9uKG1lc3NhZ2VOYW1lLGJ1bmRsZU5hbWUsZGF0YSxjYil7X19jb3ZfRnpMVmk5TnZzNERoQnR3SUhGSEdhdy5mWycxMSddKys7X19jb3ZfRnpMVmk5TnZzNERoQnR3SUhGSEdhdy5zWyc1NCddKys7dGhpcy5sb2cudHJhY2UoJ1slc10gU2VuZGluZyBtZXNzYWdlICVzIHRvIGJ1bmRsZSAlcyB3aXRoIGRhdGE6Jyx0aGlzLmJ1bmRsZU5hbWUsbWVzc2FnZU5hbWUsYnVuZGxlTmFtZSxkYXRhKTtfX2Nvdl9GekxWaTlOdnM0RGhCdHdJSEZIR2F3LnNbJzU1J10rKztOb2RlQ0cuc2VuZE1lc3NhZ2VUb0J1bmRsZS5hcHBseShOb2RlQ0csYXJndW1lbnRzKTt9O19fY292X0Z6TFZpOU52czREaEJ0d0lIRkhHYXcuc1snNTYnXSsrO05vZGVDRy5wcm90b3R5cGUubGlzdGVuRm9yPWZ1bmN0aW9uKG1lc3NhZ2VOYW1lLGJ1bmRsZU5hbWUsaGFuZGxlcil7X19jb3ZfRnpMVmk5TnZzNERoQnR3SUhGSEdhdy5mWycxMiddKys7X19jb3ZfRnpMVmk5TnZzNERoQnR3SUhGSEdhdy5zWyc1NyddKys7aWYodHlwZW9mIGhhbmRsZXI9PT0ndW5kZWZpbmVkJyl7X19jb3ZfRnpMVmk5TnZzNERoQnR3SUhGSEdhdy5iWycxNCddWzBdKys7X19jb3ZfRnpMVmk5TnZzNERoQnR3SUhGSEdhdy5zWyc1OCddKys7aGFuZGxlcj1idW5kbGVOYW1lO19fY292X0Z6TFZpOU52czREaEJ0d0lIRkhHYXcuc1snNTknXSsrO2J1bmRsZU5hbWU9dGhpcy5idW5kbGVOYW1lO31lbHNle19fY292X0Z6TFZpOU52czREaEJ0d0lIRkhHYXcuYlsnMTQnXVsxXSsrO31fX2Nvdl9GekxWaTlOdnM0RGhCdHdJSEZIR2F3LnNbJzYwJ10rKzt0aGlzLmxvZy50cmFjZSgnWyVzXSBMaXN0ZW5pbmcgZm9yICVzIGZyb20gYnVuZGxlICVzJyx0aGlzLmJ1bmRsZU5hbWUsbWVzc2FnZU5hbWUsYnVuZGxlTmFtZSk7X19jb3ZfRnpMVmk5TnZzNERoQnR3SUhGSEdhdy5zWyc2MSddKys7dmFyIGxlbj10aGlzLl9tZXNzYWdlSGFuZGxlcnMubGVuZ3RoO19fY292X0Z6TFZpOU52czREaEJ0d0lIRkhHYXcuc1snNjInXSsrO2Zvcih2YXIgaT0wO2k8bGVuO2krKyl7X19jb3ZfRnpMVmk5TnZzNERoQnR3SUhGSEdhdy5zWyc2MyddKys7dmFyIGV4aXN0aW5nSGFuZGxlcj10aGlzLl9tZXNzYWdlSGFuZGxlcnNbaV07X19jb3ZfRnpMVmk5TnZzNERoQnR3SUhGSEdhdy5zWyc2NCddKys7aWYoKF9fY292X0Z6TFZpOU52czREaEJ0d0lIRkhHYXcuYlsnMTYnXVswXSsrLG1lc3NhZ2VOYW1lPT09ZXhpc3RpbmdIYW5kbGVyLm1lc3NhZ2VOYW1lKSYmKF9fY292X0Z6TFZpOU52czREaEJ0d0lIRkhHYXcuYlsnMTYnXVsxXSsrLGJ1bmRsZU5hbWU9PT1leGlzdGluZ0hhbmRsZXIuYnVuZGxlTmFtZSkpe19fY292X0Z6TFZpOU52czREaEJ0d0lIRkhHYXcuYlsnMTUnXVswXSsrO19fY292X0Z6TFZpOU52czREaEJ0d0lIRkhHYXcuc1snNjUnXSsrO3RoaXMubG9nLmVycm9yKCclcyBhdHRlbXB0ZWQgdG8gZGVjbGFyZSBhIGR1cGxpY2F0ZSBcImxpc3RlbkZvclwiIGhhbmRsZXI6Jyx0aGlzLmJ1bmRsZU5hbWUsYnVuZGxlTmFtZSxtZXNzYWdlTmFtZSk7X19jb3ZfRnpMVmk5TnZzNERoQnR3SUhGSEdhdy5zWyc2NiddKys7cmV0dXJuO31lbHNle19fY292X0Z6TFZpOU52czREaEJ0d0lIRkhHYXcuYlsnMTUnXVsxXSsrO319X19jb3ZfRnpMVmk5TnZzNERoQnR3SUhGSEdhdy5zWyc2NyddKys7dGhpcy5fbWVzc2FnZUhhbmRsZXJzLnB1c2goe21lc3NhZ2VOYW1lOm1lc3NhZ2VOYW1lLGJ1bmRsZU5hbWU6YnVuZGxlTmFtZSxmdW5jOmhhbmRsZXJ9KTt9O19fY292X0Z6TFZpOU52czREaEJ0d0lIRkhHYXcuc1snNjgnXSsrO05vZGVDRy5kZWNsYXJlZFJlcGxpY2FudHM9UmVwbGljYW50LmRlY2xhcmVkUmVwbGljYW50cztfX2Nvdl9GekxWaTlOdnM0RGhCdHdJSEZIR2F3LnNbJzY5J10rKztOb2RlQ0cuUmVwbGljYW50PWZ1bmN0aW9uKG5hbWUsYnVuZGxlLG9wdHMpe19fY292X0Z6TFZpOU52czREaEJ0d0lIRkhHYXcuZlsnMTMnXSsrO19fY292X0Z6TFZpOU52czREaEJ0d0lIRkhHYXcuc1snNzAnXSsrO3JldHVybiBuZXcgUmVwbGljYW50KG5hbWUsYnVuZGxlLG9wdHMsdHJ1ZT8oX19jb3ZfRnpMVmk5TnZzNERoQnR3SUhGSEdhdy5iWycxNyddWzBdKyssd2luZG93LnNvY2tldCk6KF9fY292X0Z6TFZpOU52czREaEJ0d0lIRkhHYXcuYlsnMTcnXVsxXSsrLG51bGwpKTt9O19fY292X0Z6TFZpOU52czREaEJ0d0lIRkhHYXcuc1snNzEnXSsrO05vZGVDRy5wcm90b3R5cGUuUmVwbGljYW50PWZ1bmN0aW9uKG5hbWUsYnVuZGxlLG9wdHMpe19fY292X0Z6TFZpOU52czREaEJ0d0lIRkhHYXcuZlsnMTQnXSsrO19fY292X0Z6TFZpOU52czREaEJ0d0lIRkhHYXcuc1snNzInXSsrO2lmKChfX2Nvdl9GekxWaTlOdnM0RGhCdHdJSEZIR2F3LmJbJzE5J11bMF0rKywhYnVuZGxlKXx8KF9fY292X0Z6TFZpOU52czREaEJ0d0lIRkhHYXcuYlsnMTknXVsxXSsrLHR5cGVvZiBidW5kbGUhPT0nc3RyaW5nJykpe19fY292X0Z6TFZpOU52czREaEJ0d0lIRkhHYXcuYlsnMTgnXVswXSsrO19fY292X0Z6TFZpOU52czREaEJ0d0lIRkhHYXcuc1snNzMnXSsrO29wdHM9YnVuZGxlO19fY292X0Z6TFZpOU52czREaEJ0d0lIRkhHYXcuc1snNzQnXSsrO2J1bmRsZT10aGlzLmJ1bmRsZU5hbWU7fWVsc2V7X19jb3ZfRnpMVmk5TnZzNERoQnR3SUhGSEdhdy5iWycxOCddWzFdKys7fV9fY292X0Z6TFZpOU52czREaEJ0d0lIRkhHYXcuc1snNzUnXSsrO3JldHVybiBuZXcgTm9kZUNHLlJlcGxpY2FudChuYW1lLGJ1bmRsZSxvcHRzKTt9O19fY292X0Z6TFZpOU52czREaEJ0d0lIRkhHYXcuc1snNzYnXSsrO05vZGVDRy5yZWFkUmVwbGljYW50PWZ1bmN0aW9uKG5hbWUsYnVuZGxlLGNiKXtfX2Nvdl9GekxWaTlOdnM0RGhCdHdJSEZIR2F3LmZbJzE1J10rKztfX2Nvdl9GekxWaTlOdnM0RGhCdHdJSEZIR2F3LnNbJzc3J10rKztpZigoX19jb3ZfRnpMVmk5TnZzNERoQnR3SUhGSEdhdy5iWycyMSddWzBdKyssIW5hbWUpfHwoX19jb3ZfRnpMVmk5TnZzNERoQnR3SUhGSEdhdy5iWycyMSddWzFdKyssdHlwZW9mIG5hbWUhPT0nc3RyaW5nJykpe19fY292X0Z6TFZpOU52czREaEJ0d0lIRkhHYXcuYlsnMjAnXVswXSsrO19fY292X0Z6TFZpOU52czREaEJ0d0lIRkhHYXcuc1snNzgnXSsrO3Rocm93IG5ldyBFcnJvcignTXVzdCBzdXBwbHkgYSBuYW1lIHdoZW4gcmVhZGluZyBhIFJlcGxpY2FudCcpO31lbHNle19fY292X0Z6TFZpOU52czREaEJ0d0lIRkhHYXcuYlsnMjAnXVsxXSsrO31fX2Nvdl9GekxWaTlOdnM0RGhCdHdJSEZIR2F3LnNbJzc5J10rKztpZigoX19jb3ZfRnpMVmk5TnZzNERoQnR3SUhGSEdhdy5iWycyMyddWzBdKyssIWJ1bmRsZSl8fChfX2Nvdl9GekxWaTlOdnM0RGhCdHdJSEZIR2F3LmJbJzIzJ11bMV0rKyx0eXBlb2YgYnVuZGxlIT09J3N0cmluZycpKXtfX2Nvdl9GekxWaTlOdnM0RGhCdHdJSEZIR2F3LmJbJzIyJ11bMF0rKztfX2Nvdl9GekxWaTlOdnM0RGhCdHdJSEZIR2F3LnNbJzgwJ10rKzt0aHJvdyBuZXcgRXJyb3IoJ011c3Qgc3VwcGx5IGEgYnVuZGxlIG5hbWUgd2hlbiByZWFkaW5nIGEgUmVwbGljYW50Jyk7fWVsc2V7X19jb3ZfRnpMVmk5TnZzNERoQnR3SUhGSEdhdy5iWycyMiddWzFdKys7fV9fY292X0Z6TFZpOU52czREaEJ0d0lIRkhHYXcuc1snODEnXSsrO2lmKHRydWUpe19fY292X0Z6TFZpOU52czREaEJ0d0lIRkhHYXcuYlsnMjQnXVswXSsrO19fY292X0Z6TFZpOU52czREaEJ0d0lIRkhHYXcuc1snODInXSsrO3dpbmRvdy5zb2NrZXQuZW1pdCgncmVhZFJlcGxpY2FudCcse25hbWU6bmFtZSxidW5kbGU6YnVuZGxlfSxjYik7fWVsc2V7X19jb3ZfRnpMVmk5TnZzNERoQnR3SUhGSEdhdy5iWycyNCddWzFdKys7X19jb3ZfRnpMVmk5TnZzNERoQnR3SUhGSEdhdy5zWyc4MyddKys7dmFyIHJlcGxpY2FudD1yZXBsaWNhdG9yLmZpbmQobmFtZSxidW5kbGUpO19fY292X0Z6TFZpOU52czREaEJ0d0lIRkhHYXcuc1snODQnXSsrO2lmKHJlcGxpY2FudCl7X19jb3ZfRnpMVmk5TnZzNERoQnR3SUhGSEdhdy5iWycyNSddWzBdKys7X19jb3ZfRnpMVmk5TnZzNERoQnR3SUhGSEdhdy5zWyc4NSddKys7cmV0dXJuIHJlcGxpY2FudC52YWx1ZTt9ZWxzZXtfX2Nvdl9GekxWaTlOdnM0RGhCdHdJSEZIR2F3LmJbJzI1J11bMV0rKzt9fX07X19jb3ZfRnpMVmk5TnZzNERoQnR3SUhGSEdhdy5zWyc4NiddKys7Tm9kZUNHLnByb3RvdHlwZS5yZWFkUmVwbGljYW50PWZ1bmN0aW9uKG5hbWUsYnVuZGxlLGNiKXtfX2Nvdl9GekxWaTlOdnM0RGhCdHdJSEZIR2F3LmZbJzE2J10rKztfX2Nvdl9GekxWaTlOdnM0RGhCdHdJSEZIR2F3LnNbJzg3J10rKztpZigoX19jb3ZfRnpMVmk5TnZzNERoQnR3SUhGSEdhdy5iWycyNyddWzBdKyssIWJ1bmRsZSl8fChfX2Nvdl9GekxWaTlOdnM0RGhCdHdJSEZIR2F3LmJbJzI3J11bMV0rKyx0eXBlb2YgYnVuZGxlIT09J3N0cmluZycpKXtfX2Nvdl9GekxWaTlOdnM0RGhCdHdJSEZIR2F3LmJbJzI2J11bMF0rKztfX2Nvdl9GekxWaTlOdnM0RGhCdHdJSEZIR2F3LnNbJzg4J10rKztjYj1idW5kbGU7X19jb3ZfRnpMVmk5TnZzNERoQnR3SUhGSEdhdy5zWyc4OSddKys7YnVuZGxlPXRoaXMuYnVuZGxlTmFtZTt9ZWxzZXtfX2Nvdl9GekxWaTlOdnM0RGhCdHdJSEZIR2F3LmJbJzI2J11bMV0rKzt9X19jb3ZfRnpMVmk5TnZzNERoQnR3SUhGSEdhdy5zWyc5MCddKys7cmV0dXJuIE5vZGVDRy5yZWFkUmVwbGljYW50KG5hbWUsYnVuZGxlLGNiKTt9O19fY292X0Z6TFZpOU52czREaEJ0d0lIRkhHYXcuc1snOTEnXSsrO2lmKHRydWUpe19fY292X0Z6TFZpOU52czREaEJ0d0lIRkhHYXcuYlsnMjgnXVswXSsrO19fY292X0Z6TFZpOU52czREaEJ0d0lIRkhHYXcuc1snOTInXSsrO3dpbmRvdy5Ob2RlQ0c9Tm9kZUNHO19fY292X0Z6TFZpOU52czREaEJ0d0lIRkhHYXcuc1snOTMnXSsrO05vZGVDRy5uZWFyZXN0RWxlbWVudFdpdGhBdHRyaWJ1dGU9ZnVuY3Rpb24oc3RhcnRFbCxhdHRyTmFtZSl7X19jb3ZfRnpMVmk5TnZzNERoQnR3SUhGSEdhdy5mWycxNyddKys7X19jb3ZfRnpMVmk5TnZzNERoQnR3SUhGSEdhdy5zWyc5NCddKys7dmFyIHRhcmdldD1zdGFydEVsO19fY292X0Z6TFZpOU52czREaEJ0d0lIRkhHYXcuc1snOTUnXSsrO3doaWxlKHRhcmdldCl7X19jb3ZfRnpMVmk5TnZzNERoQnR3SUhGSEdhdy5zWyc5NiddKys7aWYodGFyZ2V0Lmhhc0F0dHJpYnV0ZSl7X19jb3ZfRnpMVmk5TnZzNERoQnR3SUhGSEdhdy5iWycyOSddWzBdKys7X19jb3ZfRnpMVmk5TnZzNERoQnR3SUhGSEdhdy5zWyc5NyddKys7aWYodGFyZ2V0Lmhhc0F0dHJpYnV0ZShhdHRyTmFtZSkpe19fY292X0Z6TFZpOU52czREaEJ0d0lIRkhHYXcuYlsnMzAnXVswXSsrO19fY292X0Z6TFZpOU52czREaEJ0d0lIRkhHYXcuc1snOTgnXSsrO3JldHVybiB0YXJnZXQ7fWVsc2V7X19jb3ZfRnpMVmk5TnZzNERoQnR3SUhGSEdhdy5iWyczMCddWzFdKys7fX1lbHNle19fY292X0Z6TFZpOU52czREaEJ0d0lIRkhHYXcuYlsnMjknXVsxXSsrO31fX2Nvdl9GekxWaTlOdnM0RGhCdHdJSEZIR2F3LnNbJzk5J10rKzt0YXJnZXQ9dGFyZ2V0LnBhcmVudE5vZGU7fX07X19jb3ZfRnpMVmk5TnZzNERoQnR3SUhGSEdhdy5zWycxMDAnXSsrO05vZGVDRy5wcm90b3R5cGUuZ2V0RGlhbG9nPWZ1bmN0aW9uKG5hbWUsYnVuZGxlKXtfX2Nvdl9GekxWaTlOdnM0RGhCdHdJSEZIR2F3LmZbJzE4J10rKztfX2Nvdl9GekxWaTlOdnM0RGhCdHdJSEZIR2F3LnNbJzEwMSddKys7YnVuZGxlPShfX2Nvdl9GekxWaTlOdnM0RGhCdHdJSEZIR2F3LmJbJzMxJ11bMF0rKyxidW5kbGUpfHwoX19jb3ZfRnpMVmk5TnZzNERoQnR3SUhGSEdhdy5iWyczMSddWzFdKyssdGhpcy5idW5kbGVOYW1lKTtfX2Nvdl9GekxWaTlOdnM0RGhCdHdJSEZIR2F3LnNbJzEwMiddKys7dmFyIHRvcERvYz13aW5kb3cudG9wLmRvY3VtZW50O19fY292X0Z6TFZpOU52czREaEJ0d0lIRkhHYXcuc1snMTAzJ10rKztyZXR1cm4gdG9wRG9jLmdldEVsZW1lbnRCeUlkKGJ1bmRsZSsnXycrbmFtZSk7fTtfX2Nvdl9GekxWaTlOdnM0RGhCdHdJSEZIR2F3LnNbJzEwNCddKys7Tm9kZUNHLnByb3RvdHlwZS5nZXREaWFsb2dEb2N1bWVudD1mdW5jdGlvbihuYW1lLGJ1bmRsZSl7X19jb3ZfRnpMVmk5TnZzNERoQnR3SUhGSEdhdy5mWycxOSddKys7X19jb3ZfRnpMVmk5TnZzNERoQnR3SUhGSEdhdy5zWycxMDUnXSsrO2J1bmRsZT0oX19jb3ZfRnpMVmk5TnZzNERoQnR3SUhGSEdhdy5iWyczMiddWzBdKyssYnVuZGxlKXx8KF9fY292X0Z6TFZpOU52czREaEJ0d0lIRkhHYXcuYlsnMzInXVsxXSsrLHRoaXMuYnVuZGxlTmFtZSk7X19jb3ZfRnpMVmk5TnZzNERoQnR3SUhGSEdhdy5zWycxMDYnXSsrO3ZhciBkaWFsb2c9dGhpcy5nZXREaWFsb2cobmFtZSxidW5kbGUpO19fY292X0Z6TFZpOU52czREaEJ0d0lIRkhHYXcuc1snMTA3J10rKztyZXR1cm4gZGlhbG9nLnF1ZXJ5U2VsZWN0b3IoJ2lmcmFtZScpLmNvbnRlbnRXaW5kb3cuZG9jdW1lbnQ7fTt9ZWxzZXtfX2Nvdl9GekxWaTlOdnM0RGhCdHdJSEZIR2F3LmJbJzI4J11bMV0rKztfX2Nvdl9GekxWaTlOdnM0RGhCdHdJSEZIR2F3LnNbJzEwOCddKys7Tm9kZUNHLnByb3RvdHlwZS5nZXRTb2NrZXRJT1NlcnZlcj1zZXJ2ZXIuZ2V0SU87X19jb3ZfRnpMVmk5TnZzNERoQnR3SUhGSEdhdy5zWycxMDknXSsrO05vZGVDRy5wcm90b3R5cGUubW91bnQ9c2VydmVyLm1vdW50O19fY292X0Z6TFZpOU52czREaEJ0d0lIRkhHYXcuc1snMTEwJ10rKztOb2RlQ0cucHJvdG90eXBlLnV0aWw9e307X19jb3ZfRnpMVmk5TnZzNERoQnR3SUhGSEdhdy5zWycxMTEnXSsrO05vZGVDRy5wcm90b3R5cGUudXRpbC5hdXRoQ2hlY2s9dXRpbHMuYXV0aENoZWNrO19fY292X0Z6TFZpOU52czREaEJ0d0lIRkhHYXcuc1snMTEyJ10rKztOb2RlQ0cucHJvdG90eXBlLnV0aWwuZmluZFNlc3Npb249dXRpbHMuZmluZFNlc3Npb247X19jb3ZfRnpMVmk5TnZzNERoQnR3SUhGSEdhdy5zWycxMTMnXSsrO09iamVjdC5kZWZpbmVQcm9wZXJ0eShOb2RlQ0cucHJvdG90eXBlLCdleHRlbnNpb25zJyx7Z2V0OmZ1bmN0aW9uKCl7X19jb3ZfRnpMVmk5TnZzNERoQnR3SUhGSEdhdy5mWycyMCddKys7X19jb3ZfRnpMVmk5TnZzNERoQnR3SUhGSEdhdy5zWycxMTQnXSsrO3JldHVybiBzZXJ2ZXIuZ2V0RXh0ZW5zaW9ucygpO30sZW51bWVyYWJsZTp0cnVlfSk7fV9fY292X0Z6TFZpOU52czREaEJ0d0lIRkhHYXcuc1snMTE1J10rKzttb2R1bGUuZXhwb3J0cz1Ob2RlQ0c7XG4iLCJcInVzZSBzdHJpY3RcIjtcbnZhciBfX2Nvdl90OFQzNWp5dXRnS01zRm1EaV9oRHRBID0gKEZ1bmN0aW9uKCdyZXR1cm4gdGhpcycpKSgpO1xuaWYgKCFfX2Nvdl90OFQzNWp5dXRnS01zRm1EaV9oRHRBLl9fY292ZXJhZ2VfXykgeyBfX2Nvdl90OFQzNWp5dXRnS01zRm1EaV9oRHRBLl9fY292ZXJhZ2VfXyA9IHt9OyB9XG5fX2Nvdl90OFQzNWp5dXRnS01zRm1EaV9oRHRBID0gX19jb3ZfdDhUMzVqeXV0Z0tNc0ZtRGlfaER0QS5fX2NvdmVyYWdlX187XG5pZiAoIShfX2Nvdl90OFQzNWp5dXRnS01zRm1EaV9oRHRBWydHOlxcXFxQcm9ncmFtbWluZ1xcXFxub2RlY2dcXFxcbGliXFxcXGJyb3dzZXJcXFxcY29uZmlnLmpzJ10pKSB7XG4gICBfX2Nvdl90OFQzNWp5dXRnS01zRm1EaV9oRHRBWydHOlxcXFxQcm9ncmFtbWluZ1xcXFxub2RlY2dcXFxcbGliXFxcXGJyb3dzZXJcXFxcY29uZmlnLmpzJ10gPSB7XCJwYXRoXCI6XCJHOlxcXFxQcm9ncmFtbWluZ1xcXFxub2RlY2dcXFxcbGliXFxcXGJyb3dzZXJcXFxcY29uZmlnLmpzXCIsXCJzXCI6e1wiMVwiOjB9LFwiYlwiOnt9LFwiZlwiOnt9LFwiZm5NYXBcIjp7fSxcInN0YXRlbWVudE1hcFwiOntcIjFcIjp7XCJzdGFydFwiOntcImxpbmVcIjo0LFwiY29sdW1uXCI6MH0sXCJlbmRcIjp7XCJsaW5lXCI6NixcImNvbHVtblwiOjJ9fX0sXCJicmFuY2hNYXBcIjp7fX07XG59XG5fX2Nvdl90OFQzNWp5dXRnS01zRm1EaV9oRHRBID0gX19jb3ZfdDhUMzVqeXV0Z0tNc0ZtRGlfaER0QVsnRzpcXFxcUHJvZ3JhbW1pbmdcXFxcbm9kZWNnXFxcXGxpYlxcXFxicm93c2VyXFxcXGNvbmZpZy5qcyddO1xuX19jb3ZfdDhUMzVqeXV0Z0tNc0ZtRGlfaER0QS5zWycxJ10rKzttb2R1bGUuZXhwb3J0cz17ZmlsdGVyZWRDb25maWc6d2luZG93Lm5jZ0NvbmZpZ307XG4iLCJcInVzZSBzdHJpY3RcIjtcbnZhciBfX2Nvdl9BV0F6WngxV2JtS0ExZXZFeW13ek5RID0gKEZ1bmN0aW9uKCdyZXR1cm4gdGhpcycpKSgpO1xuaWYgKCFfX2Nvdl9BV0F6WngxV2JtS0ExZXZFeW13ek5RLl9fY292ZXJhZ2VfXykgeyBfX2Nvdl9BV0F6WngxV2JtS0ExZXZFeW13ek5RLl9fY292ZXJhZ2VfXyA9IHt9OyB9XG5fX2Nvdl9BV0F6WngxV2JtS0ExZXZFeW13ek5RID0gX19jb3ZfQVdBelp4MVdibUtBMWV2RXltd3pOUS5fX2NvdmVyYWdlX187XG5pZiAoIShfX2Nvdl9BV0F6WngxV2JtS0ExZXZFeW13ek5RWydHOlxcXFxQcm9ncmFtbWluZ1xcXFxub2RlY2dcXFxcbGliXFxcXGJyb3dzZXJcXFxcbG9nZ2VyLmpzJ10pKSB7XG4gICBfX2Nvdl9BV0F6WngxV2JtS0ExZXZFeW13ek5RWydHOlxcXFxQcm9ncmFtbWluZ1xcXFxub2RlY2dcXFxcbGliXFxcXGJyb3dzZXJcXFxcbG9nZ2VyLmpzJ10gPSB7XCJwYXRoXCI6XCJHOlxcXFxQcm9ncmFtbWluZ1xcXFxub2RlY2dcXFxcbGliXFxcXGJyb3dzZXJcXFxcbG9nZ2VyLmpzXCIsXCJzXCI6e1wiMVwiOjAsXCIyXCI6MCxcIjNcIjowfSxcImJcIjp7fSxcImZcIjp7XCIxXCI6MH0sXCJmbk1hcFwiOntcIjFcIjp7XCJuYW1lXCI6XCIoYW5vbnltb3VzXzEpXCIsXCJsaW5lXCI6NixcImxvY1wiOntcInN0YXJ0XCI6e1wibGluZVwiOjYsXCJjb2x1bW5cIjoxN30sXCJlbmRcIjp7XCJsaW5lXCI6NixcImNvbHVtblwiOjMzfX19fSxcInN0YXRlbWVudE1hcFwiOntcIjFcIjp7XCJzdGFydFwiOntcImxpbmVcIjo0LFwiY29sdW1uXCI6MH0sXCJlbmRcIjp7XCJsaW5lXCI6NCxcImNvbHVtblwiOjY1fX0sXCIyXCI6e1wic3RhcnRcIjp7XCJsaW5lXCI6NixcImNvbHVtblwiOjB9LFwiZW5kXCI6e1wibGluZVwiOjgsXCJjb2x1bW5cIjoyfX0sXCIzXCI6e1wic3RhcnRcIjp7XCJsaW5lXCI6NyxcImNvbHVtblwiOjF9LFwiZW5kXCI6e1wibGluZVwiOjcsXCJjb2x1bW5cIjoyNX19fSxcImJyYW5jaE1hcFwiOnt9fTtcbn1cbl9fY292X0FXQXpaeDFXYm1LQTFldkV5bXd6TlEgPSBfX2Nvdl9BV0F6WngxV2JtS0ExZXZFeW13ek5RWydHOlxcXFxQcm9ncmFtbWluZ1xcXFxub2RlY2dcXFxcbGliXFxcXGJyb3dzZXJcXFxcbG9nZ2VyLmpzJ107XG5fX2Nvdl9BV0F6WngxV2JtS0ExZXZFeW13ek5RLnNbJzEnXSsrO3ZhciBMb2dnZXI9cmVxdWlyZSgnQG5vZGVjZy9sb2dnZXInKSh3aW5kb3cubmNnQ29uZmlnLmxvZ2dpbmcpO19fY292X0FXQXpaeDFXYm1LQTFldkV5bXd6TlEuc1snMiddKys7bW9kdWxlLmV4cG9ydHM9ZnVuY3Rpb24obmFtZSl7X19jb3ZfQVdBelp4MVdibUtBMWV2RXltd3pOUS5mWycxJ10rKztfX2Nvdl9BV0F6WngxV2JtS0ExZXZFeW13ek5RLnNbJzMnXSsrO3JldHVybiBuZXcgTG9nZ2VyKG5hbWUpO307XG4iLCJcInVzZSBzdHJpY3RcIjtcbnZhciBfX2Nvdl80ZmRWMEpYZWM1Y2NocURUdF8xdnp3ID0gKEZ1bmN0aW9uKCdyZXR1cm4gdGhpcycpKSgpO1xuaWYgKCFfX2Nvdl80ZmRWMEpYZWM1Y2NocURUdF8xdnp3Ll9fY292ZXJhZ2VfXykgeyBfX2Nvdl80ZmRWMEpYZWM1Y2NocURUdF8xdnp3Ll9fY292ZXJhZ2VfXyA9IHt9OyB9XG5fX2Nvdl80ZmRWMEpYZWM1Y2NocURUdF8xdnp3ID0gX19jb3ZfNGZkVjBKWGVjNWNjaHFEVHRfMXZ6dy5fX2NvdmVyYWdlX187XG5pZiAoIShfX2Nvdl80ZmRWMEpYZWM1Y2NocURUdF8xdnp3WydHOlxcXFxQcm9ncmFtbWluZ1xcXFxub2RlY2dcXFxcbGliXFxcXGJyb3dzZXJcXFxccmVwbGljYW50LmpzJ10pKSB7XG4gICBfX2Nvdl80ZmRWMEpYZWM1Y2NocURUdF8xdnp3WydHOlxcXFxQcm9ncmFtbWluZ1xcXFxub2RlY2dcXFxcbGliXFxcXGJyb3dzZXJcXFxccmVwbGljYW50LmpzJ10gPSB7XCJwYXRoXCI6XCJHOlxcXFxQcm9ncmFtbWluZ1xcXFxub2RlY2dcXFxcbGliXFxcXGJyb3dzZXJcXFxccmVwbGljYW50LmpzXCIsXCJzXCI6e1wiMVwiOjAsXCIyXCI6MCxcIjNcIjowLFwiNFwiOjAsXCI1XCI6MCxcIjZcIjowLFwiN1wiOjAsXCI4XCI6MCxcIjlcIjowLFwiMTBcIjowLFwiMTFcIjowLFwiMTJcIjoxLFwiMTNcIjowLFwiMTRcIjowLFwiMTVcIjowLFwiMTZcIjowLFwiMTdcIjowLFwiMThcIjowLFwiMTlcIjowLFwiMjBcIjowLFwiMjFcIjowLFwiMjJcIjowLFwiMjNcIjowLFwiMjRcIjowLFwiMjVcIjowLFwiMjZcIjowLFwiMjdcIjowLFwiMjhcIjowLFwiMjlcIjowLFwiMzBcIjowLFwiMzFcIjowLFwiMzJcIjowLFwiMzNcIjowLFwiMzRcIjowLFwiMzVcIjowLFwiMzZcIjowLFwiMzdcIjowLFwiMzhcIjowLFwiMzlcIjoxLFwiNDBcIjowLFwiNDFcIjoxLFwiNDJcIjowLFwiNDNcIjowLFwiNDRcIjowLFwiNDVcIjowLFwiNDZcIjowLFwiNDdcIjowLFwiNDhcIjowLFwiNDlcIjowLFwiNTBcIjowLFwiNTFcIjowLFwiNTJcIjowLFwiNTNcIjowLFwiNTRcIjoxLFwiNTVcIjowLFwiNTZcIjoxLFwiNTdcIjowLFwiNThcIjowLFwiNTlcIjowLFwiNjBcIjowLFwiNjFcIjowLFwiNjJcIjowLFwiNjNcIjowLFwiNjRcIjowLFwiNjVcIjowLFwiNjZcIjowLFwiNjdcIjowLFwiNjhcIjowLFwiNjlcIjowLFwiNzBcIjowLFwiNzFcIjowLFwiNzJcIjowLFwiNzNcIjowLFwiNzRcIjowLFwiNzVcIjowLFwiNzZcIjowLFwiNzdcIjoxLFwiNzhcIjowLFwiNzlcIjowLFwiODBcIjowLFwiODFcIjowLFwiODJcIjowLFwiODNcIjowLFwiODRcIjowLFwiODVcIjoxLFwiODZcIjowLFwiODdcIjowLFwiODhcIjoxLFwiODlcIjowLFwiOTBcIjowLFwiOTFcIjowLFwiOTJcIjoxLFwiOTNcIjowLFwiOTRcIjowLFwiOTVcIjowLFwiOTZcIjowLFwiOTdcIjowLFwiOThcIjowLFwiOTlcIjowLFwiMTAwXCI6MCxcIjEwMVwiOjAsXCIxMDJcIjowLFwiMTAzXCI6MCxcIjEwNFwiOjAsXCIxMDVcIjowLFwiMTA2XCI6MCxcIjEwN1wiOjAsXCIxMDhcIjowLFwiMTA5XCI6MCxcIjExMFwiOjAsXCIxMTFcIjowLFwiMTEyXCI6MCxcIjExM1wiOjEsXCIxMTRcIjowLFwiMTE1XCI6MCxcIjExNlwiOjAsXCIxMTdcIjowLFwiMTE4XCI6MCxcIjExOVwiOjAsXCIxMjBcIjowLFwiMTIxXCI6MCxcIjEyMlwiOjAsXCIxMjNcIjowLFwiMTI0XCI6MCxcIjEyNVwiOjAsXCIxMjZcIjowLFwiMTI3XCI6MCxcIjEyOFwiOjAsXCIxMjlcIjowLFwiMTMwXCI6MCxcIjEzMVwiOjAsXCIxMzJcIjowLFwiMTMzXCI6MCxcIjEzNFwiOjAsXCIxMzVcIjowLFwiMTM2XCI6MCxcIjEzN1wiOjAsXCIxMzhcIjowLFwiMTM5XCI6MCxcIjE0MFwiOjAsXCIxNDFcIjowLFwiMTQyXCI6MCxcIjE0M1wiOjAsXCIxNDRcIjowLFwiMTQ1XCI6MCxcIjE0NlwiOjAsXCIxNDdcIjowLFwiMTQ4XCI6MCxcIjE0OVwiOjAsXCIxNTBcIjowLFwiMTUxXCI6MCxcIjE1MlwiOjAsXCIxNTNcIjowLFwiMTU0XCI6MCxcIjE1NVwiOjAsXCIxNTZcIjowLFwiMTU3XCI6MCxcIjE1OFwiOjAsXCIxNTlcIjowLFwiMTYwXCI6MCxcIjE2MVwiOjAsXCIxNjJcIjowLFwiMTYzXCI6MCxcIjE2NFwiOjAsXCIxNjVcIjowLFwiMTY2XCI6MCxcIjE2N1wiOjAsXCIxNjhcIjowLFwiMTY5XCI6MCxcIjE3MFwiOjAsXCIxNzFcIjowLFwiMTcyXCI6MCxcIjE3M1wiOjAsXCIxNzRcIjowLFwiMTc1XCI6MCxcIjE3NlwiOjAsXCIxNzdcIjoxLFwiMTc4XCI6MCxcIjE3OVwiOjAsXCIxODBcIjowLFwiMTgxXCI6MCxcIjE4MlwiOjAsXCIxODNcIjowLFwiMTg0XCI6MH0sXCJiXCI6e1wiMVwiOlswLDBdLFwiMlwiOlswLDBdLFwiM1wiOlswLDBdLFwiNFwiOlswLDBdLFwiNVwiOlswLDBdLFwiNlwiOlswLDBdLFwiN1wiOlswLDBdLFwiOFwiOlswLDBdLFwiOVwiOlswLDBdLFwiMTBcIjpbMCwwXSxcIjExXCI6WzAsMF0sXCIxMlwiOlswLDBdLFwiMTNcIjpbMCwwXSxcIjE0XCI6WzAsMF0sXCIxNVwiOlswLDBdLFwiMTZcIjpbMCwwXSxcIjE3XCI6WzAsMF0sXCIxOFwiOlswLDBdLFwiMTlcIjpbMCwwXSxcIjIwXCI6WzAsMF0sXCIyMVwiOlswLDBdLFwiMjJcIjpbMCwwXSxcIjIzXCI6WzAsMF0sXCIyNFwiOlswLDAsMCwwLDBdLFwiMjVcIjpbMCwwXSxcIjI2XCI6WzAsMF0sXCIyN1wiOlswLDBdLFwiMjhcIjpbMCwwXSxcIjI5XCI6WzAsMF0sXCIzMFwiOlswLDBdLFwiMzFcIjpbMCwwXSxcIjMyXCI6WzAsMF0sXCIzM1wiOlswLDBdLFwiMzRcIjpbMCwwXSxcIjM1XCI6WzAsMCwwLDAsMF0sXCIzNlwiOlswLDBdLFwiMzdcIjpbMCwwXSxcIjM4XCI6WzAsMF0sXCIzOVwiOlswLDAsMCwwLDBdfSxcImZcIjp7XCIxXCI6MCxcIjJcIjowLFwiM1wiOjAsXCI0XCI6MCxcIjVcIjowLFwiNlwiOjAsXCI3XCI6MCxcIjhcIjowLFwiOVwiOjAsXCIxMFwiOjAsXCIxMVwiOjAsXCIxMlwiOjAsXCIxM1wiOjAsXCIxNFwiOjAsXCIxNVwiOjAsXCIxNlwiOjAsXCIxN1wiOjAsXCIxOFwiOjAsXCIxOVwiOjAsXCIyMFwiOjAsXCIyMVwiOjAsXCIyMlwiOjAsXCIyM1wiOjAsXCIyNFwiOjAsXCIyNVwiOjAsXCIyNlwiOjAsXCIyN1wiOjAsXCIyOFwiOjB9LFwiZm5NYXBcIjp7XCIxXCI6e1wibmFtZVwiOlwiUmVwbGljYW50XCIsXCJsaW5lXCI6MTgsXCJsb2NcIjp7XCJzdGFydFwiOntcImxpbmVcIjoxOCxcImNvbHVtblwiOjB9LFwiZW5kXCI6e1wibGluZVwiOjE4LFwiY29sdW1uXCI6NDd9fX0sXCIyXCI6e1wibmFtZVwiOlwiKGFub255bW91c18yKVwiLFwibGluZVwiOjYwLFwibG9jXCI6e1wic3RhcnRcIjp7XCJsaW5lXCI6NjAsXCJjb2x1bW5cIjoyNH0sXCJlbmRcIjp7XCJsaW5lXCI6NjAsXCJjb2x1bW5cIjo1MX19fSxcIjNcIjp7XCJuYW1lXCI6XCJhZGRUb1F1ZXVlXCIsXCJsaW5lXCI6NzEsXCJsb2NcIjp7XCJzdGFydFwiOntcImxpbmVcIjo3MSxcImNvbHVtblwiOjF9LFwiZW5kXCI6e1wibGluZVwiOjcxLFwiY29sdW1uXCI6MzF9fX0sXCI0XCI6e1wibmFtZVwiOlwicHJvY2Vzc1F1ZXVlXCIsXCJsaW5lXCI6NzUsXCJsb2NcIjp7XCJzdGFydFwiOntcImxpbmVcIjo3NSxcImNvbHVtblwiOjF9LFwiZW5kXCI6e1wibGluZVwiOjc1LFwiY29sdW1uXCI6MjV9fX0sXCI1XCI6e1wibmFtZVwiOlwiKGFub255bW91c181KVwiLFwibGluZVwiOjc2LFwibG9jXCI6e1wic3RhcnRcIjp7XCJsaW5lXCI6NzYsXCJjb2x1bW5cIjoxNn0sXCJlbmRcIjp7XCJsaW5lXCI6NzYsXCJjb2x1bW5cIjozMn19fSxcIjZcIjp7XCJuYW1lXCI6XCIoYW5vbnltb3VzXzYpXCIsXCJsaW5lXCI6ODIsXCJsb2NcIjp7XCJzdGFydFwiOntcImxpbmVcIjo4MixcImNvbHVtblwiOjd9LFwiZW5kXCI6e1wibGluZVwiOjgyLFwiY29sdW1uXCI6MTl9fX0sXCI3XCI6e1wibmFtZVwiOlwiKGFub255bW91c183KVwiLFwibGluZVwiOjg1LFwibG9jXCI6e1wic3RhcnRcIjp7XCJsaW5lXCI6ODUsXCJjb2x1bW5cIjo3fSxcImVuZFwiOntcImxpbmVcIjo4NSxcImNvbHVtblwiOjI3fX19LFwiOFwiOntcIm5hbWVcIjpcImRvQnJvd3NlclNldHRlclwiLFwibGluZVwiOjEwMyxcImxvY1wiOntcInN0YXJ0XCI6e1wibGluZVwiOjEwMyxcImNvbHVtblwiOjF9LFwiZW5kXCI6e1wibGluZVwiOjEwMyxcImNvbHVtblwiOjM2fX19LFwiOVwiOntcIm5hbWVcIjpcImRvQnJvd3NlckRlY2xhcmVcIixcImxpbmVcIjoxMTIsXCJsb2NcIjp7XCJzdGFydFwiOntcImxpbmVcIjoxMTIsXCJjb2x1bW5cIjoxfSxcImVuZFwiOntcImxpbmVcIjoxMTIsXCJjb2x1bW5cIjo0MX19fSxcIjEwXCI6e1wibmFtZVwiOlwiKGFub255bW91c18xMClcIixcImxpbmVcIjoxMTgsXCJsb2NcIjp7XCJzdGFydFwiOntcImxpbmVcIjoxMTgsXCJjb2x1bW5cIjozNH0sXCJlbmRcIjp7XCJsaW5lXCI6MTE4LFwiY29sdW1uXCI6NDZ9fX0sXCIxMVwiOntcIm5hbWVcIjpcIihhbm9ueW1vdXNfMTEpXCIsXCJsaW5lXCI6MTI0LFwibG9jXCI6e1wic3RhcnRcIjp7XCJsaW5lXCI6MTI0LFwiY29sdW1uXCI6Nn0sXCJlbmRcIjp7XCJsaW5lXCI6MTI0LFwiY29sdW1uXCI6MjJ9fX0sXCIxMlwiOntcIm5hbWVcIjpcImFzc2lnblZhbHVlXCIsXCJsaW5lXCI6MTQ5LFwibG9jXCI6e1wic3RhcnRcIjp7XCJsaW5lXCI6MTQ5LFwiY29sdW1uXCI6MX0sXCJlbmRcIjp7XCJsaW5lXCI6MTQ5LFwiY29sdW1uXCI6NDJ9fX0sXCIxM1wiOntcIm5hbWVcIjpcIm9ic2VydmVWYWx1ZVwiLFwibGluZVwiOjE2MCxcImxvY1wiOntcInN0YXJ0XCI6e1wibGluZVwiOjE2MCxcImNvbHVtblwiOjF9LFwiZW5kXCI6e1wibGluZVwiOjE2MCxcImNvbHVtblwiOjI1fX19LFwiMTRcIjp7XCJuYW1lXCI6XCJkaXNwYXRjaENoYW5nZXNcIixcImxpbmVcIjoxNjYsXCJsb2NcIjp7XCJzdGFydFwiOntcImxpbmVcIjoxNjYsXCJjb2x1bW5cIjoxfSxcImVuZFwiOntcImxpbmVcIjoxNjYsXCJjb2x1bW5cIjozNX19fSxcIjE1XCI6e1wibmFtZVwiOlwiKGFub255bW91c18xNSlcIixcImxpbmVcIjoxNzMsXCJsb2NcIjp7XCJzdGFydFwiOntcImxpbmVcIjoxNzMsXCJjb2x1bW5cIjo1fSxcImVuZFwiOntcImxpbmVcIjoxNzMsXCJjb2x1bW5cIjozMn19fSxcIjE2XCI6e1wibmFtZVwiOlwib25WYWx1ZUNoYW5nZVwiLFwibGluZVwiOjE4MSxcImxvY1wiOntcInN0YXJ0XCI6e1wibGluZVwiOjE4MSxcImNvbHVtblwiOjF9LFwiZW5kXCI6e1wibGluZVwiOjE4MSxcImNvbHVtblwiOjM2fX19LFwiMTdcIjp7XCJuYW1lXCI6XCIoYW5vbnltb3VzXzE3KVwiLFwibGluZVwiOjE4MyxcImxvY1wiOntcInN0YXJ0XCI6e1wibGluZVwiOjE4MyxcImNvbHVtblwiOjIxfSxcImVuZFwiOntcImxpbmVcIjoxODMsXCJjb2x1bW5cIjozOX19fSxcIjE4XCI6e1wibmFtZVwiOlwiKGFub255bW91c18xOClcIixcImxpbmVcIjoxODQsXCJsb2NcIjp7XCJzdGFydFwiOntcImxpbmVcIjoxODQsXCJjb2x1bW5cIjo1MX0sXCJlbmRcIjp7XCJsaW5lXCI6MTg0LFwiY29sdW1uXCI6Njd9fX0sXCIxOVwiOntcIm5hbWVcIjpcInVub2JzZXJ2ZVZhbHVlXCIsXCJsaW5lXCI6MjQ1LFwibG9jXCI6e1wic3RhcnRcIjp7XCJsaW5lXCI6MjQ1LFwiY29sdW1uXCI6MX0sXCJlbmRcIjp7XCJsaW5lXCI6MjQ1LFwiY29sdW1uXCI6Mjd9fX0sXCIyMFwiOntcIm5hbWVcIjpcIihhbm9ueW1vdXNfMjApXCIsXCJsaW5lXCI6MjUyLFwibG9jXCI6e1wic3RhcnRcIjp7XCJsaW5lXCI6MjUyLFwiY29sdW1uXCI6MzJ9LFwiZW5kXCI6e1wibGluZVwiOjI1MixcImNvbHVtblwiOjQ4fX19LFwiMjFcIjp7XCJuYW1lXCI6XCIoYW5vbnltb3VzXzIxKVwiLFwibGluZVwiOjI2OCxcImxvY1wiOntcInN0YXJ0XCI6e1wibGluZVwiOjI2OCxcImNvbHVtblwiOjMxfSxcImVuZFwiOntcImxpbmVcIjoyNjgsXCJjb2x1bW5cIjo0N319fSxcIjIyXCI6e1wibmFtZVwiOlwiKGFub255bW91c18yMilcIixcImxpbmVcIjoyODcsXCJsb2NcIjp7XCJzdGFydFwiOntcImxpbmVcIjoyODcsXCJjb2x1bW5cIjoyNH0sXCJlbmRcIjp7XCJsaW5lXCI6Mjg3LFwiY29sdW1uXCI6NDJ9fX0sXCIyM1wiOntcIm5hbWVcIjpcIihhbm9ueW1vdXNfMjMpXCIsXCJsaW5lXCI6MzE4LFwibG9jXCI6e1wic3RhcnRcIjp7XCJsaW5lXCI6MzE4LFwiY29sdW1uXCI6MjR9LFwiZW5kXCI6e1wibGluZVwiOjMxOCxcImNvbHVtblwiOjQyfX19LFwiMjRcIjp7XCJuYW1lXCI6XCIoYW5vbnltb3VzXzI0KVwiLFwibGluZVwiOjMyOSxcImxvY1wiOntcInN0YXJ0XCI6e1wibGluZVwiOjMyOSxcImNvbHVtblwiOjI0fSxcImVuZFwiOntcImxpbmVcIjozMjksXCJjb2x1bW5cIjo0Mn19fSxcIjI1XCI6e1wibmFtZVwiOlwiZnVsbFVwZGF0ZVwiLFwibGluZVwiOjM2MSxcImxvY1wiOntcInN0YXJ0XCI6e1wibGluZVwiOjM2MSxcImNvbHVtblwiOjF9LFwiZW5kXCI6e1wibGluZVwiOjM2MSxcImNvbHVtblwiOjIzfX19LFwiMjZcIjp7XCJuYW1lXCI6XCIoYW5vbnltb3VzXzI2KVwiLFwibGluZVwiOjM2MixcImxvY1wiOntcInN0YXJ0XCI6e1wibGluZVwiOjM2MixcImNvbHVtblwiOjQ0fSxcImVuZFwiOntcImxpbmVcIjozNjIsXCJjb2x1bW5cIjo2MH19fSxcIjI3XCI6e1wibmFtZVwiOlwiKGFub255bW91c18yNylcIixcImxpbmVcIjozNjksXCJsb2NcIjp7XCJzdGFydFwiOntcImxpbmVcIjozNjksXCJjb2x1bW5cIjoyNX0sXCJlbmRcIjp7XCJsaW5lXCI6MzY5LFwiY29sdW1uXCI6Mzd9fX0sXCIyOFwiOntcIm5hbWVcIjpcIihhbm9ueW1vdXNfMjgpXCIsXCJsaW5lXCI6MzcyLFwibG9jXCI6e1wic3RhcnRcIjp7XCJsaW5lXCI6MzcyLFwiY29sdW1uXCI6MjR9LFwiZW5kXCI6e1wibGluZVwiOjM3MixcImNvbHVtblwiOjM2fX19fSxcInN0YXRlbWVudE1hcFwiOntcIjFcIjp7XCJzdGFydFwiOntcImxpbmVcIjo0LFwiY29sdW1uXCI6MH0sXCJlbmRcIjp7XCJsaW5lXCI6NCxcImNvbHVtblwiOjM1fX0sXCIyXCI6e1wic3RhcnRcIjp7XCJsaW5lXCI6NSxcImNvbHVtblwiOjB9LFwiZW5kXCI6e1wibGluZVwiOjUsXCJjb2x1bW5cIjo1MH19LFwiM1wiOntcInN0YXJ0XCI6e1wibGluZVwiOjYsXCJjb2x1bW5cIjowfSxcImVuZFwiOntcImxpbmVcIjo2LFwiY29sdW1uXCI6Mzl9fSxcIjRcIjp7XCJzdGFydFwiOntcImxpbmVcIjo3LFwiY29sdW1uXCI6MH0sXCJlbmRcIjp7XCJsaW5lXCI6NyxcImNvbHVtblwiOjQwfX0sXCI1XCI6e1wic3RhcnRcIjp7XCJsaW5lXCI6OCxcImNvbHVtblwiOjB9LFwiZW5kXCI6e1wibGluZVwiOjgsXCJjb2x1bW5cIjozNH19LFwiNlwiOntcInN0YXJ0XCI6e1wibGluZVwiOjksXCJjb2x1bW5cIjowfSxcImVuZFwiOntcImxpbmVcIjo5LFwiY29sdW1uXCI6Mjl9fSxcIjdcIjp7XCJzdGFydFwiOntcImxpbmVcIjoxMCxcImNvbHVtblwiOjB9LFwiZW5kXCI6e1wibGluZVwiOjEwLFwiY29sdW1uXCI6Mjd9fSxcIjhcIjp7XCJzdGFydFwiOntcImxpbmVcIjoxMSxcImNvbHVtblwiOjB9LFwiZW5kXCI6e1wibGluZVwiOjExLFwiY29sdW1uXCI6Mjh9fSxcIjlcIjp7XCJzdGFydFwiOntcImxpbmVcIjoxNCxcImNvbHVtblwiOjB9LFwiZW5kXCI6e1wibGluZVwiOjE0LFwiY29sdW1uXCI6MzR9fSxcIjEwXCI6e1wic3RhcnRcIjp7XCJsaW5lXCI6MTUsXCJjb2x1bW5cIjowfSxcImVuZFwiOntcImxpbmVcIjoxNSxcImNvbHVtblwiOjI3fX0sXCIxMVwiOntcInN0YXJ0XCI6e1wibGluZVwiOjE2LFwiY29sdW1uXCI6MH0sXCJlbmRcIjp7XCJsaW5lXCI6MTYsXCJjb2x1bW5cIjo1MH19LFwiMTJcIjp7XCJzdGFydFwiOntcImxpbmVcIjoxOCxcImNvbHVtblwiOjB9LFwiZW5kXCI6e1wibGluZVwiOjM3NSxcImNvbHVtblwiOjF9fSxcIjEzXCI6e1wic3RhcnRcIjp7XCJsaW5lXCI6MTksXCJjb2x1bW5cIjoxfSxcImVuZFwiOntcImxpbmVcIjoyMSxcImNvbHVtblwiOjJ9fSxcIjE0XCI6e1wic3RhcnRcIjp7XCJsaW5lXCI6MjAsXCJjb2x1bW5cIjoyfSxcImVuZFwiOntcImxpbmVcIjoyMCxcImNvbHVtblwiOjcxfX0sXCIxNVwiOntcInN0YXJ0XCI6e1wibGluZVwiOjIzLFwiY29sdW1uXCI6MX0sXCJlbmRcIjp7XCJsaW5lXCI6MjUsXCJjb2x1bW5cIjoyfX0sXCIxNlwiOntcInN0YXJ0XCI6e1wibGluZVwiOjI0LFwiY29sdW1uXCI6Mn0sXCJlbmRcIjp7XCJsaW5lXCI6MjQsXCJjb2x1bW5cIjo3OH19LFwiMTdcIjp7XCJzdGFydFwiOntcImxpbmVcIjoyOCxcImNvbHVtblwiOjF9LFwiZW5kXCI6e1wibGluZVwiOjI4LFwiY29sdW1uXCI6Njd9fSxcIjE4XCI6e1wic3RhcnRcIjp7XCJsaW5lXCI6MzEsXCJjb2x1bW5cIjoxfSxcImVuZFwiOntcImxpbmVcIjo0MCxcImNvbHVtblwiOjJ9fSxcIjE5XCI6e1wic3RhcnRcIjp7XCJsaW5lXCI6MzIsXCJjb2x1bW5cIjoyfSxcImVuZFwiOntcImxpbmVcIjozNCxcImNvbHVtblwiOjN9fSxcIjIwXCI6e1wic3RhcnRcIjp7XCJsaW5lXCI6MzMsXCJjb2x1bW5cIjozfSxcImVuZFwiOntcImxpbmVcIjozMyxcImNvbHVtblwiOjQzfX0sXCIyMVwiOntcInN0YXJ0XCI6e1wibGluZVwiOjM2LFwiY29sdW1uXCI6Mn0sXCJlbmRcIjp7XCJsaW5lXCI6MzYsXCJjb2x1bW5cIjo0Mn19LFwiMjJcIjp7XCJzdGFydFwiOntcImxpbmVcIjozOCxcImNvbHVtblwiOjJ9LFwiZW5kXCI6e1wibGluZVwiOjM4LFwiY29sdW1uXCI6MzR9fSxcIjIzXCI6e1wic3RhcnRcIjp7XCJsaW5lXCI6MzksXCJjb2x1bW5cIjoyfSxcImVuZFwiOntcImxpbmVcIjozOSxcImNvbHVtblwiOjQyfX0sXCIyNFwiOntcInN0YXJ0XCI6e1wibGluZVwiOjQyLFwiY29sdW1uXCI6MX0sXCJlbmRcIjp7XCJsaW5lXCI6NDIsXCJjb2x1bW5cIjoxN319LFwiMjVcIjp7XCJzdGFydFwiOntcImxpbmVcIjo0MyxcImNvbHVtblwiOjF9LFwiZW5kXCI6e1wibGluZVwiOjQzLFwiY29sdW1uXCI6MTF9fSxcIjI2XCI6e1wic3RhcnRcIjp7XCJsaW5lXCI6NDQsXCJjb2x1bW5cIjoxfSxcImVuZFwiOntcImxpbmVcIjo0NCxcImNvbHVtblwiOjE5fX0sXCIyN1wiOntcInN0YXJ0XCI6e1wibGluZVwiOjQ1LFwiY29sdW1uXCI6MX0sXCJlbmRcIjp7XCJsaW5lXCI6NDUsXCJjb2x1bW5cIjoxOH19LFwiMjhcIjp7XCJzdGFydFwiOntcImxpbmVcIjo0NixcImNvbHVtblwiOjF9LFwiZW5kXCI6e1wibGluZVwiOjQ2LFwiY29sdW1uXCI6MjJ9fSxcIjI5XCI6e1wic3RhcnRcIjp7XCJsaW5lXCI6NDcsXCJjb2x1bW5cIjoxfSxcImVuZFwiOntcImxpbmVcIjo0NyxcImNvbHVtblwiOjE4fX0sXCIzMFwiOntcInN0YXJ0XCI6e1wibGluZVwiOjQ4LFwiY29sdW1uXCI6MX0sXCJlbmRcIjp7XCJsaW5lXCI6NDgsXCJjb2x1bW5cIjoxOX19LFwiMzFcIjp7XCJzdGFydFwiOntcImxpbmVcIjo0OSxcImNvbHVtblwiOjF9LFwiZW5kXCI6e1wibGluZVwiOjQ5LFwiY29sdW1uXCI6Mjh9fSxcIjMyXCI6e1wic3RhcnRcIjp7XCJsaW5lXCI6NTAsXCJjb2x1bW5cIjoxfSxcImVuZFwiOntcImxpbmVcIjo1MCxcImNvbHVtblwiOjIxfX0sXCIzM1wiOntcInN0YXJ0XCI6e1wibGluZVwiOjUxLFwiY29sdW1uXCI6MX0sXCJlbmRcIjp7XCJsaW5lXCI6NTMsXCJjb2x1bW5cIjoyfX0sXCIzNFwiOntcInN0YXJ0XCI6e1wibGluZVwiOjUyLFwiY29sdW1uXCI6Mn0sXCJlbmRcIjp7XCJsaW5lXCI6NTIsXCJjb2x1bW5cIjoyNX19LFwiMzVcIjp7XCJzdGFydFwiOntcImxpbmVcIjo2MCxcImNvbHVtblwiOjF9LFwiZW5kXCI6e1wibGluZVwiOjY0LFwiY29sdW1uXCI6NH19LFwiMzZcIjp7XCJzdGFydFwiOntcImxpbmVcIjo2MSxcImNvbHVtblwiOjJ9LFwiZW5kXCI6e1wibGluZVwiOjYzLFwiY29sdW1uXCI6M319LFwiMzdcIjp7XCJzdGFydFwiOntcImxpbmVcIjo2MixcImNvbHVtblwiOjN9LFwiZW5kXCI6e1wibGluZVwiOjYyLFwiY29sdW1uXCI6MzB9fSxcIjM4XCI6e1wic3RhcnRcIjp7XCJsaW5lXCI6NjksXCJjb2x1bW5cIjoxfSxcImVuZFwiOntcImxpbmVcIjo2OSxcImNvbHVtblwiOjE2fX0sXCIzOVwiOntcInN0YXJ0XCI6e1wibGluZVwiOjcxLFwiY29sdW1uXCI6MX0sXCJlbmRcIjp7XCJsaW5lXCI6NzMsXCJjb2x1bW5cIjoyfX0sXCI0MFwiOntcInN0YXJ0XCI6e1wibGluZVwiOjcyLFwiY29sdW1uXCI6Mn0sXCJlbmRcIjp7XCJsaW5lXCI6NzIsXCJjb2x1bW5cIjozNX19LFwiNDFcIjp7XCJzdGFydFwiOntcImxpbmVcIjo3NSxcImNvbHVtblwiOjF9LFwiZW5kXCI6e1wibGluZVwiOjc5LFwiY29sdW1uXCI6Mn19LFwiNDJcIjp7XCJzdGFydFwiOntcImxpbmVcIjo3NixcImNvbHVtblwiOjJ9LFwiZW5kXCI6e1wibGluZVwiOjc4LFwiY29sdW1uXCI6NX19LFwiNDNcIjp7XCJzdGFydFwiOntcImxpbmVcIjo3NyxcImNvbHVtblwiOjN9LFwiZW5kXCI6e1wibGluZVwiOjc3LFwiY29sdW1uXCI6MzR9fSxcIjQ0XCI6e1wic3RhcnRcIjp7XCJsaW5lXCI6ODEsXCJjb2x1bW5cIjoxfSxcImVuZFwiOntcImxpbmVcIjoxMDEsXCJjb2x1bW5cIjo0fX0sXCI0NVwiOntcInN0YXJ0XCI6e1wibGluZVwiOjgzLFwiY29sdW1uXCI6M30sXCJlbmRcIjp7XCJsaW5lXCI6ODMsXCJjb2x1bW5cIjoxNn19LFwiNDZcIjp7XCJzdGFydFwiOntcImxpbmVcIjo4NixcImNvbHVtblwiOjN9LFwiZW5kXCI6e1wibGluZVwiOjg5LFwiY29sdW1uXCI6NH19LFwiNDdcIjp7XCJzdGFydFwiOntcImxpbmVcIjo4NyxcImNvbHVtblwiOjR9LFwiZW5kXCI6e1wibGluZVwiOjg3LFwiY29sdW1uXCI6NjN9fSxcIjQ4XCI6e1wic3RhcnRcIjp7XCJsaW5lXCI6ODgsXCJjb2x1bW5cIjo0fSxcImVuZFwiOntcImxpbmVcIjo4OCxcImNvbHVtblwiOjE3fX0sXCI0OVwiOntcInN0YXJ0XCI6e1wibGluZVwiOjkxLFwiY29sdW1uXCI6M30sXCJlbmRcIjp7XCJsaW5lXCI6OTEsXCJjb2x1bW5cIjo1MX19LFwiNTBcIjp7XCJzdGFydFwiOntcImxpbmVcIjo5MyxcImNvbHVtblwiOjN9LFwiZW5kXCI6e1wibGluZVwiOjk2LFwiY29sdW1uXCI6NH19LFwiNTFcIjp7XCJzdGFydFwiOntcImxpbmVcIjo5NCxcImNvbHVtblwiOjR9LFwiZW5kXCI6e1wibGluZVwiOjk0LFwiY29sdW1uXCI6NDR9fSxcIjUyXCI6e1wic3RhcnRcIjp7XCJsaW5lXCI6OTUsXCJjb2x1bW5cIjo0fSxcImVuZFwiOntcImxpbmVcIjo5NSxcImNvbHVtblwiOjIxfX0sXCI1M1wiOntcInN0YXJ0XCI6e1wibGluZVwiOjk4LFwiY29sdW1uXCI6M30sXCJlbmRcIjp7XCJsaW5lXCI6OTgsXCJjb2x1bW5cIjoyOX19LFwiNTRcIjp7XCJzdGFydFwiOntcImxpbmVcIjoxMDMsXCJjb2x1bW5cIjoxfSxcImVuZFwiOntcImxpbmVcIjoxMTAsXCJjb2x1bW5cIjoyfX0sXCI1NVwiOntcInN0YXJ0XCI6e1wibGluZVwiOjEwNCxcImNvbHVtblwiOjJ9LFwiZW5kXCI6e1wibGluZVwiOjEwOSxcImNvbHVtblwiOjV9fSxcIjU2XCI6e1wic3RhcnRcIjp7XCJsaW5lXCI6MTEyLFwiY29sdW1uXCI6MX0sXCJlbmRcIjp7XCJsaW5lXCI6MTQzLFwiY29sdW1uXCI6Mn19LFwiNTdcIjp7XCJzdGFydFwiOntcImxpbmVcIjoxMTMsXCJjb2x1bW5cIjoyfSxcImVuZFwiOntcImxpbmVcIjoxMTUsXCJjb2x1bW5cIjozfX0sXCI1OFwiOntcInN0YXJ0XCI6e1wibGluZVwiOjExNCxcImNvbHVtblwiOjN9LFwiZW5kXCI6e1wibGluZVwiOjExNCxcImNvbHVtblwiOjEwfX0sXCI1OVwiOntcInN0YXJ0XCI6e1wibGluZVwiOjExNyxcImNvbHVtblwiOjJ9LFwiZW5kXCI6e1wibGluZVwiOjExNyxcImNvbHVtblwiOjI4fX0sXCI2MFwiOntcInN0YXJ0XCI6e1wibGluZVwiOjExOCxcImNvbHVtblwiOjJ9LFwiZW5kXCI6e1wibGluZVwiOjE0MixcImNvbHVtblwiOjV9fSxcIjYxXCI6e1wic3RhcnRcIjp7XCJsaW5lXCI6MTE5LFwiY29sdW1uXCI6M30sXCJlbmRcIjp7XCJsaW5lXCI6MTQxLFwiY29sdW1uXCI6Nn19LFwiNjJcIjp7XCJzdGFydFwiOntcImxpbmVcIjoxMjUsXCJjb2x1bW5cIjo0fSxcImVuZFwiOntcImxpbmVcIjoxMjUsXCJjb2x1bW5cIjoxMDF9fSxcIjYzXCI6e1wic3RhcnRcIjp7XCJsaW5lXCI6MTI2LFwiY29sdW1uXCI6NH0sXCJlbmRcIjp7XCJsaW5lXCI6MTI2LFwiY29sdW1uXCI6NDB9fSxcIjY0XCI6e1wic3RhcnRcIjp7XCJsaW5lXCI6MTI3LFwiY29sdW1uXCI6NH0sXCJlbmRcIjp7XCJsaW5lXCI6MTMzLFwiY29sdW1uXCI6NX19LFwiNjVcIjp7XCJzdGFydFwiOntcImxpbmVcIjoxMjgsXCJjb2x1bW5cIjo1fSxcImVuZFwiOntcImxpbmVcIjoxMjgsXCJjb2x1bW5cIjoyMn19LFwiNjZcIjp7XCJzdGFydFwiOntcImxpbmVcIjoxMjksXCJjb2x1bW5cIjo1fSxcImVuZFwiOntcImxpbmVcIjoxMjksXCJjb2x1bW5cIjoyNn19LFwiNjdcIjp7XCJzdGFydFwiOntcImxpbmVcIjoxMzAsXCJjb2x1bW5cIjo1fSxcImVuZFwiOntcImxpbmVcIjoxMzAsXCJjb2x1bW5cIjoyMH19LFwiNjhcIjp7XCJzdGFydFwiOntcImxpbmVcIjoxMzEsXCJjb2x1bW5cIjo1fSxcImVuZFwiOntcImxpbmVcIjoxMzEsXCJjb2x1bW5cIjo0NH19LFwiNjlcIjp7XCJzdGFydFwiOntcImxpbmVcIjoxMzIsXCJjb2x1bW5cIjo1fSxcImVuZFwiOntcImxpbmVcIjoxMzIsXCJjb2x1bW5cIjozNn19LFwiNzBcIjp7XCJzdGFydFwiOntcImxpbmVcIjoxMzQsXCJjb2x1bW5cIjo0fSxcImVuZFwiOntcImxpbmVcIjoxMzQsXCJjb2x1bW5cIjoyOX19LFwiNzFcIjp7XCJzdGFydFwiOntcImxpbmVcIjoxMzUsXCJjb2x1bW5cIjo0fSxcImVuZFwiOntcImxpbmVcIjoxMzUsXCJjb2x1bW5cIjozMn19LFwiNzJcIjp7XCJzdGFydFwiOntcImxpbmVcIjoxMzYsXCJjb2x1bW5cIjo0fSxcImVuZFwiOntcImxpbmVcIjoxNDAsXCJjb2x1bW5cIjo1fX0sXCI3M1wiOntcInN0YXJ0XCI6e1wibGluZVwiOjEzNyxcImNvbHVtblwiOjV9LFwiZW5kXCI6e1wibGluZVwiOjEzNyxcImNvbHVtblwiOjIwfX0sXCI3NFwiOntcInN0YXJ0XCI6e1wibGluZVwiOjEzOCxcImNvbHVtblwiOjExfSxcImVuZFwiOntcImxpbmVcIjoxNDAsXCJjb2x1bW5cIjo1fX0sXCI3NVwiOntcInN0YXJ0XCI6e1wibGluZVwiOjEzOSxcImNvbHVtblwiOjV9LFwiZW5kXCI6e1wibGluZVwiOjEzOSxcImNvbHVtblwiOjQ4fX0sXCI3NlwiOntcInN0YXJ0XCI6e1wibGluZVwiOjE0NSxcImNvbHVtblwiOjF9LFwiZW5kXCI6e1wibGluZVwiOjE0NSxcImNvbHVtblwiOjM3fX0sXCI3N1wiOntcInN0YXJ0XCI6e1wibGluZVwiOjE0OSxcImNvbHVtblwiOjF9LFwiZW5kXCI6e1wibGluZVwiOjE1OCxcImNvbHVtblwiOjJ9fSxcIjc4XCI6e1wic3RhcnRcIjp7XCJsaW5lXCI6MTUwLFwiY29sdW1uXCI6Mn0sXCJlbmRcIjp7XCJsaW5lXCI6MTUwLFwiY29sdW1uXCI6MTl9fSxcIjc5XCI6e1wic3RhcnRcIjp7XCJsaW5lXCI6MTUxLFwiY29sdW1uXCI6Mn0sXCJlbmRcIjp7XCJsaW5lXCI6MTUxLFwiY29sdW1uXCI6MzB9fSxcIjgwXCI6e1wic3RhcnRcIjp7XCJsaW5lXCI6MTUyLFwiY29sdW1uXCI6Mn0sXCJlbmRcIjp7XCJsaW5lXCI6MTUyLFwiY29sdW1uXCI6MTl9fSxcIjgxXCI6e1wic3RhcnRcIjp7XCJsaW5lXCI6MTUzLFwiY29sdW1uXCI6Mn0sXCJlbmRcIjp7XCJsaW5lXCI6MTUzLFwiY29sdW1uXCI6MTd9fSxcIjgyXCI6e1wic3RhcnRcIjp7XCJsaW5lXCI6MTU0LFwiY29sdW1uXCI6Mn0sXCJlbmRcIjp7XCJsaW5lXCI6MTU2LFwiY29sdW1uXCI6M319LFwiODNcIjp7XCJzdGFydFwiOntcImxpbmVcIjoxNTUsXCJjb2x1bW5cIjozfSxcImVuZFwiOntcImxpbmVcIjoxNTUsXCJjb2x1bW5cIjoyOH19LFwiODRcIjp7XCJzdGFydFwiOntcImxpbmVcIjoxNTcsXCJjb2x1bW5cIjoyfSxcImVuZFwiOntcImxpbmVcIjoxNTcsXCJjb2x1bW5cIjozOX19LFwiODVcIjp7XCJzdGFydFwiOntcImxpbmVcIjoxNjAsXCJjb2x1bW5cIjoxfSxcImVuZFwiOntcImxpbmVcIjoxNjQsXCJjb2x1bW5cIjoyfX0sXCI4NlwiOntcInN0YXJ0XCI6e1wibGluZVwiOjE2MSxcImNvbHVtblwiOjJ9LFwiZW5kXCI6e1wibGluZVwiOjE2MyxcImNvbHVtblwiOjN9fSxcIjg3XCI6e1wic3RhcnRcIjp7XCJsaW5lXCI6MTYyLFwiY29sdW1uXCI6M30sXCJlbmRcIjp7XCJsaW5lXCI6MTYyLFwiY29sdW1uXCI6NDB9fSxcIjg4XCI6e1wic3RhcnRcIjp7XCJsaW5lXCI6MTY2LFwiY29sdW1uXCI6MX0sXCJlbmRcIjp7XCJsaW5lXCI6MTc5LFwiY29sdW1uXCI6Mn19LFwiODlcIjp7XCJzdGFydFwiOntcImxpbmVcIjoxNjcsXCJjb2x1bW5cIjoyfSxcImVuZFwiOntcImxpbmVcIjoxNzgsXCJjb2x1bW5cIjo1fX0sXCI5MFwiOntcInN0YXJ0XCI6e1wibGluZVwiOjE3NSxcImNvbHVtblwiOjN9LFwiZW5kXCI6e1wibGluZVwiOjE3NixcImNvbHVtblwiOjI5fX0sXCI5MVwiOntcInN0YXJ0XCI6e1wibGluZVwiOjE3NyxcImNvbHVtblwiOjN9LFwiZW5kXCI6e1wibGluZVwiOjE3NyxcImNvbHVtblwiOjMyfX0sXCI5MlwiOntcInN0YXJ0XCI6e1wibGluZVwiOjE4MSxcImNvbHVtblwiOjF9LFwiZW5kXCI6e1wibGluZVwiOjI0MyxcImNvbHVtblwiOjJ9fSxcIjkzXCI6e1wic3RhcnRcIjp7XCJsaW5lXCI6MTgyLFwiY29sdW1uXCI6Mn0sXCJlbmRcIjp7XCJsaW5lXCI6MTgyLFwiY29sdW1uXCI6Mjh9fSxcIjk0XCI6e1wic3RhcnRcIjp7XCJsaW5lXCI6MTgzLFwiY29sdW1uXCI6Mn0sXCJlbmRcIjp7XCJsaW5lXCI6MjM2LFwiY29sdW1uXCI6NX19LFwiOTVcIjp7XCJzdGFydFwiOntcImxpbmVcIjoxODQsXCJjb2x1bW5cIjozfSxcImVuZFwiOntcImxpbmVcIjoxODcsXCJjb2x1bW5cIjo2fX0sXCI5NlwiOntcInN0YXJ0XCI6e1wibGluZVwiOjE4NixcImNvbHVtblwiOjR9LFwiZW5kXCI6e1wibGluZVwiOjE4NixcImNvbHVtblwiOjM3fX0sXCI5N1wiOntcInN0YXJ0XCI6e1wibGluZVwiOjE5MSxcImNvbHVtblwiOjN9LFwiZW5kXCI6e1wibGluZVwiOjE5MyxcImNvbHVtblwiOjR9fSxcIjk4XCI6e1wic3RhcnRcIjp7XCJsaW5lXCI6MTkyLFwiY29sdW1uXCI6NH0sXCJlbmRcIjp7XCJsaW5lXCI6MTkyLFwiY29sdW1uXCI6MTR9fSxcIjk5XCI6e1wic3RhcnRcIjp7XCJsaW5lXCI6MTk1LFwiY29sdW1uXCI6M30sXCJlbmRcIjp7XCJsaW5lXCI6MTk1LFwiY29sdW1uXCI6NTB9fSxcIjEwMFwiOntcInN0YXJ0XCI6e1wibGluZVwiOjE5NixcImNvbHVtblwiOjN9LFwiZW5kXCI6e1wibGluZVwiOjIzNSxcImNvbHVtblwiOjR9fSxcIjEwMVwiOntcInN0YXJ0XCI6e1wibGluZVwiOjE5OCxcImNvbHVtblwiOjV9LFwiZW5kXCI6e1wibGluZVwiOjIwMixcImNvbHVtblwiOjh9fSxcIjEwMlwiOntcInN0YXJ0XCI6e1wibGluZVwiOjIwMyxcImNvbHVtblwiOjV9LFwiZW5kXCI6e1wibGluZVwiOjIwMyxcImNvbHVtblwiOjExfX0sXCIxMDNcIjp7XCJzdGFydFwiOntcImxpbmVcIjoyMDUsXCJjb2x1bW5cIjo1fSxcImVuZFwiOntcImxpbmVcIjoyMTAsXCJjb2x1bW5cIjo4fX0sXCIxMDRcIjp7XCJzdGFydFwiOntcImxpbmVcIjoyMTEsXCJjb2x1bW5cIjo1fSxcImVuZFwiOntcImxpbmVcIjoyMTEsXCJjb2x1bW5cIjoxMX19LFwiMTA1XCI6e1wic3RhcnRcIjp7XCJsaW5lXCI6MjEzLFwiY29sdW1uXCI6NX0sXCJlbmRcIjp7XCJsaW5lXCI6MjIxLFwiY29sdW1uXCI6OH19LFwiMTA2XCI6e1wic3RhcnRcIjp7XCJsaW5lXCI6MjIyLFwiY29sdW1uXCI6NX0sXCJlbmRcIjp7XCJsaW5lXCI6MjIyLFwiY29sdW1uXCI6MTF9fSxcIjEwN1wiOntcInN0YXJ0XCI6e1wibGluZVwiOjIyNCxcImNvbHVtblwiOjV9LFwiZW5kXCI6e1wibGluZVwiOjIyOCxcImNvbHVtblwiOjh9fSxcIjEwOFwiOntcInN0YXJ0XCI6e1wibGluZVwiOjIyOSxcImNvbHVtblwiOjV9LFwiZW5kXCI6e1wibGluZVwiOjIyOSxcImNvbHVtblwiOjExfX0sXCIxMDlcIjp7XCJzdGFydFwiOntcImxpbmVcIjoyMzEsXCJjb2x1bW5cIjo1fSxcImVuZFwiOntcImxpbmVcIjoyMzQsXCJjb2x1bW5cIjo4fX0sXCIxMTBcIjp7XCJzdGFydFwiOntcImxpbmVcIjoyMzgsXCJjb2x1bW5cIjoyfSxcImVuZFwiOntcImxpbmVcIjoyNDIsXCJjb2x1bW5cIjozfX0sXCIxMTFcIjp7XCJzdGFydFwiOntcImxpbmVcIjoyMzksXCJjb2x1bW5cIjozfSxcImVuZFwiOntcImxpbmVcIjoyMzksXCJjb2x1bW5cIjozN319LFwiMTEyXCI6e1wic3RhcnRcIjp7XCJsaW5lXCI6MjQxLFwiY29sdW1uXCI6M30sXCJlbmRcIjp7XCJsaW5lXCI6MjQxLFwiY29sdW1uXCI6NTF9fSxcIjExM1wiOntcInN0YXJ0XCI6e1wibGluZVwiOjI0NSxcImNvbHVtblwiOjF9LFwiZW5kXCI6e1wibGluZVwiOjI0OSxcImNvbHVtblwiOjJ9fSxcIjExNFwiOntcInN0YXJ0XCI6e1wibGluZVwiOjI0NixcImNvbHVtblwiOjJ9LFwiZW5kXCI6e1wibGluZVwiOjI0OCxcImNvbHVtblwiOjN9fSxcIjExNVwiOntcInN0YXJ0XCI6e1wibGluZVwiOjI0NyxcImNvbHVtblwiOjN9LFwiZW5kXCI6e1wibGluZVwiOjI0NyxcImNvbHVtblwiOjQyfX0sXCIxMTZcIjp7XCJzdGFydFwiOntcImxpbmVcIjoyNTIsXCJjb2x1bW5cIjoxfSxcImVuZFwiOntcImxpbmVcIjoyNjQsXCJjb2x1bW5cIjo0fX0sXCIxMTdcIjp7XCJzdGFydFwiOntcImxpbmVcIjoyNTMsXCJjb2x1bW5cIjoyfSxcImVuZFwiOntcImxpbmVcIjoyNTUsXCJjb2x1bW5cIjozfX0sXCIxMThcIjp7XCJzdGFydFwiOntcImxpbmVcIjoyNTQsXCJjb2x1bW5cIjozfSxcImVuZFwiOntcImxpbmVcIjoyNTQsXCJjb2x1bW5cIjoxMH19LFwiMTE5XCI6e1wic3RhcnRcIjp7XCJsaW5lXCI6MjU3LFwiY29sdW1uXCI6Mn0sXCJlbmRcIjp7XCJsaW5lXCI6MjU3LFwiY29sdW1uXCI6NDR9fSxcIjEyMFwiOntcInN0YXJ0XCI6e1wibGluZVwiOjI1OSxcImNvbHVtblwiOjJ9LFwiZW5kXCI6e1wibGluZVwiOjI2MSxcImNvbHVtblwiOjN9fSxcIjEyMVwiOntcInN0YXJ0XCI6e1wibGluZVwiOjI2MCxcImNvbHVtblwiOjN9LFwiZW5kXCI6e1wibGluZVwiOjI2MCxcImNvbHVtblwiOjQxfX0sXCIxMjJcIjp7XCJzdGFydFwiOntcImxpbmVcIjoyNjMsXCJjb2x1bW5cIjoyfSxcImVuZFwiOntcImxpbmVcIjoyNjMsXCJjb2x1bW5cIjo0NH19LFwiMTIzXCI6e1wic3RhcnRcIjp7XCJsaW5lXCI6MjY4LFwiY29sdW1uXCI6MX0sXCJlbmRcIjp7XCJsaW5lXCI6MzU5LFwiY29sdW1uXCI6NH19LFwiMTI0XCI6e1wic3RhcnRcIjp7XCJsaW5lXCI6MjY5LFwiY29sdW1uXCI6Mn0sXCJlbmRcIjp7XCJsaW5lXCI6MjcxLFwiY29sdW1uXCI6M319LFwiMTI1XCI6e1wic3RhcnRcIjp7XCJsaW5lXCI6MjcwLFwiY29sdW1uXCI6M30sXCJlbmRcIjp7XCJsaW5lXCI6MjcwLFwiY29sdW1uXCI6MTB9fSxcIjEyNlwiOntcInN0YXJ0XCI6e1wibGluZVwiOjI3MyxcImNvbHVtblwiOjJ9LFwiZW5kXCI6e1wibGluZVwiOjI4MCxcImNvbHVtblwiOjN9fSxcIjEyN1wiOntcInN0YXJ0XCI6e1wibGluZVwiOjI3NCxcImNvbHVtblwiOjN9LFwiZW5kXCI6e1wibGluZVwiOjI3NCxcImNvbHVtblwiOjEwfX0sXCIxMjhcIjp7XCJzdGFydFwiOntcImxpbmVcIjoyNzUsXCJjb2x1bW5cIjo5fSxcImVuZFwiOntcImxpbmVcIjoyODAsXCJjb2x1bW5cIjozfX0sXCIxMjlcIjp7XCJzdGFydFwiOntcImxpbmVcIjoyNzYsXCJjb2x1bW5cIjozfSxcImVuZFwiOntcImxpbmVcIjoyNzcsXCJjb2x1bW5cIjo0OH19LFwiMTMwXCI6e1wic3RhcnRcIjp7XCJsaW5lXCI6Mjc4LFwiY29sdW1uXCI6M30sXCJlbmRcIjp7XCJsaW5lXCI6Mjc4LFwiY29sdW1uXCI6MTZ9fSxcIjEzMVwiOntcInN0YXJ0XCI6e1wibGluZVwiOjI3OSxcImNvbHVtblwiOjN9LFwiZW5kXCI6e1wibGluZVwiOjI3OSxcImNvbHVtblwiOjEwfX0sXCIxMzJcIjp7XCJzdGFydFwiOntcImxpbmVcIjoyODIsXCJjb2x1bW5cIjoyfSxcImVuZFwiOntcImxpbmVcIjoyODIsXCJjb2x1bW5cIjo0M319LFwiMTMzXCI6e1wic3RhcnRcIjp7XCJsaW5lXCI6Mjg0LFwiY29sdW1uXCI6Mn0sXCJlbmRcIjp7XCJsaW5lXCI6Mjg0LFwiY29sdW1uXCI6MzB9fSxcIjEzNFwiOntcInN0YXJ0XCI6e1wibGluZVwiOjI4NSxcImNvbHVtblwiOjJ9LFwiZW5kXCI6e1wibGluZVwiOjI4NSxcImNvbHVtblwiOjQyfX0sXCIxMzVcIjp7XCJzdGFydFwiOntcImxpbmVcIjoyODYsXCJjb2x1bW5cIjoyfSxcImVuZFwiOntcImxpbmVcIjoyODYsXCJjb2x1bW5cIjoyNn19LFwiMTM2XCI6e1wic3RhcnRcIjp7XCJsaW5lXCI6Mjg3LFwiY29sdW1uXCI6Mn0sXCJlbmRcIjp7XCJsaW5lXCI6MzEzLFwiY29sdW1uXCI6NX19LFwiMTM3XCI6e1wic3RhcnRcIjp7XCJsaW5lXCI6Mjg4LFwiY29sdW1uXCI6M30sXCJlbmRcIjp7XCJsaW5lXCI6MzEyLFwiY29sdW1uXCI6NH19LFwiMTM4XCI6e1wic3RhcnRcIjp7XCJsaW5lXCI6MjkwLFwiY29sdW1uXCI6NX0sXCJlbmRcIjp7XCJsaW5lXCI6MjkwLFwiY29sdW1uXCI6NDN9fSxcIjEzOVwiOntcInN0YXJ0XCI6e1wibGluZVwiOjI5MSxcImNvbHVtblwiOjV9LFwiZW5kXCI6e1wibGluZVwiOjI5MSxcImNvbHVtblwiOjExfX0sXCIxNDBcIjp7XCJzdGFydFwiOntcImxpbmVcIjoyOTMsXCJjb2x1bW5cIjo1fSxcImVuZFwiOntcImxpbmVcIjoyOTMsXCJjb2x1bW5cIjo2MH19LFwiMTQxXCI6e1wic3RhcnRcIjp7XCJsaW5lXCI6Mjk0LFwiY29sdW1uXCI6NX0sXCJlbmRcIjp7XCJsaW5lXCI6Mjk0LFwiY29sdW1uXCI6MTF9fSxcIjE0MlwiOntcInN0YXJ0XCI6e1wibGluZVwiOjI5NixcImNvbHVtblwiOjV9LFwiZW5kXCI6e1wibGluZVwiOjI5NixcImNvbHVtblwiOjUzfX0sXCIxNDNcIjp7XCJzdGFydFwiOntcImxpbmVcIjoyOTcsXCJjb2x1bW5cIjo1fSxcImVuZFwiOntcImxpbmVcIjoyOTksXCJjb2x1bW5cIjo2fX0sXCIxNDRcIjp7XCJzdGFydFwiOntcImxpbmVcIjoyOTgsXCJjb2x1bW5cIjo2fSxcImVuZFwiOntcImxpbmVcIjoyOTgsXCJjb2x1bW5cIjoxNX19LFwiMTQ1XCI6e1wic3RhcnRcIjp7XCJsaW5lXCI6MzAxLFwiY29sdW1uXCI6NX0sXCJlbmRcIjp7XCJsaW5lXCI6MzAxLFwiY29sdW1uXCI6Mzh9fSxcIjE0NlwiOntcInN0YXJ0XCI6e1wibGluZVwiOjMwMixcImNvbHVtblwiOjV9LFwiZW5kXCI6e1wibGluZVwiOjMwMixcImNvbHVtblwiOjM3fX0sXCIxNDdcIjp7XCJzdGFydFwiOntcImxpbmVcIjozMDMsXCJjb2x1bW5cIjo1fSxcImVuZFwiOntcImxpbmVcIjozMDMsXCJjb2x1bW5cIjozMn19LFwiMTQ4XCI6e1wic3RhcnRcIjp7XCJsaW5lXCI6MzA0LFwiY29sdW1uXCI6NX0sXCJlbmRcIjp7XCJsaW5lXCI6MzA0LFwiY29sdW1uXCI6NDV9fSxcIjE0OVwiOntcInN0YXJ0XCI6e1wibGluZVwiOjMwNSxcImNvbHVtblwiOjV9LFwiZW5kXCI6e1wibGluZVwiOjMwNSxcImNvbHVtblwiOjQ4fX0sXCIxNTBcIjp7XCJzdGFydFwiOntcImxpbmVcIjozMDYsXCJjb2x1bW5cIjo1fSxcImVuZFwiOntcImxpbmVcIjozMDYsXCJjb2x1bW5cIjoxMX19LFwiMTUxXCI6e1wic3RhcnRcIjp7XCJsaW5lXCI6MzA4LFwiY29sdW1uXCI6NX0sXCJlbmRcIjp7XCJsaW5lXCI6MzA4LFwiY29sdW1uXCI6NjB9fSxcIjE1MlwiOntcInN0YXJ0XCI6e1wibGluZVwiOjMwOSxcImNvbHVtblwiOjV9LFwiZW5kXCI6e1wibGluZVwiOjMwOSxcImNvbHVtblwiOjExfX0sXCIxNTNcIjp7XCJzdGFydFwiOntcImxpbmVcIjozMTEsXCJjb2x1bW5cIjo1fSxcImVuZFwiOntcImxpbmVcIjozMTEsXCJjb2x1bW5cIjo2MH19LFwiMTU0XCI6e1wic3RhcnRcIjp7XCJsaW5lXCI6MzE1LFwiY29sdW1uXCI6Mn0sXCJlbmRcIjp7XCJsaW5lXCI6MzU1LFwiY29sdW1uXCI6M319LFwiMTU1XCI6e1wic3RhcnRcIjp7XCJsaW5lXCI6MzE4LFwiY29sdW1uXCI6M30sXCJlbmRcIjp7XCJsaW5lXCI6MzI2LFwiY29sdW1uXCI6Nn19LFwiMTU2XCI6e1wic3RhcnRcIjp7XCJsaW5lXCI6MzE5LFwiY29sdW1uXCI6NH0sXCJlbmRcIjp7XCJsaW5lXCI6MzI1LFwiY29sdW1uXCI6NX19LFwiMTU3XCI6e1wic3RhcnRcIjp7XCJsaW5lXCI6MzIxLFwiY29sdW1uXCI6Nn0sXCJlbmRcIjp7XCJsaW5lXCI6MzIxLFwiY29sdW1uXCI6NTd9fSxcIjE1OFwiOntcInN0YXJ0XCI6e1wibGluZVwiOjMyMixcImNvbHVtblwiOjZ9LFwiZW5kXCI6e1wibGluZVwiOjMyMixcImNvbHVtblwiOjEyfX0sXCIxNTlcIjp7XCJzdGFydFwiOntcImxpbmVcIjozMjgsXCJjb2x1bW5cIjozfSxcImVuZFwiOntcImxpbmVcIjozMjgsXCJjb2x1bW5cIjoyMH19LFwiMTYwXCI6e1wic3RhcnRcIjp7XCJsaW5lXCI6MzI5LFwiY29sdW1uXCI6M30sXCJlbmRcIjp7XCJsaW5lXCI6MzUzLFwiY29sdW1uXCI6Nn19LFwiMTYxXCI6e1wic3RhcnRcIjp7XCJsaW5lXCI6MzMwLFwiY29sdW1uXCI6NH0sXCJlbmRcIjp7XCJsaW5lXCI6MzUyLFwiY29sdW1uXCI6NX19LFwiMTYyXCI6e1wic3RhcnRcIjp7XCJsaW5lXCI6MzMzLFwiY29sdW1uXCI6Nn0sXCJlbmRcIjp7XCJsaW5lXCI6MzMzLFwiY29sdW1uXCI6NTh9fSxcIjE2M1wiOntcInN0YXJ0XCI6e1wibGluZVwiOjMzNCxcImNvbHVtblwiOjZ9LFwiZW5kXCI6e1wibGluZVwiOjMzNCxcImNvbHVtblwiOjEyfX0sXCIxNjRcIjp7XCJzdGFydFwiOntcImxpbmVcIjozMzYsXCJjb2x1bW5cIjo2fSxcImVuZFwiOntcImxpbmVcIjozMzYsXCJjb2x1bW5cIjo1MX19LFwiMTY1XCI6e1wic3RhcnRcIjp7XCJsaW5lXCI6MzM3LFwiY29sdW1uXCI6Nn0sXCJlbmRcIjp7XCJsaW5lXCI6MzM3LFwiY29sdW1uXCI6Mzd9fSxcIjE2NlwiOntcInN0YXJ0XCI6e1wibGluZVwiOjMzOCxcImNvbHVtblwiOjZ9LFwiZW5kXCI6e1wibGluZVwiOjMzOCxcImNvbHVtblwiOjQwfX0sXCIxNjdcIjp7XCJzdGFydFwiOntcImxpbmVcIjozMzksXCJjb2x1bW5cIjo2fSxcImVuZFwiOntcImxpbmVcIjozMzksXCJjb2x1bW5cIjozM319LFwiMTY4XCI6e1wic3RhcnRcIjp7XCJsaW5lXCI6MzQwLFwiY29sdW1uXCI6Nn0sXCJlbmRcIjp7XCJsaW5lXCI6MzQwLFwiY29sdW1uXCI6NDZ9fSxcIjE2OVwiOntcInN0YXJ0XCI6e1wibGluZVwiOjM0MSxcImNvbHVtblwiOjZ9LFwiZW5kXCI6e1wibGluZVwiOjM0MSxcImNvbHVtblwiOjQ2fX0sXCIxNzBcIjp7XCJzdGFydFwiOntcImxpbmVcIjozNDUsXCJjb2x1bW5cIjo2fSxcImVuZFwiOntcImxpbmVcIjozNDUsXCJjb2x1bW5cIjoyNn19LFwiMTcxXCI6e1wic3RhcnRcIjp7XCJsaW5lXCI6MzQ2LFwiY29sdW1uXCI6Nn0sXCJlbmRcIjp7XCJsaW5lXCI6MzQ2LFwiY29sdW1uXCI6MTJ9fSxcIjE3MlwiOntcInN0YXJ0XCI6e1wibGluZVwiOjM0OCxcImNvbHVtblwiOjZ9LFwiZW5kXCI6e1wibGluZVwiOjM0OCxcImNvbHVtblwiOjQxfX0sXCIxNzNcIjp7XCJzdGFydFwiOntcImxpbmVcIjozNDksXCJjb2x1bW5cIjo2fSxcImVuZFwiOntcImxpbmVcIjozNDksXCJjb2x1bW5cIjoxMn19LFwiMTc0XCI6e1wic3RhcnRcIjp7XCJsaW5lXCI6MzU0LFwiY29sdW1uXCI6M30sXCJlbmRcIjp7XCJsaW5lXCI6MzU0LFwiY29sdW1uXCI6MTh9fSxcIjE3NVwiOntcInN0YXJ0XCI6e1wibGluZVwiOjM1NyxcImNvbHVtblwiOjJ9LFwiZW5kXCI6e1wibGluZVwiOjM1NyxcImNvbHVtblwiOjMyfX0sXCIxNzZcIjp7XCJzdGFydFwiOntcImxpbmVcIjozNTgsXCJjb2x1bW5cIjoyfSxcImVuZFwiOntcImxpbmVcIjozNTgsXCJjb2x1bW5cIjo1M319LFwiMTc3XCI6e1wic3RhcnRcIjp7XCJsaW5lXCI6MzYxLFwiY29sdW1uXCI6MX0sXCJlbmRcIjp7XCJsaW5lXCI6MzY2LFwiY29sdW1uXCI6Mn19LFwiMTc4XCI6e1wic3RhcnRcIjp7XCJsaW5lXCI6MzYyLFwiY29sdW1uXCI6Mn0sXCJlbmRcIjp7XCJsaW5lXCI6MzY1LFwiY29sdW1uXCI6NX19LFwiMTc5XCI6e1wic3RhcnRcIjp7XCJsaW5lXCI6MzYzLFwiY29sdW1uXCI6M30sXCJlbmRcIjp7XCJsaW5lXCI6MzYzLFwiY29sdW1uXCI6MzN9fSxcIjE4MFwiOntcInN0YXJ0XCI6e1wibGluZVwiOjM2NCxcImNvbHVtblwiOjN9LFwiZW5kXCI6e1wibGluZVwiOjM2NCxcImNvbHVtblwiOjQyfX0sXCIxODFcIjp7XCJzdGFydFwiOntcImxpbmVcIjozNjksXCJjb2x1bW5cIjoxfSxcImVuZFwiOntcImxpbmVcIjozNzEsXCJjb2x1bW5cIjo0fX0sXCIxODJcIjp7XCJzdGFydFwiOntcImxpbmVcIjozNzAsXCJjb2x1bW5cIjoyfSxcImVuZFwiOntcImxpbmVcIjozNzAsXCJjb2x1bW5cIjoyOX19LFwiMTgzXCI6e1wic3RhcnRcIjp7XCJsaW5lXCI6MzcyLFwiY29sdW1uXCI6MX0sXCJlbmRcIjp7XCJsaW5lXCI6Mzc0LFwiY29sdW1uXCI6NH19LFwiMTg0XCI6e1wic3RhcnRcIjp7XCJsaW5lXCI6MzczLFwiY29sdW1uXCI6Mn0sXCJlbmRcIjp7XCJsaW5lXCI6MzczLFwiY29sdW1uXCI6MjZ9fX0sXCJicmFuY2hNYXBcIjp7XCIxXCI6e1wibGluZVwiOjE5LFwidHlwZVwiOlwiaWZcIixcImxvY2F0aW9uc1wiOlt7XCJzdGFydFwiOntcImxpbmVcIjoxOSxcImNvbHVtblwiOjF9LFwiZW5kXCI6e1wibGluZVwiOjE5LFwiY29sdW1uXCI6MX19LHtcInN0YXJ0XCI6e1wibGluZVwiOjE5LFwiY29sdW1uXCI6MX0sXCJlbmRcIjp7XCJsaW5lXCI6MTksXCJjb2x1bW5cIjoxfX1dfSxcIjJcIjp7XCJsaW5lXCI6MTksXCJ0eXBlXCI6XCJiaW5hcnktZXhwclwiLFwibG9jYXRpb25zXCI6W3tcInN0YXJ0XCI6e1wibGluZVwiOjE5LFwiY29sdW1uXCI6NX0sXCJlbmRcIjp7XCJsaW5lXCI6MTksXCJjb2x1bW5cIjoxMH19LHtcInN0YXJ0XCI6e1wibGluZVwiOjE5LFwiY29sdW1uXCI6MTR9LFwiZW5kXCI6e1wibGluZVwiOjE5LFwiY29sdW1uXCI6Mzh9fV19LFwiM1wiOntcImxpbmVcIjoyMyxcInR5cGVcIjpcImlmXCIsXCJsb2NhdGlvbnNcIjpbe1wic3RhcnRcIjp7XCJsaW5lXCI6MjMsXCJjb2x1bW5cIjoxfSxcImVuZFwiOntcImxpbmVcIjoyMyxcImNvbHVtblwiOjF9fSx7XCJzdGFydFwiOntcImxpbmVcIjoyMyxcImNvbHVtblwiOjF9LFwiZW5kXCI6e1wibGluZVwiOjIzLFwiY29sdW1uXCI6MX19XX0sXCI0XCI6e1wibGluZVwiOjIzLFwidHlwZVwiOlwiYmluYXJ5LWV4cHJcIixcImxvY2F0aW9uc1wiOlt7XCJzdGFydFwiOntcImxpbmVcIjoyMyxcImNvbHVtblwiOjV9LFwiZW5kXCI6e1wibGluZVwiOjIzLFwiY29sdW1uXCI6MTJ9fSx7XCJzdGFydFwiOntcImxpbmVcIjoyMyxcImNvbHVtblwiOjE2fSxcImVuZFwiOntcImxpbmVcIjoyMyxcImNvbHVtblwiOjQyfX1dfSxcIjVcIjp7XCJsaW5lXCI6MzEsXCJ0eXBlXCI6XCJpZlwiLFwibG9jYXRpb25zXCI6W3tcInN0YXJ0XCI6e1wibGluZVwiOjMxLFwiY29sdW1uXCI6MX0sXCJlbmRcIjp7XCJsaW5lXCI6MzEsXCJjb2x1bW5cIjoxfX0se1wic3RhcnRcIjp7XCJsaW5lXCI6MzEsXCJjb2x1bW5cIjoxfSxcImVuZFwiOntcImxpbmVcIjozMSxcImNvbHVtblwiOjF9fV19LFwiNlwiOntcImxpbmVcIjozMixcInR5cGVcIjpcImlmXCIsXCJsb2NhdGlvbnNcIjpbe1wic3RhcnRcIjp7XCJsaW5lXCI6MzIsXCJjb2x1bW5cIjoyfSxcImVuZFwiOntcImxpbmVcIjozMixcImNvbHVtblwiOjJ9fSx7XCJzdGFydFwiOntcImxpbmVcIjozMixcImNvbHVtblwiOjJ9LFwiZW5kXCI6e1wibGluZVwiOjMyLFwiY29sdW1uXCI6Mn19XX0sXCI3XCI6e1wibGluZVwiOjQ0LFwidHlwZVwiOlwiYmluYXJ5LWV4cHJcIixcImxvY2F0aW9uc1wiOlt7XCJzdGFydFwiOntcImxpbmVcIjo0NCxcImNvbHVtblwiOjh9LFwiZW5kXCI6e1wibGluZVwiOjQ0LFwiY29sdW1uXCI6MTJ9fSx7XCJzdGFydFwiOntcImxpbmVcIjo0NCxcImNvbHVtblwiOjE2fSxcImVuZFwiOntcImxpbmVcIjo0NCxcImNvbHVtblwiOjE4fX1dfSxcIjhcIjp7XCJsaW5lXCI6NTEsXCJ0eXBlXCI6XCJpZlwiLFwibG9jYXRpb25zXCI6W3tcInN0YXJ0XCI6e1wibGluZVwiOjUxLFwiY29sdW1uXCI6MX0sXCJlbmRcIjp7XCJsaW5lXCI6NTEsXCJjb2x1bW5cIjoxfX0se1wic3RhcnRcIjp7XCJsaW5lXCI6NTEsXCJjb2x1bW5cIjoxfSxcImVuZFwiOntcImxpbmVcIjo1MSxcImNvbHVtblwiOjF9fV19LFwiOVwiOntcImxpbmVcIjo2MSxcInR5cGVcIjpcImlmXCIsXCJsb2NhdGlvbnNcIjpbe1wic3RhcnRcIjp7XCJsaW5lXCI6NjEsXCJjb2x1bW5cIjoyfSxcImVuZFwiOntcImxpbmVcIjo2MSxcImNvbHVtblwiOjJ9fSx7XCJzdGFydFwiOntcImxpbmVcIjo2MSxcImNvbHVtblwiOjJ9LFwiZW5kXCI6e1wibGluZVwiOjYxLFwiY29sdW1uXCI6Mn19XX0sXCIxMFwiOntcImxpbmVcIjo2MSxcInR5cGVcIjpcImJpbmFyeS1leHByXCIsXCJsb2NhdGlvbnNcIjpbe1wic3RhcnRcIjp7XCJsaW5lXCI6NjEsXCJjb2x1bW5cIjo2fSxcImVuZFwiOntcImxpbmVcIjo2MSxcImNvbHVtblwiOjI0fX0se1wic3RhcnRcIjp7XCJsaW5lXCI6NjEsXCJjb2x1bW5cIjoyOH0sXCJlbmRcIjp7XCJsaW5lXCI6NjEsXCJjb2x1bW5cIjo1NH19XX0sXCIxMVwiOntcImxpbmVcIjo4NixcInR5cGVcIjpcImlmXCIsXCJsb2NhdGlvbnNcIjpbe1wic3RhcnRcIjp7XCJsaW5lXCI6ODYsXCJjb2x1bW5cIjozfSxcImVuZFwiOntcImxpbmVcIjo4NixcImNvbHVtblwiOjN9fSx7XCJzdGFydFwiOntcImxpbmVcIjo4NixcImNvbHVtblwiOjN9LFwiZW5kXCI6e1wibGluZVwiOjg2LFwiY29sdW1uXCI6M319XX0sXCIxMlwiOntcImxpbmVcIjo5MyxcInR5cGVcIjpcImlmXCIsXCJsb2NhdGlvbnNcIjpbe1wic3RhcnRcIjp7XCJsaW5lXCI6OTMsXCJjb2x1bW5cIjozfSxcImVuZFwiOntcImxpbmVcIjo5MyxcImNvbHVtblwiOjN9fSx7XCJzdGFydFwiOntcImxpbmVcIjo5MyxcImNvbHVtblwiOjN9LFwiZW5kXCI6e1wibGluZVwiOjkzLFwiY29sdW1uXCI6M319XX0sXCIxM1wiOntcImxpbmVcIjoxMTMsXCJ0eXBlXCI6XCJpZlwiLFwibG9jYXRpb25zXCI6W3tcInN0YXJ0XCI6e1wibGluZVwiOjExMyxcImNvbHVtblwiOjJ9LFwiZW5kXCI6e1wibGluZVwiOjExMyxcImNvbHVtblwiOjJ9fSx7XCJzdGFydFwiOntcImxpbmVcIjoxMTMsXCJjb2x1bW5cIjoyfSxcImVuZFwiOntcImxpbmVcIjoxMTMsXCJjb2x1bW5cIjoyfX1dfSxcIjE0XCI6e1wibGluZVwiOjExMyxcInR5cGVcIjpcImJpbmFyeS1leHByXCIsXCJsb2NhdGlvbnNcIjpbe1wic3RhcnRcIjp7XCJsaW5lXCI6MTEzLFwiY29sdW1uXCI6Nn0sXCJlbmRcIjp7XCJsaW5lXCI6MTEzLFwiY29sdW1uXCI6MzJ9fSx7XCJzdGFydFwiOntcImxpbmVcIjoxMTMsXCJjb2x1bW5cIjozNn0sXCJlbmRcIjp7XCJsaW5lXCI6MTEzLFwiY29sdW1uXCI6NjN9fV19LFwiMTVcIjp7XCJsaW5lXCI6MTI3LFwidHlwZVwiOlwiaWZcIixcImxvY2F0aW9uc1wiOlt7XCJzdGFydFwiOntcImxpbmVcIjoxMjcsXCJjb2x1bW5cIjo0fSxcImVuZFwiOntcImxpbmVcIjoxMjcsXCJjb2x1bW5cIjo0fX0se1wic3RhcnRcIjp7XCJsaW5lXCI6MTI3LFwiY29sdW1uXCI6NH0sXCJlbmRcIjp7XCJsaW5lXCI6MTI3LFwiY29sdW1uXCI6NH19XX0sXCIxNlwiOntcImxpbmVcIjoxMjcsXCJ0eXBlXCI6XCJiaW5hcnktZXhwclwiLFwibG9jYXRpb25zXCI6W3tcInN0YXJ0XCI6e1wibGluZVwiOjEyNyxcImNvbHVtblwiOjh9LFwiZW5kXCI6e1wibGluZVwiOjEyNyxcImNvbHVtblwiOjM5fX0se1wic3RhcnRcIjp7XCJsaW5lXCI6MTI3LFwiY29sdW1uXCI6NDN9LFwiZW5kXCI6e1wibGluZVwiOjEyNyxcImNvbHVtblwiOjY4fX1dfSxcIjE3XCI6e1wibGluZVwiOjEzNixcInR5cGVcIjpcImlmXCIsXCJsb2NhdGlvbnNcIjpbe1wic3RhcnRcIjp7XCJsaW5lXCI6MTM2LFwiY29sdW1uXCI6NH0sXCJlbmRcIjp7XCJsaW5lXCI6MTM2LFwiY29sdW1uXCI6NH19LHtcInN0YXJ0XCI6e1wibGluZVwiOjEzNixcImNvbHVtblwiOjR9LFwiZW5kXCI6e1wibGluZVwiOjEzNixcImNvbHVtblwiOjR9fV19LFwiMThcIjp7XCJsaW5lXCI6MTM4LFwidHlwZVwiOlwiaWZcIixcImxvY2F0aW9uc1wiOlt7XCJzdGFydFwiOntcImxpbmVcIjoxMzgsXCJjb2x1bW5cIjoxMX0sXCJlbmRcIjp7XCJsaW5lXCI6MTM4LFwiY29sdW1uXCI6MTF9fSx7XCJzdGFydFwiOntcImxpbmVcIjoxMzgsXCJjb2x1bW5cIjoxMX0sXCJlbmRcIjp7XCJsaW5lXCI6MTM4LFwiY29sdW1uXCI6MTF9fV19LFwiMTlcIjp7XCJsaW5lXCI6MTU0LFwidHlwZVwiOlwiaWZcIixcImxvY2F0aW9uc1wiOlt7XCJzdGFydFwiOntcImxpbmVcIjoxNTQsXCJjb2x1bW5cIjoyfSxcImVuZFwiOntcImxpbmVcIjoxNTQsXCJjb2x1bW5cIjoyfX0se1wic3RhcnRcIjp7XCJsaW5lXCI6MTU0LFwiY29sdW1uXCI6Mn0sXCJlbmRcIjp7XCJsaW5lXCI6MTU0LFwiY29sdW1uXCI6Mn19XX0sXCIyMFwiOntcImxpbmVcIjoxNjEsXCJ0eXBlXCI6XCJpZlwiLFwibG9jYXRpb25zXCI6W3tcInN0YXJ0XCI6e1wibGluZVwiOjE2MSxcImNvbHVtblwiOjJ9LFwiZW5kXCI6e1wibGluZVwiOjE2MSxcImNvbHVtblwiOjJ9fSx7XCJzdGFydFwiOntcImxpbmVcIjoxNjEsXCJjb2x1bW5cIjoyfSxcImVuZFwiOntcImxpbmVcIjoxNjEsXCJjb2x1bW5cIjoyfX1dfSxcIjIxXCI6e1wibGluZVwiOjE2MSxcInR5cGVcIjpcImJpbmFyeS1leHByXCIsXCJsb2NhdGlvbnNcIjpbe1wic3RhcnRcIjp7XCJsaW5lXCI6MTYxLFwiY29sdW1uXCI6Nn0sXCJlbmRcIjp7XCJsaW5lXCI6MTYxLFwiY29sdW1uXCI6MzF9fSx7XCJzdGFydFwiOntcImxpbmVcIjoxNjEsXCJjb2x1bW5cIjozNX0sXCJlbmRcIjp7XCJsaW5lXCI6MTYxLFwiY29sdW1uXCI6NDl9fV19LFwiMjJcIjp7XCJsaW5lXCI6MTkxLFwidHlwZVwiOlwiaWZcIixcImxvY2F0aW9uc1wiOlt7XCJzdGFydFwiOntcImxpbmVcIjoxOTEsXCJjb2x1bW5cIjozfSxcImVuZFwiOntcImxpbmVcIjoxOTEsXCJjb2x1bW5cIjozfX0se1wic3RhcnRcIjp7XCJsaW5lXCI6MTkxLFwiY29sdW1uXCI6M30sXCJlbmRcIjp7XCJsaW5lXCI6MTkxLFwiY29sdW1uXCI6M319XX0sXCIyM1wiOntcImxpbmVcIjoxOTEsXCJ0eXBlXCI6XCJiaW5hcnktZXhwclwiLFwibG9jYXRpb25zXCI6W3tcInN0YXJ0XCI6e1wibGluZVwiOjE5MSxcImNvbHVtblwiOjd9LFwiZW5kXCI6e1wibGluZVwiOjE5MSxcImNvbHVtblwiOjI0fX0se1wic3RhcnRcIjp7XCJsaW5lXCI6MTkxLFwiY29sdW1uXCI6Mjh9LFwiZW5kXCI6e1wibGluZVwiOjE5MSxcImNvbHVtblwiOjQyfX1dfSxcIjI0XCI6e1wibGluZVwiOjE5NixcInR5cGVcIjpcInN3aXRjaFwiLFwibG9jYXRpb25zXCI6W3tcInN0YXJ0XCI6e1wibGluZVwiOjE5NyxcImNvbHVtblwiOjR9LFwiZW5kXCI6e1wibGluZVwiOjIwMyxcImNvbHVtblwiOjExfX0se1wic3RhcnRcIjp7XCJsaW5lXCI6MjA0LFwiY29sdW1uXCI6NH0sXCJlbmRcIjp7XCJsaW5lXCI6MjExLFwiY29sdW1uXCI6MTF9fSx7XCJzdGFydFwiOntcImxpbmVcIjoyMTIsXCJjb2x1bW5cIjo0fSxcImVuZFwiOntcImxpbmVcIjoyMjIsXCJjb2x1bW5cIjoxMX19LHtcInN0YXJ0XCI6e1wibGluZVwiOjIyMyxcImNvbHVtblwiOjR9LFwiZW5kXCI6e1wibGluZVwiOjIyOSxcImNvbHVtblwiOjExfX0se1wic3RhcnRcIjp7XCJsaW5lXCI6MjMwLFwiY29sdW1uXCI6NH0sXCJlbmRcIjp7XCJsaW5lXCI6MjM0LFwiY29sdW1uXCI6OH19XX0sXCIyNVwiOntcImxpbmVcIjoyMzgsXCJ0eXBlXCI6XCJpZlwiLFwibG9jYXRpb25zXCI6W3tcInN0YXJ0XCI6e1wibGluZVwiOjIzOCxcImNvbHVtblwiOjJ9LFwiZW5kXCI6e1wibGluZVwiOjIzOCxcImNvbHVtblwiOjJ9fSx7XCJzdGFydFwiOntcImxpbmVcIjoyMzgsXCJjb2x1bW5cIjoyfSxcImVuZFwiOntcImxpbmVcIjoyMzgsXCJjb2x1bW5cIjoyfX1dfSxcIjI2XCI6e1wibGluZVwiOjI0NixcInR5cGVcIjpcImlmXCIsXCJsb2NhdGlvbnNcIjpbe1wic3RhcnRcIjp7XCJsaW5lXCI6MjQ2LFwiY29sdW1uXCI6Mn0sXCJlbmRcIjp7XCJsaW5lXCI6MjQ2LFwiY29sdW1uXCI6Mn19LHtcInN0YXJ0XCI6e1wibGluZVwiOjI0NixcImNvbHVtblwiOjJ9LFwiZW5kXCI6e1wibGluZVwiOjI0NixcImNvbHVtblwiOjJ9fV19LFwiMjdcIjp7XCJsaW5lXCI6MjQ2LFwidHlwZVwiOlwiYmluYXJ5LWV4cHJcIixcImxvY2F0aW9uc1wiOlt7XCJzdGFydFwiOntcImxpbmVcIjoyNDYsXCJjb2x1bW5cIjo2fSxcImVuZFwiOntcImxpbmVcIjoyNDYsXCJjb2x1bW5cIjozMX19LHtcInN0YXJ0XCI6e1wibGluZVwiOjI0NixcImNvbHVtblwiOjM1fSxcImVuZFwiOntcImxpbmVcIjoyNDYsXCJjb2x1bW5cIjo0OX19XX0sXCIyOFwiOntcImxpbmVcIjoyNTMsXCJ0eXBlXCI6XCJpZlwiLFwibG9jYXRpb25zXCI6W3tcInN0YXJ0XCI6e1wibGluZVwiOjI1MyxcImNvbHVtblwiOjJ9LFwiZW5kXCI6e1wibGluZVwiOjI1MyxcImNvbHVtblwiOjJ9fSx7XCJzdGFydFwiOntcImxpbmVcIjoyNTMsXCJjb2x1bW5cIjoyfSxcImVuZFwiOntcImxpbmVcIjoyNTMsXCJjb2x1bW5cIjoyfX1dfSxcIjI5XCI6e1wibGluZVwiOjI1MyxcInR5cGVcIjpcImJpbmFyeS1leHByXCIsXCJsb2NhdGlvbnNcIjpbe1wic3RhcnRcIjp7XCJsaW5lXCI6MjUzLFwiY29sdW1uXCI6Nn0sXCJlbmRcIjp7XCJsaW5lXCI6MjUzLFwiY29sdW1uXCI6MjR9fSx7XCJzdGFydFwiOntcImxpbmVcIjoyNTMsXCJjb2x1bW5cIjoyOH0sXCJlbmRcIjp7XCJsaW5lXCI6MjUzLFwiY29sdW1uXCI6NTB9fV19LFwiMzBcIjp7XCJsaW5lXCI6MjU5LFwidHlwZVwiOlwiaWZcIixcImxvY2F0aW9uc1wiOlt7XCJzdGFydFwiOntcImxpbmVcIjoyNTksXCJjb2x1bW5cIjoyfSxcImVuZFwiOntcImxpbmVcIjoyNTksXCJjb2x1bW5cIjoyfX0se1wic3RhcnRcIjp7XCJsaW5lXCI6MjU5LFwiY29sdW1uXCI6Mn0sXCJlbmRcIjp7XCJsaW5lXCI6MjU5LFwiY29sdW1uXCI6Mn19XX0sXCIzMVwiOntcImxpbmVcIjoyNjksXCJ0eXBlXCI6XCJpZlwiLFwibG9jYXRpb25zXCI6W3tcInN0YXJ0XCI6e1wibGluZVwiOjI2OSxcImNvbHVtblwiOjJ9LFwiZW5kXCI6e1wibGluZVwiOjI2OSxcImNvbHVtblwiOjJ9fSx7XCJzdGFydFwiOntcImxpbmVcIjoyNjksXCJjb2x1bW5cIjoyfSxcImVuZFwiOntcImxpbmVcIjoyNjksXCJjb2x1bW5cIjoyfX1dfSxcIjMyXCI6e1wibGluZVwiOjI3MyxcInR5cGVcIjpcImlmXCIsXCJsb2NhdGlvbnNcIjpbe1wic3RhcnRcIjp7XCJsaW5lXCI6MjczLFwiY29sdW1uXCI6Mn0sXCJlbmRcIjp7XCJsaW5lXCI6MjczLFwiY29sdW1uXCI6Mn19LHtcInN0YXJ0XCI6e1wibGluZVwiOjI3MyxcImNvbHVtblwiOjJ9LFwiZW5kXCI6e1wibGluZVwiOjI3MyxcImNvbHVtblwiOjJ9fV19LFwiMzNcIjp7XCJsaW5lXCI6MjczLFwidHlwZVwiOlwiYmluYXJ5LWV4cHJcIixcImxvY2F0aW9uc1wiOlt7XCJzdGFydFwiOntcImxpbmVcIjoyNzMsXCJjb2x1bW5cIjo2fSxcImVuZFwiOntcImxpbmVcIjoyNzMsXCJjb2x1bW5cIjoyNH19LHtcInN0YXJ0XCI6e1wibGluZVwiOjI3MyxcImNvbHVtblwiOjI4fSxcImVuZFwiOntcImxpbmVcIjoyNzMsXCJjb2x1bW5cIjo1MH19XX0sXCIzNFwiOntcImxpbmVcIjoyNzUsXCJ0eXBlXCI6XCJpZlwiLFwibG9jYXRpb25zXCI6W3tcInN0YXJ0XCI6e1wibGluZVwiOjI3NSxcImNvbHVtblwiOjl9LFwiZW5kXCI6e1wibGluZVwiOjI3NSxcImNvbHVtblwiOjl9fSx7XCJzdGFydFwiOntcImxpbmVcIjoyNzUsXCJjb2x1bW5cIjo5fSxcImVuZFwiOntcImxpbmVcIjoyNzUsXCJjb2x1bW5cIjo5fX1dfSxcIjM1XCI6e1wibGluZVwiOjI4OCxcInR5cGVcIjpcInN3aXRjaFwiLFwibG9jYXRpb25zXCI6W3tcInN0YXJ0XCI6e1wibGluZVwiOjI4OSxcImNvbHVtblwiOjR9LFwiZW5kXCI6e1wibGluZVwiOjI5MSxcImNvbHVtblwiOjExfX0se1wic3RhcnRcIjp7XCJsaW5lXCI6MjkyLFwiY29sdW1uXCI6NH0sXCJlbmRcIjp7XCJsaW5lXCI6Mjk0LFwiY29sdW1uXCI6MTF9fSx7XCJzdGFydFwiOntcImxpbmVcIjoyOTUsXCJjb2x1bW5cIjo0fSxcImVuZFwiOntcImxpbmVcIjozMDYsXCJjb2x1bW5cIjoxMX19LHtcInN0YXJ0XCI6e1wibGluZVwiOjMwNyxcImNvbHVtblwiOjR9LFwiZW5kXCI6e1wibGluZVwiOjMwOSxcImNvbHVtblwiOjExfX0se1wic3RhcnRcIjp7XCJsaW5lXCI6MzEwLFwiY29sdW1uXCI6NH0sXCJlbmRcIjp7XCJsaW5lXCI6MzExLFwiY29sdW1uXCI6NjB9fV19LFwiMzZcIjp7XCJsaW5lXCI6Mjk3LFwidHlwZVwiOlwiaWZcIixcImxvY2F0aW9uc1wiOlt7XCJzdGFydFwiOntcImxpbmVcIjoyOTcsXCJjb2x1bW5cIjo1fSxcImVuZFwiOntcImxpbmVcIjoyOTcsXCJjb2x1bW5cIjo1fX0se1wic3RhcnRcIjp7XCJsaW5lXCI6Mjk3LFwiY29sdW1uXCI6NX0sXCJlbmRcIjp7XCJsaW5lXCI6Mjk3LFwiY29sdW1uXCI6NX19XX0sXCIzN1wiOntcImxpbmVcIjozMTUsXCJ0eXBlXCI6XCJpZlwiLFwibG9jYXRpb25zXCI6W3tcInN0YXJ0XCI6e1wibGluZVwiOjMxNSxcImNvbHVtblwiOjJ9LFwiZW5kXCI6e1wibGluZVwiOjMxNSxcImNvbHVtblwiOjJ9fSx7XCJzdGFydFwiOntcImxpbmVcIjozMTUsXCJjb2x1bW5cIjoyfSxcImVuZFwiOntcImxpbmVcIjozMTUsXCJjb2x1bW5cIjoyfX1dfSxcIjM4XCI6e1wibGluZVwiOjMxOSxcInR5cGVcIjpcInN3aXRjaFwiLFwibG9jYXRpb25zXCI6W3tcInN0YXJ0XCI6e1wibGluZVwiOjMyMCxcImNvbHVtblwiOjV9LFwiZW5kXCI6e1wibGluZVwiOjMyMixcImNvbHVtblwiOjEyfX0se1wic3RhcnRcIjp7XCJsaW5lXCI6MzIzLFwiY29sdW1uXCI6NX0sXCJlbmRcIjp7XCJsaW5lXCI6MzIzLFwiY29sdW1uXCI6MTN9fV19LFwiMzlcIjp7XCJsaW5lXCI6MzMwLFwidHlwZVwiOlwic3dpdGNoXCIsXCJsb2NhdGlvbnNcIjpbe1wic3RhcnRcIjp7XCJsaW5lXCI6MzMxLFwiY29sdW1uXCI6NX0sXCJlbmRcIjp7XCJsaW5lXCI6MzMxLFwiY29sdW1uXCI6MTZ9fSx7XCJzdGFydFwiOntcImxpbmVcIjozMzIsXCJjb2x1bW5cIjo1fSxcImVuZFwiOntcImxpbmVcIjozMzQsXCJjb2x1bW5cIjoxMn19LHtcInN0YXJ0XCI6e1wibGluZVwiOjMzNSxcImNvbHVtblwiOjV9LFwiZW5kXCI6e1wibGluZVwiOjM0NixcImNvbHVtblwiOjEyfX0se1wic3RhcnRcIjp7XCJsaW5lXCI6MzQ3LFwiY29sdW1uXCI6NX0sXCJlbmRcIjp7XCJsaW5lXCI6MzQ5LFwiY29sdW1uXCI6MTJ9fSx7XCJzdGFydFwiOntcImxpbmVcIjozNTAsXCJjb2x1bW5cIjo1fSxcImVuZFwiOntcImxpbmVcIjozNTAsXCJjb2x1bW5cIjoxM319XX19fTtcbn1cbl9fY292XzRmZFYwSlhlYzVjY2hxRFR0XzF2encgPSBfX2Nvdl80ZmRWMEpYZWM1Y2NocURUdF8xdnp3WydHOlxcXFxQcm9ncmFtbWluZ1xcXFxub2RlY2dcXFxcbGliXFxcXGJyb3dzZXJcXFxccmVwbGljYW50LmpzJ107XG5fX2Nvdl80ZmRWMEpYZWM1Y2NocURUdF8xdnp3LnNbJzEnXSsrO3ZhciBpbmhlcml0cz1yZXF1aXJlKCdpbmhlcml0cycpO19fY292XzRmZFYwSlhlYzVjY2hxRFR0XzF2encuc1snMiddKys7dmFyIEV2ZW50RW1pdHRlcj1yZXF1aXJlKCdldmVudHMnKS5FdmVudEVtaXR0ZXI7X19jb3ZfNGZkVjBKWGVjNWNjaHFEVHRfMXZ6dy5zWyczJ10rKzt2YXIgTmVzdGVkPXJlcXVpcmUoJ25lc3RlZC1vYnNlcnZlJyk7X19jb3ZfNGZkVjBKWGVjNWNjaHFEVHRfMXZ6dy5zWyc0J10rKzt2YXIgb2JqZWN0UGF0aD1yZXF1aXJlKCdvYmplY3QtcGF0aCcpO19fY292XzRmZFYwSlhlYzVjY2hxRFR0XzF2encuc1snNSddKys7dmFyIGVxdWFsPXJlcXVpcmUoJ2RlZXAtZXF1YWwnKTtfX2Nvdl80ZmRWMEpYZWM1Y2NocURUdF8xdnp3LnNbJzYnXSsrO3ZhciBjbG9uZT1yZXF1aXJlKCdjbG9uZScpO19fY292XzRmZFYwSlhlYzVjY2hxRFR0XzF2encuc1snNyddKys7dmFyIHV1aWQ9cmVxdWlyZSgndXVpZCcpO19fY292XzRmZFYwSlhlYzVjY2hxRFR0XzF2encuc1snOCddKys7dmFyIGRlY2xhcmVkUmVwbGljYW50cz17fTtfX2Nvdl80ZmRWMEpYZWM1Y2NocURUdF8xdnp3LnNbJzknXSsrO2luaGVyaXRzKFJlcGxpY2FudCxFdmVudEVtaXR0ZXIpO19fY292XzRmZFYwSlhlYzVjY2hxRFR0XzF2encuc1snMTAnXSsrO21vZHVsZS5leHBvcnRzPVJlcGxpY2FudDtfX2Nvdl80ZmRWMEpYZWM1Y2NocURUdF8xdnp3LnNbJzExJ10rKztSZXBsaWNhbnQuZGVjbGFyZWRSZXBsaWNhbnRzPWRlY2xhcmVkUmVwbGljYW50cztmdW5jdGlvbiBSZXBsaWNhbnQobmFtZSxidW5kbGUsb3B0cyxzb2NrZXQpe19fY292XzRmZFYwSlhlYzVjY2hxRFR0XzF2encuZlsnMSddKys7X19jb3ZfNGZkVjBKWGVjNWNjaHFEVHRfMXZ6dy5zWycxMyddKys7aWYoKF9fY292XzRmZFYwSlhlYzVjY2hxRFR0XzF2encuYlsnMiddWzBdKyssIW5hbWUpfHwoX19jb3ZfNGZkVjBKWGVjNWNjaHFEVHRfMXZ6dy5iWycyJ11bMV0rKyx0eXBlb2YgbmFtZSE9PSdzdHJpbmcnKSl7X19jb3ZfNGZkVjBKWGVjNWNjaHFEVHRfMXZ6dy5iWycxJ11bMF0rKztfX2Nvdl80ZmRWMEpYZWM1Y2NocURUdF8xdnp3LnNbJzE0J10rKzt0aHJvdyBuZXcgRXJyb3IoJ011c3Qgc3VwcGx5IGEgbmFtZSB3aGVuIGluc3RhbnRpYXRpbmcgYSBSZXBsaWNhbnQnKTt9ZWxzZXtfX2Nvdl80ZmRWMEpYZWM1Y2NocURUdF8xdnp3LmJbJzEnXVsxXSsrO31fX2Nvdl80ZmRWMEpYZWM1Y2NocURUdF8xdnp3LnNbJzE1J10rKztpZigoX19jb3ZfNGZkVjBKWGVjNWNjaHFEVHRfMXZ6dy5iWyc0J11bMF0rKywhYnVuZGxlKXx8KF9fY292XzRmZFYwSlhlYzVjY2hxRFR0XzF2encuYlsnNCddWzFdKyssdHlwZW9mIGJ1bmRsZSE9PSdzdHJpbmcnKSl7X19jb3ZfNGZkVjBKWGVjNWNjaHFEVHRfMXZ6dy5iWyczJ11bMF0rKztfX2Nvdl80ZmRWMEpYZWM1Y2NocURUdF8xdnp3LnNbJzE2J10rKzt0aHJvdyBuZXcgRXJyb3IoJ011c3Qgc3VwcGx5IGEgYnVuZGxlIG5hbWUgd2hlbiBpbnN0YW50aWF0aW5nIGEgUmVwbGljYW50Jyk7fWVsc2V7X19jb3ZfNGZkVjBKWGVjNWNjaHFEVHRfMXZ6dy5iWyczJ11bMV0rKzt9X19jb3ZfNGZkVjBKWGVjNWNjaHFEVHRfMXZ6dy5zWycxNyddKys7dmFyIGxvZz1yZXF1aXJlKCcuL2xvZ2dlcicpKCdSZXBsaWNhbnQvJytidW5kbGUrJy4nK25hbWUpO19fY292XzRmZFYwSlhlYzVjY2hxRFR0XzF2encuc1snMTgnXSsrO2lmKGRlY2xhcmVkUmVwbGljYW50cy5oYXNPd25Qcm9wZXJ0eShidW5kbGUpKXtfX2Nvdl80ZmRWMEpYZWM1Y2NocURUdF8xdnp3LmJbJzUnXVswXSsrO19fY292XzRmZFYwSlhlYzVjY2hxRFR0XzF2encuc1snMTknXSsrO2lmKGRlY2xhcmVkUmVwbGljYW50c1tidW5kbGVdLmhhc093blByb3BlcnR5KG5hbWUpKXtfX2Nvdl80ZmRWMEpYZWM1Y2NocURUdF8xdnp3LmJbJzYnXVswXSsrO19fY292XzRmZFYwSlhlYzVjY2hxRFR0XzF2encuc1snMjAnXSsrO3JldHVybiBkZWNsYXJlZFJlcGxpY2FudHNbYnVuZGxlXVtuYW1lXTt9ZWxzZXtfX2Nvdl80ZmRWMEpYZWM1Y2NocURUdF8xdnp3LmJbJzYnXVsxXSsrO31fX2Nvdl80ZmRWMEpYZWM1Y2NocURUdF8xdnp3LnNbJzIxJ10rKztkZWNsYXJlZFJlcGxpY2FudHNbYnVuZGxlXVtuYW1lXT10aGlzO31lbHNle19fY292XzRmZFYwSlhlYzVjY2hxRFR0XzF2encuYlsnNSddWzFdKys7X19jb3ZfNGZkVjBKWGVjNWNjaHFEVHRfMXZ6dy5zWycyMiddKys7ZGVjbGFyZWRSZXBsaWNhbnRzW2J1bmRsZV09e307X19jb3ZfNGZkVjBKWGVjNWNjaHFEVHRfMXZ6dy5zWycyMyddKys7ZGVjbGFyZWRSZXBsaWNhbnRzW2J1bmRsZV1bbmFtZV09dGhpczt9X19jb3ZfNGZkVjBKWGVjNWNjaHFEVHRfMXZ6dy5zWycyNCddKys7dmFyIHNlbGY9dGhpcztfX2Nvdl80ZmRWMEpYZWM1Y2NocURUdF8xdnp3LnNbJzI1J10rKzt2YXIgdmFsdWU7X19jb3ZfNGZkVjBKWGVjNWNjaHFEVHRfMXZ6dy5zWycyNiddKys7b3B0cz0oX19jb3ZfNGZkVjBKWGVjNWNjaHFEVHRfMXZ6dy5iWyc3J11bMF0rKyxvcHRzKXx8KF9fY292XzRmZFYwSlhlYzVjY2hxRFR0XzF2encuYlsnNyddWzFdKysse30pO19fY292XzRmZFYwSlhlYzVjY2hxRFR0XzF2encuc1snMjcnXSsrO3RoaXMubmFtZT1uYW1lO19fY292XzRmZFYwSlhlYzVjY2hxRFR0XzF2encuc1snMjgnXSsrO3RoaXMuYnVuZGxlPWJ1bmRsZTtfX2Nvdl80ZmRWMEpYZWM1Y2NocURUdF8xdnp3LnNbJzI5J10rKzt0aGlzLm9wdHM9b3B0cztfX2Nvdl80ZmRWMEpYZWM1Y2NocURUdF8xdnp3LnNbJzMwJ10rKzt0aGlzLnJldmlzaW9uPTA7X19jb3ZfNGZkVjBKWGVjNWNjaHFEVHRfMXZ6dy5zWyczMSddKys7dGhpcy5zdGF0dXM9J3VuZGVjbGFyZWQnO19fY292XzRmZFYwSlhlYzVjY2hxRFR0XzF2encuc1snMzInXSsrO3RoaXMuaWQ9dXVpZC52NCgpO19fY292XzRmZFYwSlhlYzVjY2hxRFR0XzF2encuc1snMzMnXSsrO2lmKHR5cGVvZiBvcHRzLnBlcnNpc3RlbnQ9PT0ndW5kZWZpbmVkJyl7X19jb3ZfNGZkVjBKWGVjNWNjaHFEVHRfMXZ6dy5iWyc4J11bMF0rKztfX2Nvdl80ZmRWMEpYZWM1Y2NocURUdF8xdnp3LnNbJzM0J10rKztvcHRzLnBlcnNpc3RlbnQ9dHJ1ZTt9ZWxzZXtfX2Nvdl80ZmRWMEpYZWM1Y2NocURUdF8xdnp3LmJbJzgnXVsxXSsrO31fX2Nvdl80ZmRWMEpYZWM1Y2NocURUdF8xdnp3LnNbJzM1J10rKzt0aGlzLm9uKCduZXdMaXN0ZW5lcicsZnVuY3Rpb24oZXZlbnQsbGlzdGVuZXIpe19fY292XzRmZFYwSlhlYzVjY2hxRFR0XzF2encuZlsnMiddKys7X19jb3ZfNGZkVjBKWGVjNWNjaHFEVHRfMXZ6dy5zWyczNiddKys7aWYoKF9fY292XzRmZFYwSlhlYzVjY2hxRFR0XzF2encuYlsnMTAnXVswXSsrLGV2ZW50PT09J2NoYW5nZScpJiYoX19jb3ZfNGZkVjBKWGVjNWNjaHFEVHRfMXZ6dy5iWycxMCddWzFdKyssc2VsZi5zdGF0dXM9PT0nZGVjbGFyZWQnKSl7X19jb3ZfNGZkVjBKWGVjNWNjaHFEVHRfMXZ6dy5iWyc5J11bMF0rKztfX2Nvdl80ZmRWMEpYZWM1Y2NocURUdF8xdnp3LnNbJzM3J10rKztsaXN0ZW5lcih1bmRlZmluZWQsdmFsdWUpO31lbHNle19fY292XzRmZFYwSlhlYzVjY2hxRFR0XzF2encuYlsnOSddWzFdKys7fX0pO19fY292XzRmZFYwSlhlYzVjY2hxRFR0XzF2encuc1snMzgnXSsrO3ZhciBxdWV1ZT1bXTtmdW5jdGlvbiBhZGRUb1F1ZXVlKGZuLGFyZ3Mpe19fY292XzRmZFYwSlhlYzVjY2hxRFR0XzF2encuZlsnMyddKys7X19jb3ZfNGZkVjBKWGVjNWNjaHFEVHRfMXZ6dy5zWyc0MCddKys7cXVldWUucHVzaCh7Zm46Zm4sYXJnczphcmdzfSk7fWZ1bmN0aW9uIHByb2Nlc3NRdWV1ZSgpe19fY292XzRmZFYwSlhlYzVjY2hxRFR0XzF2encuZlsnNCddKys7X19jb3ZfNGZkVjBKWGVjNWNjaHFEVHRfMXZ6dy5zWyc0MiddKys7cXVldWUuZm9yRWFjaChmdW5jdGlvbihpdGVtKXtfX2Nvdl80ZmRWMEpYZWM1Y2NocURUdF8xdnp3LmZbJzUnXSsrO19fY292XzRmZFYwSlhlYzVjY2hxRFR0XzF2encuc1snNDMnXSsrO2l0ZW0uZm4uYXBwbHkodGhpcyxpdGVtLmFyZ3MpO30pO31fX2Nvdl80ZmRWMEpYZWM1Y2NocURUdF8xdnp3LnNbJzQ0J10rKztPYmplY3QuZGVmaW5lUHJvcGVydHkodGhpcywndmFsdWUnLHtnZXQ6ZnVuY3Rpb24oKXtfX2Nvdl80ZmRWMEpYZWM1Y2NocURUdF8xdnp3LmZbJzYnXSsrO19fY292XzRmZFYwSlhlYzVjY2hxRFR0XzF2encuc1snNDUnXSsrO3JldHVybiB2YWx1ZTt9LHNldDpmdW5jdGlvbihuZXdWYWx1ZSl7X19jb3ZfNGZkVjBKWGVjNWNjaHFEVHRfMXZ6dy5mWyc3J10rKztfX2Nvdl80ZmRWMEpYZWM1Y2NocURUdF8xdnp3LnNbJzQ2J10rKztpZihuZXdWYWx1ZT09PXZhbHVlKXtfX2Nvdl80ZmRWMEpYZWM1Y2NocURUdF8xdnp3LmJbJzExJ11bMF0rKztfX2Nvdl80ZmRWMEpYZWM1Y2NocURUdF8xdnp3LnNbJzQ3J10rKztsb2cucmVwbGljYW50cygndmFsdWUgdW5jaGFuZ2VkLCBubyBhY3Rpb24gd2lsbCBiZSB0YWtlbicpO19fY292XzRmZFYwSlhlYzVjY2hxRFR0XzF2encuc1snNDgnXSsrO3JldHVybiB2YWx1ZTt9ZWxzZXtfX2Nvdl80ZmRWMEpYZWM1Y2NocURUdF8xdnp3LmJbJzExJ11bMV0rKzt9X19jb3ZfNGZkVjBKWGVjNWNjaHFEVHRfMXZ6dy5zWyc0OSddKys7bG9nLnJlcGxpY2FudHMoJ3J1bm5pbmcgc2V0dGVyIHdpdGgnLG5ld1ZhbHVlKTtfX2Nvdl80ZmRWMEpYZWM1Y2NocURUdF8xdnp3LnNbJzUwJ10rKztpZihzZWxmLnN0YXR1cyE9PSdkZWNsYXJlZCcpe19fY292XzRmZFYwSlhlYzVjY2hxRFR0XzF2encuYlsnMTInXVswXSsrO19fY292XzRmZFYwSlhlYzVjY2hxRFR0XzF2encuc1snNTEnXSsrO2FkZFRvUXVldWUoZG9Ccm93c2VyU2V0dGVyLFtuZXdWYWx1ZV0pO19fY292XzRmZFYwSlhlYzVjY2hxRFR0XzF2encuc1snNTInXSsrO3JldHVybiB1bmRlZmluZWQ7fWVsc2V7X19jb3ZfNGZkVjBKWGVjNWNjaHFEVHRfMXZ6dy5iWycxMiddWzFdKys7fV9fY292XzRmZFYwSlhlYzVjY2hxRFR0XzF2encuc1snNTMnXSsrO2RvQnJvd3NlclNldHRlcihuZXdWYWx1ZSk7fSxlbnVtZXJhYmxlOnRydWV9KTtmdW5jdGlvbiBkb0Jyb3dzZXJTZXR0ZXIobmV3VmFsdWUpe19fY292XzRmZFYwSlhlYzVjY2hxRFR0XzF2encuZlsnOCddKys7X19jb3ZfNGZkVjBKWGVjNWNjaHFEVHRfMXZ6dy5zWyc1NSddKys7c29ja2V0LmVtaXQoJ2Fzc2lnblJlcGxpY2FudCcse25hbWU6bmFtZSxidW5kbGU6YnVuZGxlLHZhbHVlOm5ld1ZhbHVlLG9yaWdpbmF0b3JJZDpzZWxmLmlkfSk7fWZ1bmN0aW9uIGRvQnJvd3NlckRlY2xhcmUoZGVmYXVsdFZhbHVlKXtfX2Nvdl80ZmRWMEpYZWM1Y2NocURUdF8xdnp3LmZbJzknXSsrO19fY292XzRmZFYwSlhlYzVjY2hxRFR0XzF2encuc1snNTcnXSsrO2lmKChfX2Nvdl80ZmRWMEpYZWM1Y2NocURUdF8xdnp3LmJbJzE0J11bMF0rKyxzZWxmLnN0YXR1cz09PSdkZWNsYXJlZCcpfHwoX19jb3ZfNGZkVjBKWGVjNWNjaHFEVHRfMXZ6dy5iWycxNCddWzFdKyssc2VsZi5zdGF0dXM9PT0nZGVjbGFyaW5nJykpe19fY292XzRmZFYwSlhlYzVjY2hxRFR0XzF2encuYlsnMTMnXVswXSsrO19fY292XzRmZFYwSlhlYzVjY2hxRFR0XzF2encuc1snNTgnXSsrO3JldHVybjt9ZWxzZXtfX2Nvdl80ZmRWMEpYZWM1Y2NocURUdF8xdnp3LmJbJzEzJ11bMV0rKzt9X19jb3ZfNGZkVjBKWGVjNWNjaHFEVHRfMXZ6dy5zWyc1OSddKys7c2VsZi5zdGF0dXM9J2RlY2xhcmluZyc7X19jb3ZfNGZkVjBKWGVjNWNjaHFEVHRfMXZ6dy5zWyc2MCddKys7c29ja2V0LmVtaXQoJ2pvaW5Sb29tJyxidW5kbGUsZnVuY3Rpb24oKXtfX2Nvdl80ZmRWMEpYZWM1Y2NocURUdF8xdnp3LmZbJzEwJ10rKztfX2Nvdl80ZmRWMEpYZWM1Y2NocURUdF8xdnp3LnNbJzYxJ10rKztzb2NrZXQuZW1pdCgnZGVjbGFyZVJlcGxpY2FudCcse25hbWU6bmFtZSxidW5kbGU6YnVuZGxlLGRlZmF1bHRWYWx1ZTpkZWZhdWx0VmFsdWUscGVyc2lzdGVudDpvcHRzLnBlcnNpc3RlbnR9LGZ1bmN0aW9uKGRhdGEpe19fY292XzRmZFYwSlhlYzVjY2hxRFR0XzF2encuZlsnMTEnXSsrO19fY292XzRmZFYwSlhlYzVjY2hxRFR0XzF2encuc1snNjInXSsrO2xvZy5yZXBsaWNhbnRzKCdkZWNsYXJlUmVwbGljYW50IGNhbGxiYWNrICh2YWx1ZTogJXMsIHJldmlzaW9uOiAlcyknLGRhdGEudmFsdWUsZGF0YS5yZXZpc2lvbik7X19jb3ZfNGZkVjBKWGVjNWNjaHFEVHRfMXZ6dy5zWyc2MyddKys7dmFyIGRpZE1pc21hdGNoUmVhc3NpZ25tZW50PWZhbHNlO19fY292XzRmZFYwSlhlYzVjY2hxRFR0XzF2encuc1snNjQnXSsrO2lmKChfX2Nvdl80ZmRWMEpYZWM1Y2NocURUdF8xdnp3LmJbJzE2J11bMF0rKyxzZWxmLnJldmlzaW9uIT09ZGF0YS5yZXZpc2lvbil8fChfX2Nvdl80ZmRWMEpYZWM1Y2NocURUdF8xdnp3LmJbJzE2J11bMV0rKywhZXF1YWwodmFsdWUsZGF0YS52YWx1ZSkpKXtfX2Nvdl80ZmRWMEpYZWM1Y2NocURUdF8xdnp3LmJbJzE1J11bMF0rKztfX2Nvdl80ZmRWMEpYZWM1Y2NocURUdF8xdnp3LnNbJzY1J10rKzt1bm9ic2VydmVWYWx1ZSgpO19fY292XzRmZFYwSlhlYzVjY2hxRFR0XzF2encuc1snNjYnXSsrO3ZhbHVlPWRlZmF1bHRWYWx1ZTtfX2Nvdl80ZmRWMEpYZWM1Y2NocURUdF8xdnp3LnNbJzY3J10rKztvYnNlcnZlVmFsdWUoKTtfX2Nvdl80ZmRWMEpYZWM1Y2NocURUdF8xdnp3LnNbJzY4J10rKzthc3NpZ25WYWx1ZShkYXRhLnZhbHVlLGRhdGEucmV2aXNpb24pO19fY292XzRmZFYwSlhlYzVjY2hxRFR0XzF2encuc1snNjknXSsrO2RpZE1pc21hdGNoUmVhc3NpZ25tZW50PXRydWU7fWVsc2V7X19jb3ZfNGZkVjBKWGVjNWNjaHFEVHRfMXZ6dy5iWycxNSddWzFdKys7fV9fY292XzRmZFYwSlhlYzVjY2hxRFR0XzF2encuc1snNzAnXSsrO3NlbGYuc3RhdHVzPSdkZWNsYXJlZCc7X19jb3ZfNGZkVjBKWGVjNWNjaHFEVHRfMXZ6dy5zWyc3MSddKys7c2VsZi5lbWl0KCdkZWNsYXJlZCcsZGF0YSk7X19jb3ZfNGZkVjBKWGVjNWNjaHFEVHRfMXZ6dy5zWyc3MiddKys7aWYocXVldWUubGVuZ3RoPjApe19fY292XzRmZFYwSlhlYzVjY2hxRFR0XzF2encuYlsnMTcnXVswXSsrO19fY292XzRmZFYwSlhlYzVjY2hxRFR0XzF2encuc1snNzMnXSsrO3Byb2Nlc3NRdWV1ZSgpO31lbHNle19fY292XzRmZFYwSlhlYzVjY2hxRFR0XzF2encuYlsnMTcnXVsxXSsrO19fY292XzRmZFYwSlhlYzVjY2hxRFR0XzF2encuc1snNzQnXSsrO2lmKCFkaWRNaXNtYXRjaFJlYXNzaWdubWVudCl7X19jb3ZfNGZkVjBKWGVjNWNjaHFEVHRfMXZ6dy5iWycxOCddWzBdKys7X19jb3ZfNGZkVjBKWGVjNWNjaHFEVHRfMXZ6dy5zWyc3NSddKys7c2VsZi5lbWl0KCdjaGFuZ2UnLHVuZGVmaW5lZCxkYXRhLnZhbHVlKTt9ZWxzZXtfX2Nvdl80ZmRWMEpYZWM1Y2NocURUdF8xdnp3LmJbJzE4J11bMV0rKzt9fX0pO30pO31fX2Nvdl80ZmRWMEpYZWM1Y2NocURUdF8xdnp3LnNbJzc2J10rKztkb0Jyb3dzZXJEZWNsYXJlKG9wdHMuZGVmYXVsdFZhbHVlKTtmdW5jdGlvbiBhc3NpZ25WYWx1ZShuZXdWYWx1ZSxyZXZpc2lvbil7X19jb3ZfNGZkVjBKWGVjNWNjaHFEVHRfMXZ6dy5mWycxMiddKys7X19jb3ZfNGZkVjBKWGVjNWNjaHFEVHRfMXZ6dy5zWyc3OCddKys7dW5vYnNlcnZlVmFsdWUoKTtfX2Nvdl80ZmRWMEpYZWM1Y2NocURUdF8xdnp3LnNbJzc5J10rKzt2YXIgb2xkVmFsdWU9Y2xvbmUodmFsdWUpO19fY292XzRmZFYwSlhlYzVjY2hxRFR0XzF2encuc1snODAnXSsrO3ZhbHVlPW5ld1ZhbHVlO19fY292XzRmZFYwSlhlYzVjY2hxRFR0XzF2encuc1snODEnXSsrO29ic2VydmVWYWx1ZSgpO19fY292XzRmZFYwSlhlYzVjY2hxRFR0XzF2encuc1snODInXSsrO2lmKHR5cGVvZiByZXZpc2lvbiE9PSd1bmRlZmluZWQnKXtfX2Nvdl80ZmRWMEpYZWM1Y2NocURUdF8xdnp3LmJbJzE5J11bMF0rKztfX2Nvdl80ZmRWMEpYZWM1Y2NocURUdF8xdnp3LnNbJzgzJ10rKztzZWxmLnJldmlzaW9uPXJldmlzaW9uO31lbHNle19fY292XzRmZFYwSlhlYzVjY2hxRFR0XzF2encuYlsnMTknXVsxXSsrO31fX2Nvdl80ZmRWMEpYZWM1Y2NocURUdF8xdnp3LnNbJzg0J10rKztzZWxmLmVtaXQoJ2NoYW5nZScsb2xkVmFsdWUsdmFsdWUpO31mdW5jdGlvbiBvYnNlcnZlVmFsdWUoKXtfX2Nvdl80ZmRWMEpYZWM1Y2NocURUdF8xdnp3LmZbJzEzJ10rKztfX2Nvdl80ZmRWMEpYZWM1Y2NocURUdF8xdnp3LnNbJzg2J10rKztpZigoX19jb3ZfNGZkVjBKWGVjNWNjaHFEVHRfMXZ6dy5iWycyMSddWzBdKyssdHlwZW9mIHZhbHVlPT09J29iamVjdCcpJiYoX19jb3ZfNGZkVjBKWGVjNWNjaHFEVHRfMXZ6dy5iWycyMSddWzFdKyssdmFsdWUhPT1udWxsKSl7X19jb3ZfNGZkVjBKWGVjNWNjaHFEVHRfMXZ6dy5iWycyMCddWzBdKys7X19jb3ZfNGZkVjBKWGVjNWNjaHFEVHRfMXZ6dy5zWyc4NyddKys7TmVzdGVkLm9ic2VydmUodmFsdWUsb25WYWx1ZUNoYW5nZSk7fWVsc2V7X19jb3ZfNGZkVjBKWGVjNWNjaHFEVHRfMXZ6dy5iWycyMCddWzFdKys7fX1mdW5jdGlvbiBkaXNwYXRjaENoYW5nZXMoY2hhbmdlcyl7X19jb3ZfNGZkVjBKWGVjNWNjaHFEVHRfMXZ6dy5mWycxNCddKys7X19jb3ZfNGZkVjBKWGVjNWNjaHFEVHRfMXZ6dy5zWyc4OSddKys7c29ja2V0LmVtaXQoJ2NoYW5nZVJlcGxpY2FudCcse25hbWU6bmFtZSxidW5kbGU6YnVuZGxlLGNoYW5nZXM6Y2hhbmdlcyxyZXZpc2lvbjpzZWxmLnJldmlzaW9uLG9yaWdpbmF0b3JJZDpzZWxmLmlkfSxmdW5jdGlvbih2YWx1ZSxyZXZpc2lvbil7X19jb3ZfNGZkVjBKWGVjNWNjaHFEVHRfMXZ6dy5mWycxNSddKys7X19jb3ZfNGZkVjBKWGVjNWNjaHFEVHRfMXZ6dy5zWyc5MCddKys7bG9nLnJlcGxpY2FudHMoJ05vdCBhdCBoZWFkIHJldmlzaW9uIChvdXJzICVzLCB0aGVpcnMgJXMpLiBDaGFuZ2UgYWJvcnRlZCAmIGhlYWQgcmV2aXNpb24gYXBwbGllZC4nLHNlbGYucmV2aXNpb24scmV2aXNpb24pO19fY292XzRmZFYwSlhlYzVjY2hxRFR0XzF2encuc1snOTEnXSsrO2Fzc2lnblZhbHVlKHZhbHVlLHJldmlzaW9uKTt9KTt9ZnVuY3Rpb24gb25WYWx1ZUNoYW5nZShyYXdDaGFuZ2VzKXtfX2Nvdl80ZmRWMEpYZWM1Y2NocURUdF8xdnp3LmZbJzE2J10rKztfX2Nvdl80ZmRWMEpYZWM1Y2NocURUdF8xdnp3LnNbJzkzJ10rKzt2YXIgZm9ybWF0dGVkQ2hhbmdlcz1bXTtfX2Nvdl80ZmRWMEpYZWM1Y2NocURUdF8xdnp3LnNbJzk0J10rKztyYXdDaGFuZ2VzLmZvckVhY2goZnVuY3Rpb24oY2hhbmdlKXtfX2Nvdl80ZmRWMEpYZWM1Y2NocURUdF8xdnp3LmZbJzE3J10rKztfX2Nvdl80ZmRWMEpYZWM1Y2NocURUdF8xdnp3LnNbJzk1J10rKzt2YXIgcGF0aD1jaGFuZ2UucGF0aC5zdWJzdHIoMSkuc3BsaXQoJy8nKS5tYXAoZnVuY3Rpb24ocGFydCl7X19jb3ZfNGZkVjBKWGVjNWNjaHFEVHRfMXZ6dy5mWycxOCddKys7X19jb3ZfNGZkVjBKWGVjNWNjaHFEVHRfMXZ6dy5zWyc5NiddKys7cmV0dXJuIHBhcnQucmVwbGFjZSgvXFx+MS9nLCcvJyk7fSk7X19jb3ZfNGZkVjBKWGVjNWNjaHFEVHRfMXZ6dy5zWyc5NyddKys7aWYoKF9fY292XzRmZFYwSlhlYzVjY2hxRFR0XzF2encuYlsnMjMnXVswXSsrLHBhdGgubGVuZ3RoPT09MSkmJihfX2Nvdl80ZmRWMEpYZWM1Y2NocURUdF8xdnp3LmJbJzIzJ11bMV0rKyxwYXRoWzBdPT09JycpKXtfX2Nvdl80ZmRWMEpYZWM1Y2NocURUdF8xdnp3LmJbJzIyJ11bMF0rKztfX2Nvdl80ZmRWMEpYZWM1Y2NocURUdF8xdnp3LnNbJzk4J10rKztwYXRoPVtdO31lbHNle19fY292XzRmZFYwSlhlYzVjY2hxRFR0XzF2encuYlsnMjInXVsxXSsrO31fX2Nvdl80ZmRWMEpYZWM1Y2NocURUdF8xdnp3LnNbJzk5J10rKzt2YXIgbmV3VmFsPW9iamVjdFBhdGguZ2V0KGNoYW5nZS5yb290LHBhdGgpO19fY292XzRmZFYwSlhlYzVjY2hxRFR0XzF2encuc1snMTAwJ10rKztzd2l0Y2goY2hhbmdlLnR5cGUpe2Nhc2UnYWRkJzpfX2Nvdl80ZmRWMEpYZWM1Y2NocURUdF8xdnp3LmJbJzI0J11bMF0rKztfX2Nvdl80ZmRWMEpYZWM1Y2NocURUdF8xdnp3LnNbJzEwMSddKys7Zm9ybWF0dGVkQ2hhbmdlcy5wdXNoKHt0eXBlOidhZGQnLHBhdGg6cGF0aCxuZXdWYWx1ZTpuZXdWYWx9KTtfX2Nvdl80ZmRWMEpYZWM1Y2NocURUdF8xdnp3LnNbJzEwMiddKys7YnJlYWs7Y2FzZSd1cGRhdGUnOl9fY292XzRmZFYwSlhlYzVjY2hxRFR0XzF2encuYlsnMjQnXVsxXSsrO19fY292XzRmZFYwSlhlYzVjY2hxRFR0XzF2encuc1snMTAzJ10rKztmb3JtYXR0ZWRDaGFuZ2VzLnB1c2goe3R5cGU6J3VwZGF0ZScscGF0aDpwYXRoLG9sZFZhbHVlOmNoYW5nZS5vbGRWYWx1ZSxuZXdWYWx1ZTpuZXdWYWx9KTtfX2Nvdl80ZmRWMEpYZWM1Y2NocURUdF8xdnp3LnNbJzEwNCddKys7YnJlYWs7Y2FzZSdzcGxpY2UnOl9fY292XzRmZFYwSlhlYzVjY2hxRFR0XzF2encuYlsnMjQnXVsyXSsrO19fY292XzRmZFYwSlhlYzVjY2hxRFR0XzF2encuc1snMTA1J10rKztmb3JtYXR0ZWRDaGFuZ2VzLnB1c2goe3R5cGU6J3NwbGljZScscGF0aDpwYXRoLGluZGV4OmNoYW5nZS5pbmRleCxyZW1vdmVkOmNoYW5nZS5yZW1vdmVkLHJlbW92ZWRDb3VudDpjaGFuZ2UucmVtb3ZlZC5sZW5ndGgsYWRkZWQ6Y2hhbmdlLm9iamVjdC5zbGljZShjaGFuZ2UuaW5kZXgsY2hhbmdlLmluZGV4K2NoYW5nZS5hZGRlZENvdW50KSxhZGRlZENvdW50OmNoYW5nZS5hZGRlZENvdW50fSk7X19jb3ZfNGZkVjBKWGVjNWNjaHFEVHRfMXZ6dy5zWycxMDYnXSsrO2JyZWFrO2Nhc2UnZGVsZXRlJzpfX2Nvdl80ZmRWMEpYZWM1Y2NocURUdF8xdnp3LmJbJzI0J11bM10rKztfX2Nvdl80ZmRWMEpYZWM1Y2NocURUdF8xdnp3LnNbJzEwNyddKys7Zm9ybWF0dGVkQ2hhbmdlcy5wdXNoKHt0eXBlOidkZWxldGUnLHBhdGg6cGF0aCxvbGRWYWx1ZTpjaGFuZ2Uub2xkVmFsdWV9KTtfX2Nvdl80ZmRWMEpYZWM1Y2NocURUdF8xdnp3LnNbJzEwOCddKys7YnJlYWs7ZGVmYXVsdDpfX2Nvdl80ZmRWMEpYZWM1Y2NocURUdF8xdnp3LmJbJzI0J11bNF0rKztfX2Nvdl80ZmRWMEpYZWM1Y2NocURUdF8xdnp3LnNbJzEwOSddKys7Zm9ybWF0dGVkQ2hhbmdlcy5wdXNoKHt0eXBlOidvdGhlcicscGF0aDpwYXRofSk7fX0pO19fY292XzRmZFYwSlhlYzVjY2hxRFR0XzF2encuc1snMTEwJ10rKztpZihzZWxmLnN0YXR1cz09PSdkZWNsYXJlZCcpe19fY292XzRmZFYwSlhlYzVjY2hxRFR0XzF2encuYlsnMjUnXVswXSsrO19fY292XzRmZFYwSlhlYzVjY2hxRFR0XzF2encuc1snMTExJ10rKztkaXNwYXRjaENoYW5nZXMoZm9ybWF0dGVkQ2hhbmdlcyk7fWVsc2V7X19jb3ZfNGZkVjBKWGVjNWNjaHFEVHRfMXZ6dy5iWycyNSddWzFdKys7X19jb3ZfNGZkVjBKWGVjNWNjaHFEVHRfMXZ6dy5zWycxMTInXSsrO2FkZFRvUXVldWUoZGlzcGF0Y2hDaGFuZ2VzLFtmb3JtYXR0ZWRDaGFuZ2VzXSk7fX1mdW5jdGlvbiB1bm9ic2VydmVWYWx1ZSgpe19fY292XzRmZFYwSlhlYzVjY2hxRFR0XzF2encuZlsnMTknXSsrO19fY292XzRmZFYwSlhlYzVjY2hxRFR0XzF2encuc1snMTE0J10rKztpZigoX19jb3ZfNGZkVjBKWGVjNWNjaHFEVHRfMXZ6dy5iWycyNyddWzBdKyssdHlwZW9mIHZhbHVlPT09J29iamVjdCcpJiYoX19jb3ZfNGZkVjBKWGVjNWNjaHFEVHRfMXZ6dy5iWycyNyddWzFdKyssdmFsdWUhPT1udWxsKSl7X19jb3ZfNGZkVjBKWGVjNWNjaHFEVHRfMXZ6dy5iWycyNiddWzBdKys7X19jb3ZfNGZkVjBKWGVjNWNjaHFEVHRfMXZ6dy5zWycxMTUnXSsrO05lc3RlZC51bm9ic2VydmUodmFsdWUsb25WYWx1ZUNoYW5nZSk7fWVsc2V7X19jb3ZfNGZkVjBKWGVjNWNjaHFEVHRfMXZ6dy5iWycyNiddWzFdKys7fX1fX2Nvdl80ZmRWMEpYZWM1Y2NocURUdF8xdnp3LnNbJzExNiddKys7c29ja2V0Lm9uKCdyZXBsaWNhbnRBc3NpZ25lZCcsZnVuY3Rpb24oZGF0YSl7X19jb3ZfNGZkVjBKWGVjNWNjaHFEVHRfMXZ6dy5mWycyMCddKys7X19jb3ZfNGZkVjBKWGVjNWNjaHFEVHRfMXZ6dy5zWycxMTcnXSsrO2lmKChfX2Nvdl80ZmRWMEpYZWM1Y2NocURUdF8xdnp3LmJbJzI5J11bMF0rKyxkYXRhLm5hbWUhPT1uYW1lKXx8KF9fY292XzRmZFYwSlhlYzVjY2hxRFR0XzF2encuYlsnMjknXVsxXSsrLGRhdGEuYnVuZGxlIT09YnVuZGxlKSl7X19jb3ZfNGZkVjBKWGVjNWNjaHFEVHRfMXZ6dy5iWycyOCddWzBdKys7X19jb3ZfNGZkVjBKWGVjNWNjaHFEVHRfMXZ6dy5zWycxMTgnXSsrO3JldHVybjt9ZWxzZXtfX2Nvdl80ZmRWMEpYZWM1Y2NocURUdF8xdnp3LmJbJzI4J11bMV0rKzt9X19jb3ZfNGZkVjBKWGVjNWNjaHFEVHRfMXZ6dy5zWycxMTknXSsrO2xvZy5yZXBsaWNhbnRzKCdyZXBsaWNhbnRBc3NpZ25lZCcsZGF0YSk7X19jb3ZfNGZkVjBKWGVjNWNjaHFEVHRfMXZ6dy5zWycxMjAnXSsrO2lmKGRhdGEub3JpZ2luYXRvcklkPT09c2VsZi5pZCl7X19jb3ZfNGZkVjBKWGVjNWNjaHFEVHRfMXZ6dy5iWyczMCddWzBdKys7X19jb3ZfNGZkVjBKWGVjNWNjaHFEVHRfMXZ6dy5zWycxMjEnXSsrO3NlbGYuZW1pdCgnYXNzaWdubWVudEFjY2VwdGVkJyxkYXRhKTt9ZWxzZXtfX2Nvdl80ZmRWMEpYZWM1Y2NocURUdF8xdnp3LmJbJzMwJ11bMV0rKzt9X19jb3ZfNGZkVjBKWGVjNWNjaHFEVHRfMXZ6dy5zWycxMjInXSsrO2Fzc2lnblZhbHVlKGRhdGEubmV3VmFsdWUsZGF0YS5yZXZpc2lvbik7fSk7X19jb3ZfNGZkVjBKWGVjNWNjaHFEVHRfMXZ6dy5zWycxMjMnXSsrO3NvY2tldC5vbigncmVwbGljYW50Q2hhbmdlZCcsZnVuY3Rpb24oZGF0YSl7X19jb3ZfNGZkVjBKWGVjNWNjaHFEVHRfMXZ6dy5mWycyMSddKys7X19jb3ZfNGZkVjBKWGVjNWNjaHFEVHRfMXZ6dy5zWycxMjQnXSsrO2lmKHNlbGYuc3RhdHVzIT09J2RlY2xhcmVkJyl7X19jb3ZfNGZkVjBKWGVjNWNjaHFEVHRfMXZ6dy5iWyczMSddWzBdKys7X19jb3ZfNGZkVjBKWGVjNWNjaHFEVHRfMXZ6dy5zWycxMjUnXSsrO3JldHVybjt9ZWxzZXtfX2Nvdl80ZmRWMEpYZWM1Y2NocURUdF8xdnp3LmJbJzMxJ11bMV0rKzt9X19jb3ZfNGZkVjBKWGVjNWNjaHFEVHRfMXZ6dy5zWycxMjYnXSsrO2lmKChfX2Nvdl80ZmRWMEpYZWM1Y2NocURUdF8xdnp3LmJbJzMzJ11bMF0rKyxkYXRhLm5hbWUhPT1uYW1lKXx8KF9fY292XzRmZFYwSlhlYzVjY2hxRFR0XzF2encuYlsnMzMnXVsxXSsrLGRhdGEuYnVuZGxlIT09YnVuZGxlKSl7X19jb3ZfNGZkVjBKWGVjNWNjaHFEVHRfMXZ6dy5iWyczMiddWzBdKys7X19jb3ZfNGZkVjBKWGVjNWNjaHFEVHRfMXZ6dy5zWycxMjcnXSsrO3JldHVybjt9ZWxzZXtfX2Nvdl80ZmRWMEpYZWM1Y2NocURUdF8xdnp3LmJbJzMyJ11bMV0rKztfX2Nvdl80ZmRWMEpYZWM1Y2NocURUdF8xdnp3LnNbJzEyOCddKys7aWYoZGF0YS5yZXZpc2lvbiE9PXNlbGYucmV2aXNpb24rMSl7X19jb3ZfNGZkVjBKWGVjNWNjaHFEVHRfMXZ6dy5iWyczNCddWzBdKys7X19jb3ZfNGZkVjBKWGVjNWNjaHFEVHRfMXZ6dy5zWycxMjknXSsrO2xvZy5yZXBsaWNhbnRzKCdbJXNdIFJlcGxpY2FudCBcIiVzXCIgbm90IGF0IGhlYWQgcmV2aXNpb24gKG91cnMgJXMsIHRoZWlycyAlcyksIGZldGNoaW5nIGxhdGVzdC4uLicsYnVuZGxlLG5hbWUsc2VsZi5yZXZpc2lvbixkYXRhLnJldmlzaW9uKTtfX2Nvdl80ZmRWMEpYZWM1Y2NocURUdF8xdnp3LnNbJzEzMCddKys7ZnVsbFVwZGF0ZSgpO19fY292XzRmZFYwSlhlYzVjY2hxRFR0XzF2encuc1snMTMxJ10rKztyZXR1cm47fWVsc2V7X19jb3ZfNGZkVjBKWGVjNWNjaHFEVHRfMXZ6dy5iWyczNCddWzFdKys7fX1fX2Nvdl80ZmRWMEpYZWM1Y2NocURUdF8xdnp3LnNbJzEzMiddKys7bG9nLnJlcGxpY2FudHMoJ3JlcGxpY2FudENoYW5nZWQnLGRhdGEpO19fY292XzRmZFYwSlhlYzVjY2hxRFR0XzF2encuc1snMTMzJ10rKzt2YXIgb2xkVmFsdWU9Y2xvbmUodmFsdWUpO19fY292XzRmZFYwSlhlYzVjY2hxRFR0XzF2encuc1snMTM0J10rKzt2YXIgcmVwbGF5Q2hhbmdlcz1jbG9uZShkYXRhLmNoYW5nZXMpO19fY292XzRmZFYwSlhlYzVjY2hxRFR0XzF2encuc1snMTM1J10rKztyZXBsYXlDaGFuZ2VzLnJldmVyc2UoKTtfX2Nvdl80ZmRWMEpYZWM1Y2NocURUdF8xdnp3LnNbJzEzNiddKys7cmVwbGF5Q2hhbmdlcy5mb3JFYWNoKGZ1bmN0aW9uKGNoYW5nZSl7X19jb3ZfNGZkVjBKWGVjNWNjaHFEVHRfMXZ6dy5mWycyMiddKys7X19jb3ZfNGZkVjBKWGVjNWNjaHFEVHRfMXZ6dy5zWycxMzcnXSsrO3N3aXRjaChjaGFuZ2UudHlwZSl7Y2FzZSdhZGQnOl9fY292XzRmZFYwSlhlYzVjY2hxRFR0XzF2encuYlsnMzUnXVswXSsrO19fY292XzRmZFYwSlhlYzVjY2hxRFR0XzF2encuc1snMTM4J10rKztvYmplY3RQYXRoLmRlbChvbGRWYWx1ZSxjaGFuZ2UucGF0aCk7X19jb3ZfNGZkVjBKWGVjNWNjaHFEVHRfMXZ6dy5zWycxMzknXSsrO2JyZWFrO2Nhc2UndXBkYXRlJzpfX2Nvdl80ZmRWMEpYZWM1Y2NocURUdF8xdnp3LmJbJzM1J11bMV0rKztfX2Nvdl80ZmRWMEpYZWM1Y2NocURUdF8xdnp3LnNbJzE0MCddKys7b2JqZWN0UGF0aC5zZXQob2xkVmFsdWUsY2hhbmdlLnBhdGgsY2hhbmdlLm9sZFZhbHVlKTtfX2Nvdl80ZmRWMEpYZWM1Y2NocURUdF8xdnp3LnNbJzE0MSddKys7YnJlYWs7Y2FzZSdzcGxpY2UnOl9fY292XzRmZFYwSlhlYzVjY2hxRFR0XzF2encuYlsnMzUnXVsyXSsrO19fY292XzRmZFYwSlhlYzVjY2hxRFR0XzF2encuc1snMTQyJ10rKzt2YXIgYXJyPW9iamVjdFBhdGguZ2V0KG9sZFZhbHVlLGNoYW5nZS5wYXRoKTtfX2Nvdl80ZmRWMEpYZWM1Y2NocURUdF8xdnp3LnNbJzE0MyddKys7aWYoIWFycil7X19jb3ZfNGZkVjBKWGVjNWNjaHFEVHRfMXZ6dy5iWyczNiddWzBdKys7X19jb3ZfNGZkVjBKWGVjNWNjaHFEVHRfMXZ6dy5zWycxNDQnXSsrO2Fycj1bXTt9ZWxzZXtfX2Nvdl80ZmRWMEpYZWM1Y2NocURUdF8xdnp3LmJbJzM2J11bMV0rKzt9X19jb3ZfNGZkVjBKWGVjNWNjaHFEVHRfMXZ6dy5zWycxNDUnXSsrO3ZhciBhcmdzPWNsb25lKGNoYW5nZS5yZW1vdmVkKTtfX2Nvdl80ZmRWMEpYZWM1Y2NocURUdF8xdnp3LnNbJzE0NiddKys7YXJncy51bnNoaWZ0KGNoYW5nZS5hZGRlZENvdW50KTtfX2Nvdl80ZmRWMEpYZWM1Y2NocURUdF8xdnp3LnNbJzE0NyddKys7YXJncy51bnNoaWZ0KGNoYW5nZS5pbmRleCk7X19jb3ZfNGZkVjBKWGVjNWNjaHFEVHRfMXZ6dy5zWycxNDgnXSsrO0FycmF5LnByb3RvdHlwZS5zcGxpY2UuYXBwbHkoYXJyLGFyZ3MpO19fY292XzRmZFYwSlhlYzVjY2hxRFR0XzF2encuc1snMTQ5J10rKztvYmplY3RQYXRoLnNldChvbGRWYWx1ZSxjaGFuZ2UucGF0aCxhcnIpO19fY292XzRmZFYwSlhlYzVjY2hxRFR0XzF2encuc1snMTUwJ10rKzticmVhaztjYXNlJ2RlbGV0ZSc6X19jb3ZfNGZkVjBKWGVjNWNjaHFEVHRfMXZ6dy5iWyczNSddWzNdKys7X19jb3ZfNGZkVjBKWGVjNWNjaHFEVHRfMXZ6dy5zWycxNTEnXSsrO29iamVjdFBhdGguc2V0KG9sZFZhbHVlLGNoYW5nZS5wYXRoLGNoYW5nZS5vbGRWYWx1ZSk7X19jb3ZfNGZkVjBKWGVjNWNjaHFEVHRfMXZ6dy5zWycxNTInXSsrO2JyZWFrO2RlZmF1bHQ6X19jb3ZfNGZkVjBKWGVjNWNjaHFEVHRfMXZ6dy5iWyczNSddWzRdKys7X19jb3ZfNGZkVjBKWGVjNWNjaHFEVHRfMXZ6dy5zWycxNTMnXSsrO29iamVjdFBhdGguc2V0KG9sZFZhbHVlLGNoYW5nZS5wYXRoLGNoYW5nZS5vbGRWYWx1ZSk7fX0pO19fY292XzRmZFYwSlhlYzVjY2hxRFR0XzF2encuc1snMTU0J10rKztpZihkYXRhLm9yaWdpbmF0b3JJZD09PXNlbGYuaWQpe19fY292XzRmZFYwSlhlYzVjY2hxRFR0XzF2encuYlsnMzcnXVswXSsrO19fY292XzRmZFYwSlhlYzVjY2hxRFR0XzF2encuc1snMTU1J10rKztkYXRhLmNoYW5nZXMuZm9yRWFjaChmdW5jdGlvbihjaGFuZ2Upe19fY292XzRmZFYwSlhlYzVjY2hxRFR0XzF2encuZlsnMjMnXSsrO19fY292XzRmZFYwSlhlYzVjY2hxRFR0XzF2encuc1snMTU2J10rKztzd2l0Y2goY2hhbmdlLnR5cGUpe2Nhc2Unc3BsaWNlJzpfX2Nvdl80ZmRWMEpYZWM1Y2NocURUdF8xdnp3LmJbJzM4J11bMF0rKztfX2Nvdl80ZmRWMEpYZWM1Y2NocURUdF8xdnp3LnNbJzE1NyddKys7Y2hhbmdlLm9iamVjdD1vYmplY3RQYXRoLmdldCh2YWx1ZSxjaGFuZ2UucGF0aCk7X19jb3ZfNGZkVjBKWGVjNWNjaHFEVHRfMXZ6dy5zWycxNTgnXSsrO2JyZWFrO2RlZmF1bHQ6X19jb3ZfNGZkVjBKWGVjNWNjaHFEVHRfMXZ6dy5iWyczOCddWzFdKys7fX0pO31lbHNle19fY292XzRmZFYwSlhlYzVjY2hxRFR0XzF2encuYlsnMzcnXVsxXSsrO19fY292XzRmZFYwSlhlYzVjY2hxRFR0XzF2encuc1snMTU5J10rKzt1bm9ic2VydmVWYWx1ZSgpO19fY292XzRmZFYwSlhlYzVjY2hxRFR0XzF2encuc1snMTYwJ10rKztkYXRhLmNoYW5nZXMuZm9yRWFjaChmdW5jdGlvbihjaGFuZ2Upe19fY292XzRmZFYwSlhlYzVjY2hxRFR0XzF2encuZlsnMjQnXSsrO19fY292XzRmZFYwSlhlYzVjY2hxRFR0XzF2encuc1snMTYxJ10rKztzd2l0Y2goY2hhbmdlLnR5cGUpe2Nhc2UnYWRkJzpfX2Nvdl80ZmRWMEpYZWM1Y2NocURUdF8xdnp3LmJbJzM5J11bMF0rKztjYXNlJ3VwZGF0ZSc6X19jb3ZfNGZkVjBKWGVjNWNjaHFEVHRfMXZ6dy5iWyczOSddWzFdKys7X19jb3ZfNGZkVjBKWGVjNWNjaHFEVHRfMXZ6dy5zWycxNjInXSsrO29iamVjdFBhdGguc2V0KHZhbHVlLGNoYW5nZS5wYXRoLGNoYW5nZS5uZXdWYWx1ZSk7X19jb3ZfNGZkVjBKWGVjNWNjaHFEVHRfMXZ6dy5zWycxNjMnXSsrO2JyZWFrO2Nhc2Unc3BsaWNlJzpfX2Nvdl80ZmRWMEpYZWM1Y2NocURUdF8xdnp3LmJbJzM5J11bMl0rKztfX2Nvdl80ZmRWMEpYZWM1Y2NocURUdF8xdnp3LnNbJzE2NCddKys7dmFyIGFycj1vYmplY3RQYXRoLmdldCh2YWx1ZSxjaGFuZ2UucGF0aCk7X19jb3ZfNGZkVjBKWGVjNWNjaHFEVHRfMXZ6dy5zWycxNjUnXSsrO3ZhciBhcmdzPWNsb25lKGNoYW5nZS5hZGRlZCk7X19jb3ZfNGZkVjBKWGVjNWNjaHFEVHRfMXZ6dy5zWycxNjYnXSsrO2FyZ3MudW5zaGlmdChjaGFuZ2UucmVtb3ZlZENvdW50KTtfX2Nvdl80ZmRWMEpYZWM1Y2NocURUdF8xdnp3LnNbJzE2NyddKys7YXJncy51bnNoaWZ0KGNoYW5nZS5pbmRleCk7X19jb3ZfNGZkVjBKWGVjNWNjaHFEVHRfMXZ6dy5zWycxNjgnXSsrO0FycmF5LnByb3RvdHlwZS5zcGxpY2UuYXBwbHkoYXJyLGFyZ3MpO19fY292XzRmZFYwSlhlYzVjY2hxRFR0XzF2encuc1snMTY5J10rKztvYmplY3RQYXRoLnNldCh2YWx1ZSxjaGFuZ2UucGF0aCxhcnIpO19fY292XzRmZFYwSlhlYzVjY2hxRFR0XzF2encuc1snMTcwJ10rKztjaGFuZ2Uub2JqZWN0PWFycjtfX2Nvdl80ZmRWMEpYZWM1Y2NocURUdF8xdnp3LnNbJzE3MSddKys7YnJlYWs7Y2FzZSdkZWxldGUnOl9fY292XzRmZFYwSlhlYzVjY2hxRFR0XzF2encuYlsnMzknXVszXSsrO19fY292XzRmZFYwSlhlYzVjY2hxRFR0XzF2encuc1snMTcyJ10rKztvYmplY3RQYXRoLmRlbCh2YWx1ZSxjaGFuZ2UucGF0aCk7X19jb3ZfNGZkVjBKWGVjNWNjaHFEVHRfMXZ6dy5zWycxNzMnXSsrO2JyZWFrO2RlZmF1bHQ6X19jb3ZfNGZkVjBKWGVjNWNjaHFEVHRfMXZ6dy5iWyczOSddWzRdKys7fX0pO19fY292XzRmZFYwSlhlYzVjY2hxRFR0XzF2encuc1snMTc0J10rKztvYnNlcnZlVmFsdWUoKTt9X19jb3ZfNGZkVjBKWGVjNWNjaHFEVHRfMXZ6dy5zWycxNzUnXSsrO3NlbGYucmV2aXNpb249ZGF0YS5yZXZpc2lvbjtfX2Nvdl80ZmRWMEpYZWM1Y2NocURUdF8xdnp3LnNbJzE3NiddKys7c2VsZi5lbWl0KCdjaGFuZ2UnLG9sZFZhbHVlLHZhbHVlLGRhdGEuY2hhbmdlcyk7fSk7ZnVuY3Rpb24gZnVsbFVwZGF0ZSgpe19fY292XzRmZFYwSlhlYzVjY2hxRFR0XzF2encuZlsnMjUnXSsrO19fY292XzRmZFYwSlhlYzVjY2hxRFR0XzF2encuc1snMTc4J10rKzt3aW5kb3cuTm9kZUNHLnJlYWRSZXBsaWNhbnQobmFtZSxidW5kbGUsZnVuY3Rpb24oZGF0YSl7X19jb3ZfNGZkVjBKWGVjNWNjaHFEVHRfMXZ6dy5mWycyNiddKys7X19jb3ZfNGZkVjBKWGVjNWNjaHFEVHRfMXZ6dy5zWycxNzknXSsrO3NlbGYuZW1pdCgnZnVsbFVwZGF0ZScsZGF0YSk7X19jb3ZfNGZkVjBKWGVjNWNjaHFEVHRfMXZ6dy5zWycxODAnXSsrO2Fzc2lnblZhbHVlKGRhdGEudmFsdWUsZGF0YS5yZXZpc2lvbik7fSk7fV9fY292XzRmZFYwSlhlYzVjY2hxRFR0XzF2encuc1snMTgxJ10rKztzb2NrZXQub24oJ2Rpc2Nvbm5lY3QnLGZ1bmN0aW9uKCl7X19jb3ZfNGZkVjBKWGVjNWNjaHFEVHRfMXZ6dy5mWycyNyddKys7X19jb3ZfNGZkVjBKWGVjNWNjaHFEVHRfMXZ6dy5zWycxODInXSsrO3NlbGYuc3RhdHVzPSd1bmRlY2xhcmVkJzt9KTtfX2Nvdl80ZmRWMEpYZWM1Y2NocURUdF8xdnp3LnNbJzE4MyddKys7c29ja2V0Lm9uKCdyZWNvbm5lY3QnLGZ1bmN0aW9uKCl7X19jb3ZfNGZkVjBKWGVjNWNjaHFEVHRfMXZ6dy5mWycyOCddKys7X19jb3ZfNGZkVjBKWGVjNWNjaHFEVHRfMXZ6dy5zWycxODQnXSsrO2RvQnJvd3NlckRlY2xhcmUodmFsdWUpO30pO31cbiIsIid1c2Ugc3RyaWN0JztcclxuXHJcbnZhciBMT0dfTEVWRUxTID0ge1xyXG4gICAgdHJhY2U6IDAsXHJcbiAgICBkZWJ1ZzogMSxcclxuICAgIGluZm86IDIsXHJcbiAgICB3YXJuOiAzLFxyXG4gICAgZXJyb3I6IDQsXHJcbiAgICBfaW5maW5pdGU6IEluZmluaXR5XHJcbn07XHJcblxyXG4vKipcclxuICogRW51bSBsb2dnaW5nIGxldmVsIHZhbHVlcy5cclxuICogQGVudW0ge1N0cmluZ31cclxuICovXHJcbnZhciBFTlVNX0xFVkVMUyA9IHsgLy8ganNoaW50IGlnbm9yZTpsaW5lXHJcbiAgICB0cmFjZTogJ1RoZSBoaWdoZXN0IGxldmVsIG9mIGxvZ2dpbmcsIGxvZ3MgZXZlcnl0aGluZy4nLFxyXG4gICAgZGVidWc6ICdMZXNzIHNwYW1teSB0aGFuIHRyYWNlLCBpbmNsdWRlcyBtb3N0IGluZm8gcmVsZXZhbnQgZm9yIGRlYnVnZ2luZy4nLFxyXG4gICAgaW5mbzogJ1RoZSBkZWZhdWx0IGxvZ2dpbmcgbGV2ZWwuIExvZ3MgdXNlZnVsIGluZm8sIHdhcm5pbmdzLCBhbmQgZXJyb3JzLicsXHJcbiAgICB3YXJuOiAnT25seSBsb2dzIHdhcm5pbmdzIGFuZCBlcnJvcnMuJyxcclxuICAgIGVycm9yOiAnT25seSBsb2dzIGVycm9ycy4nXHJcbn07XHJcblxyXG4vKipcclxuICogQSBmYWN0b3J5IHRoYXQgY29uZmlndXJlcyBhbmQgcmV0dXJucyBhIExvZ2dlciBjb25zdHJ1Y3Rvci5cclxuICogQHBhcmFtIFtpbml0aWFsT3B0c10ge09iamVjdH0gLSBDb25maWd1cmF0aW9uIGZvciB0aGUgbG9nZ2VyLlxyXG4gKlxyXG4gKiBAcGFyYW0gW2luaXRpYWxPcHRzLmNvbnNvbGVdIHtPYmplY3R9IC0gQ29uZmlndXJhdGlvbiBmb3IgdGhlIGNvbnNvbGUgbG9nZ2luZy5cclxuICogQHBhcmFtIFtpbml0aWFsT3B0cy5jb25zb2xlLmVuYWJsZWQ9ZmFsc2VdIHtCb29sZWFufSAtIFdoZXRoZXIgdG8gZW5hYmxlIGNvbnNvbGUgbG9nZ2luZy5cclxuICogQHBhcmFtIFtpbml0aWFsT3B0cy5jb25zb2xlLmxldmVsPVwiaW5mb1wiXSB7RU5VTV9MRVZFTFN9IC0gVGhlIGxldmVsIG9mIGxvZ2dpbmcgdG8gb3V0cHV0IHRvIHRoZSBjb25zb2xlLlxyXG4gKlxyXG4gKiBAcGFyYW0gW2luaXRpYWxPcHRzLnJlcGxpY2FudHM9ZmFsc2VdIHtCb29sZWFufSAtIFdoZXRoZXIgdG8gZW5hYmxlIGxvZ2dpbmcgc3BlY2lmaWNhbGx5IGZvciB0aGUgUmVwbGljYW50cyBzeXN0ZW0uXHJcbiAqXHJcbiAqIEByZXR1cm5zIHtmdW5jdGlvbn0gLSBBIGNvbnN0cnVjdG9yIHVzZWQgdG8gY3JlYXRlIGRpc2NyZXRlIGxvZ2dlciBpbnN0YW5jZXMuXHJcbiAqL1xyXG5tb2R1bGUuZXhwb3J0cyA9IGZ1bmN0aW9uKGluaXRpYWxPcHRzKSB7XHJcbiAgICBpbml0aWFsT3B0cyA9IGluaXRpYWxPcHRzIHx8IHt9O1xyXG4gICAgaW5pdGlhbE9wdHMuY29uc29sZSA9IGluaXRpYWxPcHRzLmNvbnNvbGUgfHwge307XHJcblxyXG4gICAgLyoqXHJcbiAgICAgKiBDb25zdHJ1Y3RzIGEgbmV3IExvZ2dlciBpbnN0YW5jZSB0aGF0IHByZWZpeGVzIGFsbCBvdXRwdXQgd2l0aCB0aGUgZ2l2ZW4gbmFtZS5cclxuICAgICAqIEBwYXJhbSBuYW1lIHtTdHJpbmd9IC0gVGhlIGxhYmVsIHRvIHByZWZpeCBhbGwgb3V0cHV0IG9mIHRoaXMgbG9nZ2VyIHdpdGguXHJcbiAgICAgKiBAcmV0dXJucyB7T2JqZWN0fSAtIEEgTG9nZ2VyIGluc3RhbmNlLlxyXG4gICAgICogQGNvbnN0cnVjdG9yXHJcbiAgICAgKi9cclxuICAgIGZ1bmN0aW9uIExvZ2dlcihuYW1lKSB7XHJcbiAgICAgICAgdGhpcy5uYW1lID0gbmFtZTtcclxuICAgIH1cclxuXHJcbiAgICBMb2dnZXIucHJvdG90eXBlID0ge1xyXG4gICAgICAgIHRyYWNlOiBmdW5jdGlvbiAoKSB7XHJcbiAgICAgICAgICAgIGlmIChMb2dnZXIuX3NpbGVudCkgcmV0dXJuO1xyXG4gICAgICAgICAgICBpZiAoTE9HX0xFVkVMU1tMb2dnZXIuX2xldmVsXSA+IExPR19MRVZFTFMudHJhY2UpIHJldHVybjtcclxuICAgICAgICAgICAgYXJndW1lbnRzWzBdID0gJ1snICsgdGhpcy5uYW1lICsgJ10gJyArIGFyZ3VtZW50c1swXTtcclxuICAgICAgICAgICAgY29uc29sZS5pbmZvLmFwcGx5KGNvbnNvbGUsIGFyZ3VtZW50cyk7XHJcbiAgICAgICAgfSxcclxuICAgICAgICBkZWJ1ZzogZnVuY3Rpb24gKCkge1xyXG4gICAgICAgICAgICBpZiAoTG9nZ2VyLl9zaWxlbnQpIHJldHVybjtcclxuICAgICAgICAgICAgaWYgKExPR19MRVZFTFNbTG9nZ2VyLl9sZXZlbF0gPiBMT0dfTEVWRUxTLmRlYnVnKSByZXR1cm47XHJcbiAgICAgICAgICAgIGFyZ3VtZW50c1swXSA9ICdbJyArIHRoaXMubmFtZSArICddICcgKyBhcmd1bWVudHNbMF07XHJcbiAgICAgICAgICAgIGNvbnNvbGUuaW5mby5hcHBseShjb25zb2xlLCBhcmd1bWVudHMpO1xyXG4gICAgICAgIH0sXHJcbiAgICAgICAgaW5mbzogZnVuY3Rpb24oKSB7XHJcbiAgICAgICAgICAgIGlmIChMb2dnZXIuX3NpbGVudCkgcmV0dXJuO1xyXG4gICAgICAgICAgICBpZiAoTE9HX0xFVkVMU1tMb2dnZXIuX2xldmVsXSA+IExPR19MRVZFTFMuaW5mbykgcmV0dXJuO1xyXG4gICAgICAgICAgICBhcmd1bWVudHNbMF0gPSAnWycgKyB0aGlzLm5hbWUgKyAnXSAnICsgYXJndW1lbnRzWzBdO1xyXG4gICAgICAgICAgICBjb25zb2xlLmluZm8uYXBwbHkoY29uc29sZSwgYXJndW1lbnRzKTtcclxuICAgICAgICB9LFxyXG4gICAgICAgIHdhcm46IGZ1bmN0aW9uKCkge1xyXG4gICAgICAgICAgICBpZiAoTG9nZ2VyLl9zaWxlbnQpIHJldHVybjtcclxuICAgICAgICAgICAgaWYgKExPR19MRVZFTFNbTG9nZ2VyLl9sZXZlbF0gPiBMT0dfTEVWRUxTLndhcm4pIHJldHVybjtcclxuICAgICAgICAgICAgYXJndW1lbnRzWzBdID0gJ1snICsgdGhpcy5uYW1lICsgJ10gJyArIGFyZ3VtZW50c1swXTtcclxuICAgICAgICAgICAgY29uc29sZS53YXJuLmFwcGx5KGNvbnNvbGUsIGFyZ3VtZW50cyk7XHJcbiAgICAgICAgfSxcclxuICAgICAgICBlcnJvcjogZnVuY3Rpb24oKSB7XHJcbiAgICAgICAgICAgIGlmIChMb2dnZXIuX3NpbGVudCkgcmV0dXJuO1xyXG4gICAgICAgICAgICBpZiAoTE9HX0xFVkVMU1tMb2dnZXIuX2xldmVsXSA+IExPR19MRVZFTFMuZXJyb3IpIHJldHVybjtcclxuICAgICAgICAgICAgYXJndW1lbnRzWzBdID0gJ1snICsgdGhpcy5uYW1lICsgJ10gJyArIGFyZ3VtZW50c1swXTtcclxuICAgICAgICAgICAgY29uc29sZS5lcnJvci5hcHBseShjb25zb2xlLCBhcmd1bWVudHMpO1xyXG4gICAgICAgIH0sXHJcbiAgICAgICAgcmVwbGljYW50czogZnVuY3Rpb24oKSB7XHJcbiAgICAgICAgICAgIGlmIChMb2dnZXIuX3NpbGVudCkgcmV0dXJuO1xyXG4gICAgICAgICAgICBpZiAoIUxvZ2dlci5fc2hvdWxkTG9nUmVwbGljYW50cykgcmV0dXJuO1xyXG4gICAgICAgICAgICBhcmd1bWVudHNbMF0gPSAnWycgKyB0aGlzLm5hbWUgKyAnXSAnICsgYXJndW1lbnRzWzBdO1xyXG4gICAgICAgICAgICBjb25zb2xlLmluZm8uYXBwbHkoY29uc29sZSwgYXJndW1lbnRzKTtcclxuICAgICAgICB9XHJcbiAgICB9O1xyXG5cclxuICAgIExvZ2dlci5nbG9iYWxSZWNvbmZpZ3VyZSA9IGZ1bmN0aW9uKG9wdHMpIHtcclxuICAgICAgICBfY29uZmlndXJlKG9wdHMpO1xyXG4gICAgfTtcclxuXHJcbiAgICAvLyBJbml0aWFsaXplIHdpdGggZGVmYXVsdHNcclxuICAgIExvZ2dlci5fbGV2ZWwgPSAnaW5mbyc7XHJcbiAgICBMb2dnZXIuX3NpbGVudCA9IHRydWU7XHJcbiAgICBMb2dnZXIuX3Nob3VsZExvZ1JlcGxpY2FudHMgPSBmYWxzZTtcclxuXHJcbiAgICBfY29uZmlndXJlKGluaXRpYWxPcHRzKTtcclxuXHJcbiAgICBmdW5jdGlvbiBfY29uZmlndXJlKG9wdHMpIHtcclxuICAgICAgICAvLyBJbml0aWFsaXplIG9wdHMgd2l0aCBlbXB0eSBvYmplY3RzLCBpZiBub3RoaW5nIHdhcyBwcm92aWRlZC5cclxuICAgICAgICBvcHRzID0gb3B0cyB8fCB7fTtcclxuICAgICAgICBvcHRzLmNvbnNvbGUgPSBvcHRzLmNvbnNvbGUgfHwge307XHJcblxyXG4gICAgICAgIGlmICh0eXBlb2Ygb3B0cy5jb25zb2xlLmVuYWJsZWQgIT09ICd1bmRlZmluZWQnKSB7XHJcbiAgICAgICAgICAgIExvZ2dlci5fc2lsZW50ID0gIW9wdHMuY29uc29sZS5lbmFibGVkO1xyXG4gICAgICAgIH1cclxuXHJcbiAgICAgICAgaWYgKHR5cGVvZiBvcHRzLmNvbnNvbGUubGV2ZWwgIT09ICd1bmRlZmluZWQnKSB7XHJcbiAgICAgICAgICAgIExvZ2dlci5fbGV2ZWwgPSBvcHRzLmNvbnNvbGUubGV2ZWw7XHJcbiAgICAgICAgfVxyXG5cclxuICAgICAgICBpZiAodHlwZW9mIG9wdHMucmVwbGljYW50cyAhPT0gJ3VuZGVmaW5lZCcpIHtcclxuICAgICAgICAgICAgTG9nZ2VyLl9zaG91bGRMb2dSZXBsaWNhbnRzID0gb3B0cy5yZXBsaWNhbnRzO1xyXG4gICAgICAgIH1cclxuICAgIH1cclxuXHJcbiAgICByZXR1cm4gTG9nZ2VyO1xyXG59O1xyXG5cclxuIiwidmFyIGxvb2t1cCA9ICdBQkNERUZHSElKS0xNTk9QUVJTVFVWV1hZWmFiY2RlZmdoaWprbG1ub3BxcnN0dXZ3eHl6MDEyMzQ1Njc4OSsvJztcblxuOyhmdW5jdGlvbiAoZXhwb3J0cykge1xuXHQndXNlIHN0cmljdCc7XG5cbiAgdmFyIEFyciA9ICh0eXBlb2YgVWludDhBcnJheSAhPT0gJ3VuZGVmaW5lZCcpXG4gICAgPyBVaW50OEFycmF5XG4gICAgOiBBcnJheVxuXG5cdHZhciBQTFVTICAgPSAnKycuY2hhckNvZGVBdCgwKVxuXHR2YXIgU0xBU0ggID0gJy8nLmNoYXJDb2RlQXQoMClcblx0dmFyIE5VTUJFUiA9ICcwJy5jaGFyQ29kZUF0KDApXG5cdHZhciBMT1dFUiAgPSAnYScuY2hhckNvZGVBdCgwKVxuXHR2YXIgVVBQRVIgID0gJ0EnLmNoYXJDb2RlQXQoMClcblx0dmFyIFBMVVNfVVJMX1NBRkUgPSAnLScuY2hhckNvZGVBdCgwKVxuXHR2YXIgU0xBU0hfVVJMX1NBRkUgPSAnXycuY2hhckNvZGVBdCgwKVxuXG5cdGZ1bmN0aW9uIGRlY29kZSAoZWx0KSB7XG5cdFx0dmFyIGNvZGUgPSBlbHQuY2hhckNvZGVBdCgwKVxuXHRcdGlmIChjb2RlID09PSBQTFVTIHx8XG5cdFx0ICAgIGNvZGUgPT09IFBMVVNfVVJMX1NBRkUpXG5cdFx0XHRyZXR1cm4gNjIgLy8gJysnXG5cdFx0aWYgKGNvZGUgPT09IFNMQVNIIHx8XG5cdFx0ICAgIGNvZGUgPT09IFNMQVNIX1VSTF9TQUZFKVxuXHRcdFx0cmV0dXJuIDYzIC8vICcvJ1xuXHRcdGlmIChjb2RlIDwgTlVNQkVSKVxuXHRcdFx0cmV0dXJuIC0xIC8vbm8gbWF0Y2hcblx0XHRpZiAoY29kZSA8IE5VTUJFUiArIDEwKVxuXHRcdFx0cmV0dXJuIGNvZGUgLSBOVU1CRVIgKyAyNiArIDI2XG5cdFx0aWYgKGNvZGUgPCBVUFBFUiArIDI2KVxuXHRcdFx0cmV0dXJuIGNvZGUgLSBVUFBFUlxuXHRcdGlmIChjb2RlIDwgTE9XRVIgKyAyNilcblx0XHRcdHJldHVybiBjb2RlIC0gTE9XRVIgKyAyNlxuXHR9XG5cblx0ZnVuY3Rpb24gYjY0VG9CeXRlQXJyYXkgKGI2NCkge1xuXHRcdHZhciBpLCBqLCBsLCB0bXAsIHBsYWNlSG9sZGVycywgYXJyXG5cblx0XHRpZiAoYjY0Lmxlbmd0aCAlIDQgPiAwKSB7XG5cdFx0XHR0aHJvdyBuZXcgRXJyb3IoJ0ludmFsaWQgc3RyaW5nLiBMZW5ndGggbXVzdCBiZSBhIG11bHRpcGxlIG9mIDQnKVxuXHRcdH1cblxuXHRcdC8vIHRoZSBudW1iZXIgb2YgZXF1YWwgc2lnbnMgKHBsYWNlIGhvbGRlcnMpXG5cdFx0Ly8gaWYgdGhlcmUgYXJlIHR3byBwbGFjZWhvbGRlcnMsIHRoYW4gdGhlIHR3byBjaGFyYWN0ZXJzIGJlZm9yZSBpdFxuXHRcdC8vIHJlcHJlc2VudCBvbmUgYnl0ZVxuXHRcdC8vIGlmIHRoZXJlIGlzIG9ubHkgb25lLCB0aGVuIHRoZSB0aHJlZSBjaGFyYWN0ZXJzIGJlZm9yZSBpdCByZXByZXNlbnQgMiBieXRlc1xuXHRcdC8vIHRoaXMgaXMganVzdCBhIGNoZWFwIGhhY2sgdG8gbm90IGRvIGluZGV4T2YgdHdpY2Vcblx0XHR2YXIgbGVuID0gYjY0Lmxlbmd0aFxuXHRcdHBsYWNlSG9sZGVycyA9ICc9JyA9PT0gYjY0LmNoYXJBdChsZW4gLSAyKSA/IDIgOiAnPScgPT09IGI2NC5jaGFyQXQobGVuIC0gMSkgPyAxIDogMFxuXG5cdFx0Ly8gYmFzZTY0IGlzIDQvMyArIHVwIHRvIHR3byBjaGFyYWN0ZXJzIG9mIHRoZSBvcmlnaW5hbCBkYXRhXG5cdFx0YXJyID0gbmV3IEFycihiNjQubGVuZ3RoICogMyAvIDQgLSBwbGFjZUhvbGRlcnMpXG5cblx0XHQvLyBpZiB0aGVyZSBhcmUgcGxhY2Vob2xkZXJzLCBvbmx5IGdldCB1cCB0byB0aGUgbGFzdCBjb21wbGV0ZSA0IGNoYXJzXG5cdFx0bCA9IHBsYWNlSG9sZGVycyA+IDAgPyBiNjQubGVuZ3RoIC0gNCA6IGI2NC5sZW5ndGhcblxuXHRcdHZhciBMID0gMFxuXG5cdFx0ZnVuY3Rpb24gcHVzaCAodikge1xuXHRcdFx0YXJyW0wrK10gPSB2XG5cdFx0fVxuXG5cdFx0Zm9yIChpID0gMCwgaiA9IDA7IGkgPCBsOyBpICs9IDQsIGogKz0gMykge1xuXHRcdFx0dG1wID0gKGRlY29kZShiNjQuY2hhckF0KGkpKSA8PCAxOCkgfCAoZGVjb2RlKGI2NC5jaGFyQXQoaSArIDEpKSA8PCAxMikgfCAoZGVjb2RlKGI2NC5jaGFyQXQoaSArIDIpKSA8PCA2KSB8IGRlY29kZShiNjQuY2hhckF0KGkgKyAzKSlcblx0XHRcdHB1c2goKHRtcCAmIDB4RkYwMDAwKSA+PiAxNilcblx0XHRcdHB1c2goKHRtcCAmIDB4RkYwMCkgPj4gOClcblx0XHRcdHB1c2godG1wICYgMHhGRilcblx0XHR9XG5cblx0XHRpZiAocGxhY2VIb2xkZXJzID09PSAyKSB7XG5cdFx0XHR0bXAgPSAoZGVjb2RlKGI2NC5jaGFyQXQoaSkpIDw8IDIpIHwgKGRlY29kZShiNjQuY2hhckF0KGkgKyAxKSkgPj4gNClcblx0XHRcdHB1c2godG1wICYgMHhGRilcblx0XHR9IGVsc2UgaWYgKHBsYWNlSG9sZGVycyA9PT0gMSkge1xuXHRcdFx0dG1wID0gKGRlY29kZShiNjQuY2hhckF0KGkpKSA8PCAxMCkgfCAoZGVjb2RlKGI2NC5jaGFyQXQoaSArIDEpKSA8PCA0KSB8IChkZWNvZGUoYjY0LmNoYXJBdChpICsgMikpID4+IDIpXG5cdFx0XHRwdXNoKCh0bXAgPj4gOCkgJiAweEZGKVxuXHRcdFx0cHVzaCh0bXAgJiAweEZGKVxuXHRcdH1cblxuXHRcdHJldHVybiBhcnJcblx0fVxuXG5cdGZ1bmN0aW9uIHVpbnQ4VG9CYXNlNjQgKHVpbnQ4KSB7XG5cdFx0dmFyIGksXG5cdFx0XHRleHRyYUJ5dGVzID0gdWludDgubGVuZ3RoICUgMywgLy8gaWYgd2UgaGF2ZSAxIGJ5dGUgbGVmdCwgcGFkIDIgYnl0ZXNcblx0XHRcdG91dHB1dCA9IFwiXCIsXG5cdFx0XHR0ZW1wLCBsZW5ndGhcblxuXHRcdGZ1bmN0aW9uIGVuY29kZSAobnVtKSB7XG5cdFx0XHRyZXR1cm4gbG9va3VwLmNoYXJBdChudW0pXG5cdFx0fVxuXG5cdFx0ZnVuY3Rpb24gdHJpcGxldFRvQmFzZTY0IChudW0pIHtcblx0XHRcdHJldHVybiBlbmNvZGUobnVtID4+IDE4ICYgMHgzRikgKyBlbmNvZGUobnVtID4+IDEyICYgMHgzRikgKyBlbmNvZGUobnVtID4+IDYgJiAweDNGKSArIGVuY29kZShudW0gJiAweDNGKVxuXHRcdH1cblxuXHRcdC8vIGdvIHRocm91Z2ggdGhlIGFycmF5IGV2ZXJ5IHRocmVlIGJ5dGVzLCB3ZSdsbCBkZWFsIHdpdGggdHJhaWxpbmcgc3R1ZmYgbGF0ZXJcblx0XHRmb3IgKGkgPSAwLCBsZW5ndGggPSB1aW50OC5sZW5ndGggLSBleHRyYUJ5dGVzOyBpIDwgbGVuZ3RoOyBpICs9IDMpIHtcblx0XHRcdHRlbXAgPSAodWludDhbaV0gPDwgMTYpICsgKHVpbnQ4W2kgKyAxXSA8PCA4KSArICh1aW50OFtpICsgMl0pXG5cdFx0XHRvdXRwdXQgKz0gdHJpcGxldFRvQmFzZTY0KHRlbXApXG5cdFx0fVxuXG5cdFx0Ly8gcGFkIHRoZSBlbmQgd2l0aCB6ZXJvcywgYnV0IG1ha2Ugc3VyZSB0byBub3QgZm9yZ2V0IHRoZSBleHRyYSBieXRlc1xuXHRcdHN3aXRjaCAoZXh0cmFCeXRlcykge1xuXHRcdFx0Y2FzZSAxOlxuXHRcdFx0XHR0ZW1wID0gdWludDhbdWludDgubGVuZ3RoIC0gMV1cblx0XHRcdFx0b3V0cHV0ICs9IGVuY29kZSh0ZW1wID4+IDIpXG5cdFx0XHRcdG91dHB1dCArPSBlbmNvZGUoKHRlbXAgPDwgNCkgJiAweDNGKVxuXHRcdFx0XHRvdXRwdXQgKz0gJz09J1xuXHRcdFx0XHRicmVha1xuXHRcdFx0Y2FzZSAyOlxuXHRcdFx0XHR0ZW1wID0gKHVpbnQ4W3VpbnQ4Lmxlbmd0aCAtIDJdIDw8IDgpICsgKHVpbnQ4W3VpbnQ4Lmxlbmd0aCAtIDFdKVxuXHRcdFx0XHRvdXRwdXQgKz0gZW5jb2RlKHRlbXAgPj4gMTApXG5cdFx0XHRcdG91dHB1dCArPSBlbmNvZGUoKHRlbXAgPj4gNCkgJiAweDNGKVxuXHRcdFx0XHRvdXRwdXQgKz0gZW5jb2RlKCh0ZW1wIDw8IDIpICYgMHgzRilcblx0XHRcdFx0b3V0cHV0ICs9ICc9J1xuXHRcdFx0XHRicmVha1xuXHRcdH1cblxuXHRcdHJldHVybiBvdXRwdXRcblx0fVxuXG5cdGV4cG9ydHMudG9CeXRlQXJyYXkgPSBiNjRUb0J5dGVBcnJheVxuXHRleHBvcnRzLmZyb21CeXRlQXJyYXkgPSB1aW50OFRvQmFzZTY0XG59KHR5cGVvZiBleHBvcnRzID09PSAndW5kZWZpbmVkJyA/ICh0aGlzLmJhc2U2NGpzID0ge30pIDogZXhwb3J0cykpXG4iLG51bGwsIi8qIVxuICogVGhlIGJ1ZmZlciBtb2R1bGUgZnJvbSBub2RlLmpzLCBmb3IgdGhlIGJyb3dzZXIuXG4gKlxuICogQGF1dGhvciAgIEZlcm9zcyBBYm91a2hhZGlqZWggPGZlcm9zc0BmZXJvc3Mub3JnPiA8aHR0cDovL2Zlcm9zcy5vcmc+XG4gKiBAbGljZW5zZSAgTUlUXG4gKi9cbi8qIGVzbGludC1kaXNhYmxlIG5vLXByb3RvICovXG5cbid1c2Ugc3RyaWN0J1xuXG52YXIgYmFzZTY0ID0gcmVxdWlyZSgnYmFzZTY0LWpzJylcbnZhciBpZWVlNzU0ID0gcmVxdWlyZSgnaWVlZTc1NCcpXG52YXIgaXNBcnJheSA9IHJlcXVpcmUoJ2lzYXJyYXknKVxuXG5leHBvcnRzLkJ1ZmZlciA9IEJ1ZmZlclxuZXhwb3J0cy5TbG93QnVmZmVyID0gU2xvd0J1ZmZlclxuZXhwb3J0cy5JTlNQRUNUX01BWF9CWVRFUyA9IDUwXG5CdWZmZXIucG9vbFNpemUgPSA4MTkyIC8vIG5vdCB1c2VkIGJ5IHRoaXMgaW1wbGVtZW50YXRpb25cblxudmFyIHJvb3RQYXJlbnQgPSB7fVxuXG4vKipcbiAqIElmIGBCdWZmZXIuVFlQRURfQVJSQVlfU1VQUE9SVGA6XG4gKiAgID09PSB0cnVlICAgIFVzZSBVaW50OEFycmF5IGltcGxlbWVudGF0aW9uIChmYXN0ZXN0KVxuICogICA9PT0gZmFsc2UgICBVc2UgT2JqZWN0IGltcGxlbWVudGF0aW9uIChtb3N0IGNvbXBhdGlibGUsIGV2ZW4gSUU2KVxuICpcbiAqIEJyb3dzZXJzIHRoYXQgc3VwcG9ydCB0eXBlZCBhcnJheXMgYXJlIElFIDEwKywgRmlyZWZveCA0KywgQ2hyb21lIDcrLCBTYWZhcmkgNS4xKyxcbiAqIE9wZXJhIDExLjYrLCBpT1MgNC4yKy5cbiAqXG4gKiBEdWUgdG8gdmFyaW91cyBicm93c2VyIGJ1Z3MsIHNvbWV0aW1lcyB0aGUgT2JqZWN0IGltcGxlbWVudGF0aW9uIHdpbGwgYmUgdXNlZCBldmVuXG4gKiB3aGVuIHRoZSBicm93c2VyIHN1cHBvcnRzIHR5cGVkIGFycmF5cy5cbiAqXG4gKiBOb3RlOlxuICpcbiAqICAgLSBGaXJlZm94IDQtMjkgbGFja3Mgc3VwcG9ydCBmb3IgYWRkaW5nIG5ldyBwcm9wZXJ0aWVzIHRvIGBVaW50OEFycmF5YCBpbnN0YW5jZXMsXG4gKiAgICAgU2VlOiBodHRwczovL2J1Z3ppbGxhLm1vemlsbGEub3JnL3Nob3dfYnVnLmNnaT9pZD02OTU0MzguXG4gKlxuICogICAtIFNhZmFyaSA1LTcgbGFja3Mgc3VwcG9ydCBmb3IgY2hhbmdpbmcgdGhlIGBPYmplY3QucHJvdG90eXBlLmNvbnN0cnVjdG9yYCBwcm9wZXJ0eVxuICogICAgIG9uIG9iamVjdHMuXG4gKlxuICogICAtIENocm9tZSA5LTEwIGlzIG1pc3NpbmcgdGhlIGBUeXBlZEFycmF5LnByb3RvdHlwZS5zdWJhcnJheWAgZnVuY3Rpb24uXG4gKlxuICogICAtIElFMTAgaGFzIGEgYnJva2VuIGBUeXBlZEFycmF5LnByb3RvdHlwZS5zdWJhcnJheWAgZnVuY3Rpb24gd2hpY2ggcmV0dXJucyBhcnJheXMgb2ZcbiAqICAgICBpbmNvcnJlY3QgbGVuZ3RoIGluIHNvbWUgc2l0dWF0aW9ucy5cblxuICogV2UgZGV0ZWN0IHRoZXNlIGJ1Z2d5IGJyb3dzZXJzIGFuZCBzZXQgYEJ1ZmZlci5UWVBFRF9BUlJBWV9TVVBQT1JUYCB0byBgZmFsc2VgIHNvIHRoZXlcbiAqIGdldCB0aGUgT2JqZWN0IGltcGxlbWVudGF0aW9uLCB3aGljaCBpcyBzbG93ZXIgYnV0IGJlaGF2ZXMgY29ycmVjdGx5LlxuICovXG5CdWZmZXIuVFlQRURfQVJSQVlfU1VQUE9SVCA9IGdsb2JhbC5UWVBFRF9BUlJBWV9TVVBQT1JUICE9PSB1bmRlZmluZWRcbiAgPyBnbG9iYWwuVFlQRURfQVJSQVlfU1VQUE9SVFxuICA6IHR5cGVkQXJyYXlTdXBwb3J0KClcblxuZnVuY3Rpb24gdHlwZWRBcnJheVN1cHBvcnQgKCkge1xuICBmdW5jdGlvbiBCYXIgKCkge31cbiAgdHJ5IHtcbiAgICB2YXIgYXJyID0gbmV3IFVpbnQ4QXJyYXkoMSlcbiAgICBhcnIuZm9vID0gZnVuY3Rpb24gKCkgeyByZXR1cm4gNDIgfVxuICAgIGFyci5jb25zdHJ1Y3RvciA9IEJhclxuICAgIHJldHVybiBhcnIuZm9vKCkgPT09IDQyICYmIC8vIHR5cGVkIGFycmF5IGluc3RhbmNlcyBjYW4gYmUgYXVnbWVudGVkXG4gICAgICAgIGFyci5jb25zdHJ1Y3RvciA9PT0gQmFyICYmIC8vIGNvbnN0cnVjdG9yIGNhbiBiZSBzZXRcbiAgICAgICAgdHlwZW9mIGFyci5zdWJhcnJheSA9PT0gJ2Z1bmN0aW9uJyAmJiAvLyBjaHJvbWUgOS0xMCBsYWNrIGBzdWJhcnJheWBcbiAgICAgICAgYXJyLnN1YmFycmF5KDEsIDEpLmJ5dGVMZW5ndGggPT09IDAgLy8gaWUxMCBoYXMgYnJva2VuIGBzdWJhcnJheWBcbiAgfSBjYXRjaCAoZSkge1xuICAgIHJldHVybiBmYWxzZVxuICB9XG59XG5cbmZ1bmN0aW9uIGtNYXhMZW5ndGggKCkge1xuICByZXR1cm4gQnVmZmVyLlRZUEVEX0FSUkFZX1NVUFBPUlRcbiAgICA/IDB4N2ZmZmZmZmZcbiAgICA6IDB4M2ZmZmZmZmZcbn1cblxuLyoqXG4gKiBDbGFzczogQnVmZmVyXG4gKiA9PT09PT09PT09PT09XG4gKlxuICogVGhlIEJ1ZmZlciBjb25zdHJ1Y3RvciByZXR1cm5zIGluc3RhbmNlcyBvZiBgVWludDhBcnJheWAgdGhhdCBhcmUgYXVnbWVudGVkXG4gKiB3aXRoIGZ1bmN0aW9uIHByb3BlcnRpZXMgZm9yIGFsbCB0aGUgbm9kZSBgQnVmZmVyYCBBUEkgZnVuY3Rpb25zLiBXZSB1c2VcbiAqIGBVaW50OEFycmF5YCBzbyB0aGF0IHNxdWFyZSBicmFja2V0IG5vdGF0aW9uIHdvcmtzIGFzIGV4cGVjdGVkIC0tIGl0IHJldHVybnNcbiAqIGEgc2luZ2xlIG9jdGV0LlxuICpcbiAqIEJ5IGF1Z21lbnRpbmcgdGhlIGluc3RhbmNlcywgd2UgY2FuIGF2b2lkIG1vZGlmeWluZyB0aGUgYFVpbnQ4QXJyYXlgXG4gKiBwcm90b3R5cGUuXG4gKi9cbmZ1bmN0aW9uIEJ1ZmZlciAoYXJnKSB7XG4gIGlmICghKHRoaXMgaW5zdGFuY2VvZiBCdWZmZXIpKSB7XG4gICAgLy8gQXZvaWQgZ29pbmcgdGhyb3VnaCBhbiBBcmd1bWVudHNBZGFwdG9yVHJhbXBvbGluZSBpbiB0aGUgY29tbW9uIGNhc2UuXG4gICAgaWYgKGFyZ3VtZW50cy5sZW5ndGggPiAxKSByZXR1cm4gbmV3IEJ1ZmZlcihhcmcsIGFyZ3VtZW50c1sxXSlcbiAgICByZXR1cm4gbmV3IEJ1ZmZlcihhcmcpXG4gIH1cblxuICBpZiAoIUJ1ZmZlci5UWVBFRF9BUlJBWV9TVVBQT1JUKSB7XG4gICAgdGhpcy5sZW5ndGggPSAwXG4gICAgdGhpcy5wYXJlbnQgPSB1bmRlZmluZWRcbiAgfVxuXG4gIC8vIENvbW1vbiBjYXNlLlxuICBpZiAodHlwZW9mIGFyZyA9PT0gJ251bWJlcicpIHtcbiAgICByZXR1cm4gZnJvbU51bWJlcih0aGlzLCBhcmcpXG4gIH1cblxuICAvLyBTbGlnaHRseSBsZXNzIGNvbW1vbiBjYXNlLlxuICBpZiAodHlwZW9mIGFyZyA9PT0gJ3N0cmluZycpIHtcbiAgICByZXR1cm4gZnJvbVN0cmluZyh0aGlzLCBhcmcsIGFyZ3VtZW50cy5sZW5ndGggPiAxID8gYXJndW1lbnRzWzFdIDogJ3V0ZjgnKVxuICB9XG5cbiAgLy8gVW51c3VhbC5cbiAgcmV0dXJuIGZyb21PYmplY3QodGhpcywgYXJnKVxufVxuXG5mdW5jdGlvbiBmcm9tTnVtYmVyICh0aGF0LCBsZW5ndGgpIHtcbiAgdGhhdCA9IGFsbG9jYXRlKHRoYXQsIGxlbmd0aCA8IDAgPyAwIDogY2hlY2tlZChsZW5ndGgpIHwgMClcbiAgaWYgKCFCdWZmZXIuVFlQRURfQVJSQVlfU1VQUE9SVCkge1xuICAgIGZvciAodmFyIGkgPSAwOyBpIDwgbGVuZ3RoOyBpKyspIHtcbiAgICAgIHRoYXRbaV0gPSAwXG4gICAgfVxuICB9XG4gIHJldHVybiB0aGF0XG59XG5cbmZ1bmN0aW9uIGZyb21TdHJpbmcgKHRoYXQsIHN0cmluZywgZW5jb2RpbmcpIHtcbiAgaWYgKHR5cGVvZiBlbmNvZGluZyAhPT0gJ3N0cmluZycgfHwgZW5jb2RpbmcgPT09ICcnKSBlbmNvZGluZyA9ICd1dGY4J1xuXG4gIC8vIEFzc3VtcHRpb246IGJ5dGVMZW5ndGgoKSByZXR1cm4gdmFsdWUgaXMgYWx3YXlzIDwga01heExlbmd0aC5cbiAgdmFyIGxlbmd0aCA9IGJ5dGVMZW5ndGgoc3RyaW5nLCBlbmNvZGluZykgfCAwXG4gIHRoYXQgPSBhbGxvY2F0ZSh0aGF0LCBsZW5ndGgpXG5cbiAgdGhhdC53cml0ZShzdHJpbmcsIGVuY29kaW5nKVxuICByZXR1cm4gdGhhdFxufVxuXG5mdW5jdGlvbiBmcm9tT2JqZWN0ICh0aGF0LCBvYmplY3QpIHtcbiAgaWYgKEJ1ZmZlci5pc0J1ZmZlcihvYmplY3QpKSByZXR1cm4gZnJvbUJ1ZmZlcih0aGF0LCBvYmplY3QpXG5cbiAgaWYgKGlzQXJyYXkob2JqZWN0KSkgcmV0dXJuIGZyb21BcnJheSh0aGF0LCBvYmplY3QpXG5cbiAgaWYgKG9iamVjdCA9PSBudWxsKSB7XG4gICAgdGhyb3cgbmV3IFR5cGVFcnJvcignbXVzdCBzdGFydCB3aXRoIG51bWJlciwgYnVmZmVyLCBhcnJheSBvciBzdHJpbmcnKVxuICB9XG5cbiAgaWYgKHR5cGVvZiBBcnJheUJ1ZmZlciAhPT0gJ3VuZGVmaW5lZCcpIHtcbiAgICBpZiAob2JqZWN0LmJ1ZmZlciBpbnN0YW5jZW9mIEFycmF5QnVmZmVyKSB7XG4gICAgICByZXR1cm4gZnJvbVR5cGVkQXJyYXkodGhhdCwgb2JqZWN0KVxuICAgIH1cbiAgICBpZiAob2JqZWN0IGluc3RhbmNlb2YgQXJyYXlCdWZmZXIpIHtcbiAgICAgIHJldHVybiBmcm9tQXJyYXlCdWZmZXIodGhhdCwgb2JqZWN0KVxuICAgIH1cbiAgfVxuXG4gIGlmIChvYmplY3QubGVuZ3RoKSByZXR1cm4gZnJvbUFycmF5TGlrZSh0aGF0LCBvYmplY3QpXG5cbiAgcmV0dXJuIGZyb21Kc29uT2JqZWN0KHRoYXQsIG9iamVjdClcbn1cblxuZnVuY3Rpb24gZnJvbUJ1ZmZlciAodGhhdCwgYnVmZmVyKSB7XG4gIHZhciBsZW5ndGggPSBjaGVja2VkKGJ1ZmZlci5sZW5ndGgpIHwgMFxuICB0aGF0ID0gYWxsb2NhdGUodGhhdCwgbGVuZ3RoKVxuICBidWZmZXIuY29weSh0aGF0LCAwLCAwLCBsZW5ndGgpXG4gIHJldHVybiB0aGF0XG59XG5cbmZ1bmN0aW9uIGZyb21BcnJheSAodGhhdCwgYXJyYXkpIHtcbiAgdmFyIGxlbmd0aCA9IGNoZWNrZWQoYXJyYXkubGVuZ3RoKSB8IDBcbiAgdGhhdCA9IGFsbG9jYXRlKHRoYXQsIGxlbmd0aClcbiAgZm9yICh2YXIgaSA9IDA7IGkgPCBsZW5ndGg7IGkgKz0gMSkge1xuICAgIHRoYXRbaV0gPSBhcnJheVtpXSAmIDI1NVxuICB9XG4gIHJldHVybiB0aGF0XG59XG5cbi8vIER1cGxpY2F0ZSBvZiBmcm9tQXJyYXkoKSB0byBrZWVwIGZyb21BcnJheSgpIG1vbm9tb3JwaGljLlxuZnVuY3Rpb24gZnJvbVR5cGVkQXJyYXkgKHRoYXQsIGFycmF5KSB7XG4gIHZhciBsZW5ndGggPSBjaGVja2VkKGFycmF5Lmxlbmd0aCkgfCAwXG4gIHRoYXQgPSBhbGxvY2F0ZSh0aGF0LCBsZW5ndGgpXG4gIC8vIFRydW5jYXRpbmcgdGhlIGVsZW1lbnRzIGlzIHByb2JhYmx5IG5vdCB3aGF0IHBlb3BsZSBleHBlY3QgZnJvbSB0eXBlZFxuICAvLyBhcnJheXMgd2l0aCBCWVRFU19QRVJfRUxFTUVOVCA+IDEgYnV0IGl0J3MgY29tcGF0aWJsZSB3aXRoIHRoZSBiZWhhdmlvclxuICAvLyBvZiB0aGUgb2xkIEJ1ZmZlciBjb25zdHJ1Y3Rvci5cbiAgZm9yICh2YXIgaSA9IDA7IGkgPCBsZW5ndGg7IGkgKz0gMSkge1xuICAgIHRoYXRbaV0gPSBhcnJheVtpXSAmIDI1NVxuICB9XG4gIHJldHVybiB0aGF0XG59XG5cbmZ1bmN0aW9uIGZyb21BcnJheUJ1ZmZlciAodGhhdCwgYXJyYXkpIHtcbiAgaWYgKEJ1ZmZlci5UWVBFRF9BUlJBWV9TVVBQT1JUKSB7XG4gICAgLy8gUmV0dXJuIGFuIGF1Z21lbnRlZCBgVWludDhBcnJheWAgaW5zdGFuY2UsIGZvciBiZXN0IHBlcmZvcm1hbmNlXG4gICAgYXJyYXkuYnl0ZUxlbmd0aFxuICAgIHRoYXQgPSBCdWZmZXIuX2F1Z21lbnQobmV3IFVpbnQ4QXJyYXkoYXJyYXkpKVxuICB9IGVsc2Uge1xuICAgIC8vIEZhbGxiYWNrOiBSZXR1cm4gYW4gb2JqZWN0IGluc3RhbmNlIG9mIHRoZSBCdWZmZXIgY2xhc3NcbiAgICB0aGF0ID0gZnJvbVR5cGVkQXJyYXkodGhhdCwgbmV3IFVpbnQ4QXJyYXkoYXJyYXkpKVxuICB9XG4gIHJldHVybiB0aGF0XG59XG5cbmZ1bmN0aW9uIGZyb21BcnJheUxpa2UgKHRoYXQsIGFycmF5KSB7XG4gIHZhciBsZW5ndGggPSBjaGVja2VkKGFycmF5Lmxlbmd0aCkgfCAwXG4gIHRoYXQgPSBhbGxvY2F0ZSh0aGF0LCBsZW5ndGgpXG4gIGZvciAodmFyIGkgPSAwOyBpIDwgbGVuZ3RoOyBpICs9IDEpIHtcbiAgICB0aGF0W2ldID0gYXJyYXlbaV0gJiAyNTVcbiAgfVxuICByZXR1cm4gdGhhdFxufVxuXG4vLyBEZXNlcmlhbGl6ZSB7IHR5cGU6ICdCdWZmZXInLCBkYXRhOiBbMSwyLDMsLi4uXSB9IGludG8gYSBCdWZmZXIgb2JqZWN0LlxuLy8gUmV0dXJucyBhIHplcm8tbGVuZ3RoIGJ1ZmZlciBmb3IgaW5wdXRzIHRoYXQgZG9uJ3QgY29uZm9ybSB0byB0aGUgc3BlYy5cbmZ1bmN0aW9uIGZyb21Kc29uT2JqZWN0ICh0aGF0LCBvYmplY3QpIHtcbiAgdmFyIGFycmF5XG4gIHZhciBsZW5ndGggPSAwXG5cbiAgaWYgKG9iamVjdC50eXBlID09PSAnQnVmZmVyJyAmJiBpc0FycmF5KG9iamVjdC5kYXRhKSkge1xuICAgIGFycmF5ID0gb2JqZWN0LmRhdGFcbiAgICBsZW5ndGggPSBjaGVja2VkKGFycmF5Lmxlbmd0aCkgfCAwXG4gIH1cbiAgdGhhdCA9IGFsbG9jYXRlKHRoYXQsIGxlbmd0aClcblxuICBmb3IgKHZhciBpID0gMDsgaSA8IGxlbmd0aDsgaSArPSAxKSB7XG4gICAgdGhhdFtpXSA9IGFycmF5W2ldICYgMjU1XG4gIH1cbiAgcmV0dXJuIHRoYXRcbn1cblxuaWYgKEJ1ZmZlci5UWVBFRF9BUlJBWV9TVVBQT1JUKSB7XG4gIEJ1ZmZlci5wcm90b3R5cGUuX19wcm90b19fID0gVWludDhBcnJheS5wcm90b3R5cGVcbiAgQnVmZmVyLl9fcHJvdG9fXyA9IFVpbnQ4QXJyYXlcbn0gZWxzZSB7XG4gIC8vIHByZS1zZXQgZm9yIHZhbHVlcyB0aGF0IG1heSBleGlzdCBpbiB0aGUgZnV0dXJlXG4gIEJ1ZmZlci5wcm90b3R5cGUubGVuZ3RoID0gdW5kZWZpbmVkXG4gIEJ1ZmZlci5wcm90b3R5cGUucGFyZW50ID0gdW5kZWZpbmVkXG59XG5cbmZ1bmN0aW9uIGFsbG9jYXRlICh0aGF0LCBsZW5ndGgpIHtcbiAgaWYgKEJ1ZmZlci5UWVBFRF9BUlJBWV9TVVBQT1JUKSB7XG4gICAgLy8gUmV0dXJuIGFuIGF1Z21lbnRlZCBgVWludDhBcnJheWAgaW5zdGFuY2UsIGZvciBiZXN0IHBlcmZvcm1hbmNlXG4gICAgdGhhdCA9IEJ1ZmZlci5fYXVnbWVudChuZXcgVWludDhBcnJheShsZW5ndGgpKVxuICAgIHRoYXQuX19wcm90b19fID0gQnVmZmVyLnByb3RvdHlwZVxuICB9IGVsc2Uge1xuICAgIC8vIEZhbGxiYWNrOiBSZXR1cm4gYW4gb2JqZWN0IGluc3RhbmNlIG9mIHRoZSBCdWZmZXIgY2xhc3NcbiAgICB0aGF0Lmxlbmd0aCA9IGxlbmd0aFxuICAgIHRoYXQuX2lzQnVmZmVyID0gdHJ1ZVxuICB9XG5cbiAgdmFyIGZyb21Qb29sID0gbGVuZ3RoICE9PSAwICYmIGxlbmd0aCA8PSBCdWZmZXIucG9vbFNpemUgPj4+IDFcbiAgaWYgKGZyb21Qb29sKSB0aGF0LnBhcmVudCA9IHJvb3RQYXJlbnRcblxuICByZXR1cm4gdGhhdFxufVxuXG5mdW5jdGlvbiBjaGVja2VkIChsZW5ndGgpIHtcbiAgLy8gTm90ZTogY2Fubm90IHVzZSBgbGVuZ3RoIDwga01heExlbmd0aGAgaGVyZSBiZWNhdXNlIHRoYXQgZmFpbHMgd2hlblxuICAvLyBsZW5ndGggaXMgTmFOICh3aGljaCBpcyBvdGhlcndpc2UgY29lcmNlZCB0byB6ZXJvLilcbiAgaWYgKGxlbmd0aCA+PSBrTWF4TGVuZ3RoKCkpIHtcbiAgICB0aHJvdyBuZXcgUmFuZ2VFcnJvcignQXR0ZW1wdCB0byBhbGxvY2F0ZSBCdWZmZXIgbGFyZ2VyIHRoYW4gbWF4aW11bSAnICtcbiAgICAgICAgICAgICAgICAgICAgICAgICAnc2l6ZTogMHgnICsga01heExlbmd0aCgpLnRvU3RyaW5nKDE2KSArICcgYnl0ZXMnKVxuICB9XG4gIHJldHVybiBsZW5ndGggfCAwXG59XG5cbmZ1bmN0aW9uIFNsb3dCdWZmZXIgKHN1YmplY3QsIGVuY29kaW5nKSB7XG4gIGlmICghKHRoaXMgaW5zdGFuY2VvZiBTbG93QnVmZmVyKSkgcmV0dXJuIG5ldyBTbG93QnVmZmVyKHN1YmplY3QsIGVuY29kaW5nKVxuXG4gIHZhciBidWYgPSBuZXcgQnVmZmVyKHN1YmplY3QsIGVuY29kaW5nKVxuICBkZWxldGUgYnVmLnBhcmVudFxuICByZXR1cm4gYnVmXG59XG5cbkJ1ZmZlci5pc0J1ZmZlciA9IGZ1bmN0aW9uIGlzQnVmZmVyIChiKSB7XG4gIHJldHVybiAhIShiICE9IG51bGwgJiYgYi5faXNCdWZmZXIpXG59XG5cbkJ1ZmZlci5jb21wYXJlID0gZnVuY3Rpb24gY29tcGFyZSAoYSwgYikge1xuICBpZiAoIUJ1ZmZlci5pc0J1ZmZlcihhKSB8fCAhQnVmZmVyLmlzQnVmZmVyKGIpKSB7XG4gICAgdGhyb3cgbmV3IFR5cGVFcnJvcignQXJndW1lbnRzIG11c3QgYmUgQnVmZmVycycpXG4gIH1cblxuICBpZiAoYSA9PT0gYikgcmV0dXJuIDBcblxuICB2YXIgeCA9IGEubGVuZ3RoXG4gIHZhciB5ID0gYi5sZW5ndGhcblxuICB2YXIgaSA9IDBcbiAgdmFyIGxlbiA9IE1hdGgubWluKHgsIHkpXG4gIHdoaWxlIChpIDwgbGVuKSB7XG4gICAgaWYgKGFbaV0gIT09IGJbaV0pIGJyZWFrXG5cbiAgICArK2lcbiAgfVxuXG4gIGlmIChpICE9PSBsZW4pIHtcbiAgICB4ID0gYVtpXVxuICAgIHkgPSBiW2ldXG4gIH1cblxuICBpZiAoeCA8IHkpIHJldHVybiAtMVxuICBpZiAoeSA8IHgpIHJldHVybiAxXG4gIHJldHVybiAwXG59XG5cbkJ1ZmZlci5pc0VuY29kaW5nID0gZnVuY3Rpb24gaXNFbmNvZGluZyAoZW5jb2RpbmcpIHtcbiAgc3dpdGNoIChTdHJpbmcoZW5jb2RpbmcpLnRvTG93ZXJDYXNlKCkpIHtcbiAgICBjYXNlICdoZXgnOlxuICAgIGNhc2UgJ3V0ZjgnOlxuICAgIGNhc2UgJ3V0Zi04JzpcbiAgICBjYXNlICdhc2NpaSc6XG4gICAgY2FzZSAnYmluYXJ5JzpcbiAgICBjYXNlICdiYXNlNjQnOlxuICAgIGNhc2UgJ3Jhdyc6XG4gICAgY2FzZSAndWNzMic6XG4gICAgY2FzZSAndWNzLTInOlxuICAgIGNhc2UgJ3V0ZjE2bGUnOlxuICAgIGNhc2UgJ3V0Zi0xNmxlJzpcbiAgICAgIHJldHVybiB0cnVlXG4gICAgZGVmYXVsdDpcbiAgICAgIHJldHVybiBmYWxzZVxuICB9XG59XG5cbkJ1ZmZlci5jb25jYXQgPSBmdW5jdGlvbiBjb25jYXQgKGxpc3QsIGxlbmd0aCkge1xuICBpZiAoIWlzQXJyYXkobGlzdCkpIHRocm93IG5ldyBUeXBlRXJyb3IoJ2xpc3QgYXJndW1lbnQgbXVzdCBiZSBhbiBBcnJheSBvZiBCdWZmZXJzLicpXG5cbiAgaWYgKGxpc3QubGVuZ3RoID09PSAwKSB7XG4gICAgcmV0dXJuIG5ldyBCdWZmZXIoMClcbiAgfVxuXG4gIHZhciBpXG4gIGlmIChsZW5ndGggPT09IHVuZGVmaW5lZCkge1xuICAgIGxlbmd0aCA9IDBcbiAgICBmb3IgKGkgPSAwOyBpIDwgbGlzdC5sZW5ndGg7IGkrKykge1xuICAgICAgbGVuZ3RoICs9IGxpc3RbaV0ubGVuZ3RoXG4gICAgfVxuICB9XG5cbiAgdmFyIGJ1ZiA9IG5ldyBCdWZmZXIobGVuZ3RoKVxuICB2YXIgcG9zID0gMFxuICBmb3IgKGkgPSAwOyBpIDwgbGlzdC5sZW5ndGg7IGkrKykge1xuICAgIHZhciBpdGVtID0gbGlzdFtpXVxuICAgIGl0ZW0uY29weShidWYsIHBvcylcbiAgICBwb3MgKz0gaXRlbS5sZW5ndGhcbiAgfVxuICByZXR1cm4gYnVmXG59XG5cbmZ1bmN0aW9uIGJ5dGVMZW5ndGggKHN0cmluZywgZW5jb2RpbmcpIHtcbiAgaWYgKHR5cGVvZiBzdHJpbmcgIT09ICdzdHJpbmcnKSBzdHJpbmcgPSAnJyArIHN0cmluZ1xuXG4gIHZhciBsZW4gPSBzdHJpbmcubGVuZ3RoXG4gIGlmIChsZW4gPT09IDApIHJldHVybiAwXG5cbiAgLy8gVXNlIGEgZm9yIGxvb3AgdG8gYXZvaWQgcmVjdXJzaW9uXG4gIHZhciBsb3dlcmVkQ2FzZSA9IGZhbHNlXG4gIGZvciAoOzspIHtcbiAgICBzd2l0Y2ggKGVuY29kaW5nKSB7XG4gICAgICBjYXNlICdhc2NpaSc6XG4gICAgICBjYXNlICdiaW5hcnknOlxuICAgICAgLy8gRGVwcmVjYXRlZFxuICAgICAgY2FzZSAncmF3JzpcbiAgICAgIGNhc2UgJ3Jhd3MnOlxuICAgICAgICByZXR1cm4gbGVuXG4gICAgICBjYXNlICd1dGY4JzpcbiAgICAgIGNhc2UgJ3V0Zi04JzpcbiAgICAgICAgcmV0dXJuIHV0ZjhUb0J5dGVzKHN0cmluZykubGVuZ3RoXG4gICAgICBjYXNlICd1Y3MyJzpcbiAgICAgIGNhc2UgJ3Vjcy0yJzpcbiAgICAgIGNhc2UgJ3V0ZjE2bGUnOlxuICAgICAgY2FzZSAndXRmLTE2bGUnOlxuICAgICAgICByZXR1cm4gbGVuICogMlxuICAgICAgY2FzZSAnaGV4JzpcbiAgICAgICAgcmV0dXJuIGxlbiA+Pj4gMVxuICAgICAgY2FzZSAnYmFzZTY0JzpcbiAgICAgICAgcmV0dXJuIGJhc2U2NFRvQnl0ZXMoc3RyaW5nKS5sZW5ndGhcbiAgICAgIGRlZmF1bHQ6XG4gICAgICAgIGlmIChsb3dlcmVkQ2FzZSkgcmV0dXJuIHV0ZjhUb0J5dGVzKHN0cmluZykubGVuZ3RoIC8vIGFzc3VtZSB1dGY4XG4gICAgICAgIGVuY29kaW5nID0gKCcnICsgZW5jb2RpbmcpLnRvTG93ZXJDYXNlKClcbiAgICAgICAgbG93ZXJlZENhc2UgPSB0cnVlXG4gICAgfVxuICB9XG59XG5CdWZmZXIuYnl0ZUxlbmd0aCA9IGJ5dGVMZW5ndGhcblxuZnVuY3Rpb24gc2xvd1RvU3RyaW5nIChlbmNvZGluZywgc3RhcnQsIGVuZCkge1xuICB2YXIgbG93ZXJlZENhc2UgPSBmYWxzZVxuXG4gIHN0YXJ0ID0gc3RhcnQgfCAwXG4gIGVuZCA9IGVuZCA9PT0gdW5kZWZpbmVkIHx8IGVuZCA9PT0gSW5maW5pdHkgPyB0aGlzLmxlbmd0aCA6IGVuZCB8IDBcblxuICBpZiAoIWVuY29kaW5nKSBlbmNvZGluZyA9ICd1dGY4J1xuICBpZiAoc3RhcnQgPCAwKSBzdGFydCA9IDBcbiAgaWYgKGVuZCA+IHRoaXMubGVuZ3RoKSBlbmQgPSB0aGlzLmxlbmd0aFxuICBpZiAoZW5kIDw9IHN0YXJ0KSByZXR1cm4gJydcblxuICB3aGlsZSAodHJ1ZSkge1xuICAgIHN3aXRjaCAoZW5jb2RpbmcpIHtcbiAgICAgIGNhc2UgJ2hleCc6XG4gICAgICAgIHJldHVybiBoZXhTbGljZSh0aGlzLCBzdGFydCwgZW5kKVxuXG4gICAgICBjYXNlICd1dGY4JzpcbiAgICAgIGNhc2UgJ3V0Zi04JzpcbiAgICAgICAgcmV0dXJuIHV0ZjhTbGljZSh0aGlzLCBzdGFydCwgZW5kKVxuXG4gICAgICBjYXNlICdhc2NpaSc6XG4gICAgICAgIHJldHVybiBhc2NpaVNsaWNlKHRoaXMsIHN0YXJ0LCBlbmQpXG5cbiAgICAgIGNhc2UgJ2JpbmFyeSc6XG4gICAgICAgIHJldHVybiBiaW5hcnlTbGljZSh0aGlzLCBzdGFydCwgZW5kKVxuXG4gICAgICBjYXNlICdiYXNlNjQnOlxuICAgICAgICByZXR1cm4gYmFzZTY0U2xpY2UodGhpcywgc3RhcnQsIGVuZClcblxuICAgICAgY2FzZSAndWNzMic6XG4gICAgICBjYXNlICd1Y3MtMic6XG4gICAgICBjYXNlICd1dGYxNmxlJzpcbiAgICAgIGNhc2UgJ3V0Zi0xNmxlJzpcbiAgICAgICAgcmV0dXJuIHV0ZjE2bGVTbGljZSh0aGlzLCBzdGFydCwgZW5kKVxuXG4gICAgICBkZWZhdWx0OlxuICAgICAgICBpZiAobG93ZXJlZENhc2UpIHRocm93IG5ldyBUeXBlRXJyb3IoJ1Vua25vd24gZW5jb2Rpbmc6ICcgKyBlbmNvZGluZylcbiAgICAgICAgZW5jb2RpbmcgPSAoZW5jb2RpbmcgKyAnJykudG9Mb3dlckNhc2UoKVxuICAgICAgICBsb3dlcmVkQ2FzZSA9IHRydWVcbiAgICB9XG4gIH1cbn1cblxuQnVmZmVyLnByb3RvdHlwZS50b1N0cmluZyA9IGZ1bmN0aW9uIHRvU3RyaW5nICgpIHtcbiAgdmFyIGxlbmd0aCA9IHRoaXMubGVuZ3RoIHwgMFxuICBpZiAobGVuZ3RoID09PSAwKSByZXR1cm4gJydcbiAgaWYgKGFyZ3VtZW50cy5sZW5ndGggPT09IDApIHJldHVybiB1dGY4U2xpY2UodGhpcywgMCwgbGVuZ3RoKVxuICByZXR1cm4gc2xvd1RvU3RyaW5nLmFwcGx5KHRoaXMsIGFyZ3VtZW50cylcbn1cblxuQnVmZmVyLnByb3RvdHlwZS5lcXVhbHMgPSBmdW5jdGlvbiBlcXVhbHMgKGIpIHtcbiAgaWYgKCFCdWZmZXIuaXNCdWZmZXIoYikpIHRocm93IG5ldyBUeXBlRXJyb3IoJ0FyZ3VtZW50IG11c3QgYmUgYSBCdWZmZXInKVxuICBpZiAodGhpcyA9PT0gYikgcmV0dXJuIHRydWVcbiAgcmV0dXJuIEJ1ZmZlci5jb21wYXJlKHRoaXMsIGIpID09PSAwXG59XG5cbkJ1ZmZlci5wcm90b3R5cGUuaW5zcGVjdCA9IGZ1bmN0aW9uIGluc3BlY3QgKCkge1xuICB2YXIgc3RyID0gJydcbiAgdmFyIG1heCA9IGV4cG9ydHMuSU5TUEVDVF9NQVhfQllURVNcbiAgaWYgKHRoaXMubGVuZ3RoID4gMCkge1xuICAgIHN0ciA9IHRoaXMudG9TdHJpbmcoJ2hleCcsIDAsIG1heCkubWF0Y2goLy57Mn0vZykuam9pbignICcpXG4gICAgaWYgKHRoaXMubGVuZ3RoID4gbWF4KSBzdHIgKz0gJyAuLi4gJ1xuICB9XG4gIHJldHVybiAnPEJ1ZmZlciAnICsgc3RyICsgJz4nXG59XG5cbkJ1ZmZlci5wcm90b3R5cGUuY29tcGFyZSA9IGZ1bmN0aW9uIGNvbXBhcmUgKGIpIHtcbiAgaWYgKCFCdWZmZXIuaXNCdWZmZXIoYikpIHRocm93IG5ldyBUeXBlRXJyb3IoJ0FyZ3VtZW50IG11c3QgYmUgYSBCdWZmZXInKVxuICBpZiAodGhpcyA9PT0gYikgcmV0dXJuIDBcbiAgcmV0dXJuIEJ1ZmZlci5jb21wYXJlKHRoaXMsIGIpXG59XG5cbkJ1ZmZlci5wcm90b3R5cGUuaW5kZXhPZiA9IGZ1bmN0aW9uIGluZGV4T2YgKHZhbCwgYnl0ZU9mZnNldCkge1xuICBpZiAoYnl0ZU9mZnNldCA+IDB4N2ZmZmZmZmYpIGJ5dGVPZmZzZXQgPSAweDdmZmZmZmZmXG4gIGVsc2UgaWYgKGJ5dGVPZmZzZXQgPCAtMHg4MDAwMDAwMCkgYnl0ZU9mZnNldCA9IC0weDgwMDAwMDAwXG4gIGJ5dGVPZmZzZXQgPj49IDBcblxuICBpZiAodGhpcy5sZW5ndGggPT09IDApIHJldHVybiAtMVxuICBpZiAoYnl0ZU9mZnNldCA+PSB0aGlzLmxlbmd0aCkgcmV0dXJuIC0xXG5cbiAgLy8gTmVnYXRpdmUgb2Zmc2V0cyBzdGFydCBmcm9tIHRoZSBlbmQgb2YgdGhlIGJ1ZmZlclxuICBpZiAoYnl0ZU9mZnNldCA8IDApIGJ5dGVPZmZzZXQgPSBNYXRoLm1heCh0aGlzLmxlbmd0aCArIGJ5dGVPZmZzZXQsIDApXG5cbiAgaWYgKHR5cGVvZiB2YWwgPT09ICdzdHJpbmcnKSB7XG4gICAgaWYgKHZhbC5sZW5ndGggPT09IDApIHJldHVybiAtMSAvLyBzcGVjaWFsIGNhc2U6IGxvb2tpbmcgZm9yIGVtcHR5IHN0cmluZyBhbHdheXMgZmFpbHNcbiAgICByZXR1cm4gU3RyaW5nLnByb3RvdHlwZS5pbmRleE9mLmNhbGwodGhpcywgdmFsLCBieXRlT2Zmc2V0KVxuICB9XG4gIGlmIChCdWZmZXIuaXNCdWZmZXIodmFsKSkge1xuICAgIHJldHVybiBhcnJheUluZGV4T2YodGhpcywgdmFsLCBieXRlT2Zmc2V0KVxuICB9XG4gIGlmICh0eXBlb2YgdmFsID09PSAnbnVtYmVyJykge1xuICAgIGlmIChCdWZmZXIuVFlQRURfQVJSQVlfU1VQUE9SVCAmJiBVaW50OEFycmF5LnByb3RvdHlwZS5pbmRleE9mID09PSAnZnVuY3Rpb24nKSB7XG4gICAgICByZXR1cm4gVWludDhBcnJheS5wcm90b3R5cGUuaW5kZXhPZi5jYWxsKHRoaXMsIHZhbCwgYnl0ZU9mZnNldClcbiAgICB9XG4gICAgcmV0dXJuIGFycmF5SW5kZXhPZih0aGlzLCBbIHZhbCBdLCBieXRlT2Zmc2V0KVxuICB9XG5cbiAgZnVuY3Rpb24gYXJyYXlJbmRleE9mIChhcnIsIHZhbCwgYnl0ZU9mZnNldCkge1xuICAgIHZhciBmb3VuZEluZGV4ID0gLTFcbiAgICBmb3IgKHZhciBpID0gMDsgYnl0ZU9mZnNldCArIGkgPCBhcnIubGVuZ3RoOyBpKyspIHtcbiAgICAgIGlmIChhcnJbYnl0ZU9mZnNldCArIGldID09PSB2YWxbZm91bmRJbmRleCA9PT0gLTEgPyAwIDogaSAtIGZvdW5kSW5kZXhdKSB7XG4gICAgICAgIGlmIChmb3VuZEluZGV4ID09PSAtMSkgZm91bmRJbmRleCA9IGlcbiAgICAgICAgaWYgKGkgLSBmb3VuZEluZGV4ICsgMSA9PT0gdmFsLmxlbmd0aCkgcmV0dXJuIGJ5dGVPZmZzZXQgKyBmb3VuZEluZGV4XG4gICAgICB9IGVsc2Uge1xuICAgICAgICBmb3VuZEluZGV4ID0gLTFcbiAgICAgIH1cbiAgICB9XG4gICAgcmV0dXJuIC0xXG4gIH1cblxuICB0aHJvdyBuZXcgVHlwZUVycm9yKCd2YWwgbXVzdCBiZSBzdHJpbmcsIG51bWJlciBvciBCdWZmZXInKVxufVxuXG4vLyBgZ2V0YCBpcyBkZXByZWNhdGVkXG5CdWZmZXIucHJvdG90eXBlLmdldCA9IGZ1bmN0aW9uIGdldCAob2Zmc2V0KSB7XG4gIGNvbnNvbGUubG9nKCcuZ2V0KCkgaXMgZGVwcmVjYXRlZC4gQWNjZXNzIHVzaW5nIGFycmF5IGluZGV4ZXMgaW5zdGVhZC4nKVxuICByZXR1cm4gdGhpcy5yZWFkVUludDgob2Zmc2V0KVxufVxuXG4vLyBgc2V0YCBpcyBkZXByZWNhdGVkXG5CdWZmZXIucHJvdG90eXBlLnNldCA9IGZ1bmN0aW9uIHNldCAodiwgb2Zmc2V0KSB7XG4gIGNvbnNvbGUubG9nKCcuc2V0KCkgaXMgZGVwcmVjYXRlZC4gQWNjZXNzIHVzaW5nIGFycmF5IGluZGV4ZXMgaW5zdGVhZC4nKVxuICByZXR1cm4gdGhpcy53cml0ZVVJbnQ4KHYsIG9mZnNldClcbn1cblxuZnVuY3Rpb24gaGV4V3JpdGUgKGJ1Ziwgc3RyaW5nLCBvZmZzZXQsIGxlbmd0aCkge1xuICBvZmZzZXQgPSBOdW1iZXIob2Zmc2V0KSB8fCAwXG4gIHZhciByZW1haW5pbmcgPSBidWYubGVuZ3RoIC0gb2Zmc2V0XG4gIGlmICghbGVuZ3RoKSB7XG4gICAgbGVuZ3RoID0gcmVtYWluaW5nXG4gIH0gZWxzZSB7XG4gICAgbGVuZ3RoID0gTnVtYmVyKGxlbmd0aClcbiAgICBpZiAobGVuZ3RoID4gcmVtYWluaW5nKSB7XG4gICAgICBsZW5ndGggPSByZW1haW5pbmdcbiAgICB9XG4gIH1cblxuICAvLyBtdXN0IGJlIGFuIGV2ZW4gbnVtYmVyIG9mIGRpZ2l0c1xuICB2YXIgc3RyTGVuID0gc3RyaW5nLmxlbmd0aFxuICBpZiAoc3RyTGVuICUgMiAhPT0gMCkgdGhyb3cgbmV3IEVycm9yKCdJbnZhbGlkIGhleCBzdHJpbmcnKVxuXG4gIGlmIChsZW5ndGggPiBzdHJMZW4gLyAyKSB7XG4gICAgbGVuZ3RoID0gc3RyTGVuIC8gMlxuICB9XG4gIGZvciAodmFyIGkgPSAwOyBpIDwgbGVuZ3RoOyBpKyspIHtcbiAgICB2YXIgcGFyc2VkID0gcGFyc2VJbnQoc3RyaW5nLnN1YnN0cihpICogMiwgMiksIDE2KVxuICAgIGlmIChpc05hTihwYXJzZWQpKSB0aHJvdyBuZXcgRXJyb3IoJ0ludmFsaWQgaGV4IHN0cmluZycpXG4gICAgYnVmW29mZnNldCArIGldID0gcGFyc2VkXG4gIH1cbiAgcmV0dXJuIGlcbn1cblxuZnVuY3Rpb24gdXRmOFdyaXRlIChidWYsIHN0cmluZywgb2Zmc2V0LCBsZW5ndGgpIHtcbiAgcmV0dXJuIGJsaXRCdWZmZXIodXRmOFRvQnl0ZXMoc3RyaW5nLCBidWYubGVuZ3RoIC0gb2Zmc2V0KSwgYnVmLCBvZmZzZXQsIGxlbmd0aClcbn1cblxuZnVuY3Rpb24gYXNjaWlXcml0ZSAoYnVmLCBzdHJpbmcsIG9mZnNldCwgbGVuZ3RoKSB7XG4gIHJldHVybiBibGl0QnVmZmVyKGFzY2lpVG9CeXRlcyhzdHJpbmcpLCBidWYsIG9mZnNldCwgbGVuZ3RoKVxufVxuXG5mdW5jdGlvbiBiaW5hcnlXcml0ZSAoYnVmLCBzdHJpbmcsIG9mZnNldCwgbGVuZ3RoKSB7XG4gIHJldHVybiBhc2NpaVdyaXRlKGJ1Ziwgc3RyaW5nLCBvZmZzZXQsIGxlbmd0aClcbn1cblxuZnVuY3Rpb24gYmFzZTY0V3JpdGUgKGJ1Ziwgc3RyaW5nLCBvZmZzZXQsIGxlbmd0aCkge1xuICByZXR1cm4gYmxpdEJ1ZmZlcihiYXNlNjRUb0J5dGVzKHN0cmluZyksIGJ1Ziwgb2Zmc2V0LCBsZW5ndGgpXG59XG5cbmZ1bmN0aW9uIHVjczJXcml0ZSAoYnVmLCBzdHJpbmcsIG9mZnNldCwgbGVuZ3RoKSB7XG4gIHJldHVybiBibGl0QnVmZmVyKHV0ZjE2bGVUb0J5dGVzKHN0cmluZywgYnVmLmxlbmd0aCAtIG9mZnNldCksIGJ1Ziwgb2Zmc2V0LCBsZW5ndGgpXG59XG5cbkJ1ZmZlci5wcm90b3R5cGUud3JpdGUgPSBmdW5jdGlvbiB3cml0ZSAoc3RyaW5nLCBvZmZzZXQsIGxlbmd0aCwgZW5jb2RpbmcpIHtcbiAgLy8gQnVmZmVyI3dyaXRlKHN0cmluZylcbiAgaWYgKG9mZnNldCA9PT0gdW5kZWZpbmVkKSB7XG4gICAgZW5jb2RpbmcgPSAndXRmOCdcbiAgICBsZW5ndGggPSB0aGlzLmxlbmd0aFxuICAgIG9mZnNldCA9IDBcbiAgLy8gQnVmZmVyI3dyaXRlKHN0cmluZywgZW5jb2RpbmcpXG4gIH0gZWxzZSBpZiAobGVuZ3RoID09PSB1bmRlZmluZWQgJiYgdHlwZW9mIG9mZnNldCA9PT0gJ3N0cmluZycpIHtcbiAgICBlbmNvZGluZyA9IG9mZnNldFxuICAgIGxlbmd0aCA9IHRoaXMubGVuZ3RoXG4gICAgb2Zmc2V0ID0gMFxuICAvLyBCdWZmZXIjd3JpdGUoc3RyaW5nLCBvZmZzZXRbLCBsZW5ndGhdWywgZW5jb2RpbmddKVxuICB9IGVsc2UgaWYgKGlzRmluaXRlKG9mZnNldCkpIHtcbiAgICBvZmZzZXQgPSBvZmZzZXQgfCAwXG4gICAgaWYgKGlzRmluaXRlKGxlbmd0aCkpIHtcbiAgICAgIGxlbmd0aCA9IGxlbmd0aCB8IDBcbiAgICAgIGlmIChlbmNvZGluZyA9PT0gdW5kZWZpbmVkKSBlbmNvZGluZyA9ICd1dGY4J1xuICAgIH0gZWxzZSB7XG4gICAgICBlbmNvZGluZyA9IGxlbmd0aFxuICAgICAgbGVuZ3RoID0gdW5kZWZpbmVkXG4gICAgfVxuICAvLyBsZWdhY3kgd3JpdGUoc3RyaW5nLCBlbmNvZGluZywgb2Zmc2V0LCBsZW5ndGgpIC0gcmVtb3ZlIGluIHYwLjEzXG4gIH0gZWxzZSB7XG4gICAgdmFyIHN3YXAgPSBlbmNvZGluZ1xuICAgIGVuY29kaW5nID0gb2Zmc2V0XG4gICAgb2Zmc2V0ID0gbGVuZ3RoIHwgMFxuICAgIGxlbmd0aCA9IHN3YXBcbiAgfVxuXG4gIHZhciByZW1haW5pbmcgPSB0aGlzLmxlbmd0aCAtIG9mZnNldFxuICBpZiAobGVuZ3RoID09PSB1bmRlZmluZWQgfHwgbGVuZ3RoID4gcmVtYWluaW5nKSBsZW5ndGggPSByZW1haW5pbmdcblxuICBpZiAoKHN0cmluZy5sZW5ndGggPiAwICYmIChsZW5ndGggPCAwIHx8IG9mZnNldCA8IDApKSB8fCBvZmZzZXQgPiB0aGlzLmxlbmd0aCkge1xuICAgIHRocm93IG5ldyBSYW5nZUVycm9yKCdhdHRlbXB0IHRvIHdyaXRlIG91dHNpZGUgYnVmZmVyIGJvdW5kcycpXG4gIH1cblxuICBpZiAoIWVuY29kaW5nKSBlbmNvZGluZyA9ICd1dGY4J1xuXG4gIHZhciBsb3dlcmVkQ2FzZSA9IGZhbHNlXG4gIGZvciAoOzspIHtcbiAgICBzd2l0Y2ggKGVuY29kaW5nKSB7XG4gICAgICBjYXNlICdoZXgnOlxuICAgICAgICByZXR1cm4gaGV4V3JpdGUodGhpcywgc3RyaW5nLCBvZmZzZXQsIGxlbmd0aClcblxuICAgICAgY2FzZSAndXRmOCc6XG4gICAgICBjYXNlICd1dGYtOCc6XG4gICAgICAgIHJldHVybiB1dGY4V3JpdGUodGhpcywgc3RyaW5nLCBvZmZzZXQsIGxlbmd0aClcblxuICAgICAgY2FzZSAnYXNjaWknOlxuICAgICAgICByZXR1cm4gYXNjaWlXcml0ZSh0aGlzLCBzdHJpbmcsIG9mZnNldCwgbGVuZ3RoKVxuXG4gICAgICBjYXNlICdiaW5hcnknOlxuICAgICAgICByZXR1cm4gYmluYXJ5V3JpdGUodGhpcywgc3RyaW5nLCBvZmZzZXQsIGxlbmd0aClcblxuICAgICAgY2FzZSAnYmFzZTY0JzpcbiAgICAgICAgLy8gV2FybmluZzogbWF4TGVuZ3RoIG5vdCB0YWtlbiBpbnRvIGFjY291bnQgaW4gYmFzZTY0V3JpdGVcbiAgICAgICAgcmV0dXJuIGJhc2U2NFdyaXRlKHRoaXMsIHN0cmluZywgb2Zmc2V0LCBsZW5ndGgpXG5cbiAgICAgIGNhc2UgJ3VjczInOlxuICAgICAgY2FzZSAndWNzLTInOlxuICAgICAgY2FzZSAndXRmMTZsZSc6XG4gICAgICBjYXNlICd1dGYtMTZsZSc6XG4gICAgICAgIHJldHVybiB1Y3MyV3JpdGUodGhpcywgc3RyaW5nLCBvZmZzZXQsIGxlbmd0aClcblxuICAgICAgZGVmYXVsdDpcbiAgICAgICAgaWYgKGxvd2VyZWRDYXNlKSB0aHJvdyBuZXcgVHlwZUVycm9yKCdVbmtub3duIGVuY29kaW5nOiAnICsgZW5jb2RpbmcpXG4gICAgICAgIGVuY29kaW5nID0gKCcnICsgZW5jb2RpbmcpLnRvTG93ZXJDYXNlKClcbiAgICAgICAgbG93ZXJlZENhc2UgPSB0cnVlXG4gICAgfVxuICB9XG59XG5cbkJ1ZmZlci5wcm90b3R5cGUudG9KU09OID0gZnVuY3Rpb24gdG9KU09OICgpIHtcbiAgcmV0dXJuIHtcbiAgICB0eXBlOiAnQnVmZmVyJyxcbiAgICBkYXRhOiBBcnJheS5wcm90b3R5cGUuc2xpY2UuY2FsbCh0aGlzLl9hcnIgfHwgdGhpcywgMClcbiAgfVxufVxuXG5mdW5jdGlvbiBiYXNlNjRTbGljZSAoYnVmLCBzdGFydCwgZW5kKSB7XG4gIGlmIChzdGFydCA9PT0gMCAmJiBlbmQgPT09IGJ1Zi5sZW5ndGgpIHtcbiAgICByZXR1cm4gYmFzZTY0LmZyb21CeXRlQXJyYXkoYnVmKVxuICB9IGVsc2Uge1xuICAgIHJldHVybiBiYXNlNjQuZnJvbUJ5dGVBcnJheShidWYuc2xpY2Uoc3RhcnQsIGVuZCkpXG4gIH1cbn1cblxuZnVuY3Rpb24gdXRmOFNsaWNlIChidWYsIHN0YXJ0LCBlbmQpIHtcbiAgZW5kID0gTWF0aC5taW4oYnVmLmxlbmd0aCwgZW5kKVxuICB2YXIgcmVzID0gW11cblxuICB2YXIgaSA9IHN0YXJ0XG4gIHdoaWxlIChpIDwgZW5kKSB7XG4gICAgdmFyIGZpcnN0Qnl0ZSA9IGJ1ZltpXVxuICAgIHZhciBjb2RlUG9pbnQgPSBudWxsXG4gICAgdmFyIGJ5dGVzUGVyU2VxdWVuY2UgPSAoZmlyc3RCeXRlID4gMHhFRikgPyA0XG4gICAgICA6IChmaXJzdEJ5dGUgPiAweERGKSA/IDNcbiAgICAgIDogKGZpcnN0Qnl0ZSA+IDB4QkYpID8gMlxuICAgICAgOiAxXG5cbiAgICBpZiAoaSArIGJ5dGVzUGVyU2VxdWVuY2UgPD0gZW5kKSB7XG4gICAgICB2YXIgc2Vjb25kQnl0ZSwgdGhpcmRCeXRlLCBmb3VydGhCeXRlLCB0ZW1wQ29kZVBvaW50XG5cbiAgICAgIHN3aXRjaCAoYnl0ZXNQZXJTZXF1ZW5jZSkge1xuICAgICAgICBjYXNlIDE6XG4gICAgICAgICAgaWYgKGZpcnN0Qnl0ZSA8IDB4ODApIHtcbiAgICAgICAgICAgIGNvZGVQb2ludCA9IGZpcnN0Qnl0ZVxuICAgICAgICAgIH1cbiAgICAgICAgICBicmVha1xuICAgICAgICBjYXNlIDI6XG4gICAgICAgICAgc2Vjb25kQnl0ZSA9IGJ1ZltpICsgMV1cbiAgICAgICAgICBpZiAoKHNlY29uZEJ5dGUgJiAweEMwKSA9PT0gMHg4MCkge1xuICAgICAgICAgICAgdGVtcENvZGVQb2ludCA9IChmaXJzdEJ5dGUgJiAweDFGKSA8PCAweDYgfCAoc2Vjb25kQnl0ZSAmIDB4M0YpXG4gICAgICAgICAgICBpZiAodGVtcENvZGVQb2ludCA+IDB4N0YpIHtcbiAgICAgICAgICAgICAgY29kZVBvaW50ID0gdGVtcENvZGVQb2ludFxuICAgICAgICAgICAgfVxuICAgICAgICAgIH1cbiAgICAgICAgICBicmVha1xuICAgICAgICBjYXNlIDM6XG4gICAgICAgICAgc2Vjb25kQnl0ZSA9IGJ1ZltpICsgMV1cbiAgICAgICAgICB0aGlyZEJ5dGUgPSBidWZbaSArIDJdXG4gICAgICAgICAgaWYgKChzZWNvbmRCeXRlICYgMHhDMCkgPT09IDB4ODAgJiYgKHRoaXJkQnl0ZSAmIDB4QzApID09PSAweDgwKSB7XG4gICAgICAgICAgICB0ZW1wQ29kZVBvaW50ID0gKGZpcnN0Qnl0ZSAmIDB4RikgPDwgMHhDIHwgKHNlY29uZEJ5dGUgJiAweDNGKSA8PCAweDYgfCAodGhpcmRCeXRlICYgMHgzRilcbiAgICAgICAgICAgIGlmICh0ZW1wQ29kZVBvaW50ID4gMHg3RkYgJiYgKHRlbXBDb2RlUG9pbnQgPCAweEQ4MDAgfHwgdGVtcENvZGVQb2ludCA+IDB4REZGRikpIHtcbiAgICAgICAgICAgICAgY29kZVBvaW50ID0gdGVtcENvZGVQb2ludFxuICAgICAgICAgICAgfVxuICAgICAgICAgIH1cbiAgICAgICAgICBicmVha1xuICAgICAgICBjYXNlIDQ6XG4gICAgICAgICAgc2Vjb25kQnl0ZSA9IGJ1ZltpICsgMV1cbiAgICAgICAgICB0aGlyZEJ5dGUgPSBidWZbaSArIDJdXG4gICAgICAgICAgZm91cnRoQnl0ZSA9IGJ1ZltpICsgM11cbiAgICAgICAgICBpZiAoKHNlY29uZEJ5dGUgJiAweEMwKSA9PT0gMHg4MCAmJiAodGhpcmRCeXRlICYgMHhDMCkgPT09IDB4ODAgJiYgKGZvdXJ0aEJ5dGUgJiAweEMwKSA9PT0gMHg4MCkge1xuICAgICAgICAgICAgdGVtcENvZGVQb2ludCA9IChmaXJzdEJ5dGUgJiAweEYpIDw8IDB4MTIgfCAoc2Vjb25kQnl0ZSAmIDB4M0YpIDw8IDB4QyB8ICh0aGlyZEJ5dGUgJiAweDNGKSA8PCAweDYgfCAoZm91cnRoQnl0ZSAmIDB4M0YpXG4gICAgICAgICAgICBpZiAodGVtcENvZGVQb2ludCA+IDB4RkZGRiAmJiB0ZW1wQ29kZVBvaW50IDwgMHgxMTAwMDApIHtcbiAgICAgICAgICAgICAgY29kZVBvaW50ID0gdGVtcENvZGVQb2ludFxuICAgICAgICAgICAgfVxuICAgICAgICAgIH1cbiAgICAgIH1cbiAgICB9XG5cbiAgICBpZiAoY29kZVBvaW50ID09PSBudWxsKSB7XG4gICAgICAvLyB3ZSBkaWQgbm90IGdlbmVyYXRlIGEgdmFsaWQgY29kZVBvaW50IHNvIGluc2VydCBhXG4gICAgICAvLyByZXBsYWNlbWVudCBjaGFyIChVK0ZGRkQpIGFuZCBhZHZhbmNlIG9ubHkgMSBieXRlXG4gICAgICBjb2RlUG9pbnQgPSAweEZGRkRcbiAgICAgIGJ5dGVzUGVyU2VxdWVuY2UgPSAxXG4gICAgfSBlbHNlIGlmIChjb2RlUG9pbnQgPiAweEZGRkYpIHtcbiAgICAgIC8vIGVuY29kZSB0byB1dGYxNiAoc3Vycm9nYXRlIHBhaXIgZGFuY2UpXG4gICAgICBjb2RlUG9pbnQgLT0gMHgxMDAwMFxuICAgICAgcmVzLnB1c2goY29kZVBvaW50ID4+PiAxMCAmIDB4M0ZGIHwgMHhEODAwKVxuICAgICAgY29kZVBvaW50ID0gMHhEQzAwIHwgY29kZVBvaW50ICYgMHgzRkZcbiAgICB9XG5cbiAgICByZXMucHVzaChjb2RlUG9pbnQpXG4gICAgaSArPSBieXRlc1BlclNlcXVlbmNlXG4gIH1cblxuICByZXR1cm4gZGVjb2RlQ29kZVBvaW50c0FycmF5KHJlcylcbn1cblxuLy8gQmFzZWQgb24gaHR0cDovL3N0YWNrb3ZlcmZsb3cuY29tL2EvMjI3NDcyNzIvNjgwNzQyLCB0aGUgYnJvd3NlciB3aXRoXG4vLyB0aGUgbG93ZXN0IGxpbWl0IGlzIENocm9tZSwgd2l0aCAweDEwMDAwIGFyZ3MuXG4vLyBXZSBnbyAxIG1hZ25pdHVkZSBsZXNzLCBmb3Igc2FmZXR5XG52YXIgTUFYX0FSR1VNRU5UU19MRU5HVEggPSAweDEwMDBcblxuZnVuY3Rpb24gZGVjb2RlQ29kZVBvaW50c0FycmF5IChjb2RlUG9pbnRzKSB7XG4gIHZhciBsZW4gPSBjb2RlUG9pbnRzLmxlbmd0aFxuICBpZiAobGVuIDw9IE1BWF9BUkdVTUVOVFNfTEVOR1RIKSB7XG4gICAgcmV0dXJuIFN0cmluZy5mcm9tQ2hhckNvZGUuYXBwbHkoU3RyaW5nLCBjb2RlUG9pbnRzKSAvLyBhdm9pZCBleHRyYSBzbGljZSgpXG4gIH1cblxuICAvLyBEZWNvZGUgaW4gY2h1bmtzIHRvIGF2b2lkIFwiY2FsbCBzdGFjayBzaXplIGV4Y2VlZGVkXCIuXG4gIHZhciByZXMgPSAnJ1xuICB2YXIgaSA9IDBcbiAgd2hpbGUgKGkgPCBsZW4pIHtcbiAgICByZXMgKz0gU3RyaW5nLmZyb21DaGFyQ29kZS5hcHBseShcbiAgICAgIFN0cmluZyxcbiAgICAgIGNvZGVQb2ludHMuc2xpY2UoaSwgaSArPSBNQVhfQVJHVU1FTlRTX0xFTkdUSClcbiAgICApXG4gIH1cbiAgcmV0dXJuIHJlc1xufVxuXG5mdW5jdGlvbiBhc2NpaVNsaWNlIChidWYsIHN0YXJ0LCBlbmQpIHtcbiAgdmFyIHJldCA9ICcnXG4gIGVuZCA9IE1hdGgubWluKGJ1Zi5sZW5ndGgsIGVuZClcblxuICBmb3IgKHZhciBpID0gc3RhcnQ7IGkgPCBlbmQ7IGkrKykge1xuICAgIHJldCArPSBTdHJpbmcuZnJvbUNoYXJDb2RlKGJ1ZltpXSAmIDB4N0YpXG4gIH1cbiAgcmV0dXJuIHJldFxufVxuXG5mdW5jdGlvbiBiaW5hcnlTbGljZSAoYnVmLCBzdGFydCwgZW5kKSB7XG4gIHZhciByZXQgPSAnJ1xuICBlbmQgPSBNYXRoLm1pbihidWYubGVuZ3RoLCBlbmQpXG5cbiAgZm9yICh2YXIgaSA9IHN0YXJ0OyBpIDwgZW5kOyBpKyspIHtcbiAgICByZXQgKz0gU3RyaW5nLmZyb21DaGFyQ29kZShidWZbaV0pXG4gIH1cbiAgcmV0dXJuIHJldFxufVxuXG5mdW5jdGlvbiBoZXhTbGljZSAoYnVmLCBzdGFydCwgZW5kKSB7XG4gIHZhciBsZW4gPSBidWYubGVuZ3RoXG5cbiAgaWYgKCFzdGFydCB8fCBzdGFydCA8IDApIHN0YXJ0ID0gMFxuICBpZiAoIWVuZCB8fCBlbmQgPCAwIHx8IGVuZCA+IGxlbikgZW5kID0gbGVuXG5cbiAgdmFyIG91dCA9ICcnXG4gIGZvciAodmFyIGkgPSBzdGFydDsgaSA8IGVuZDsgaSsrKSB7XG4gICAgb3V0ICs9IHRvSGV4KGJ1ZltpXSlcbiAgfVxuICByZXR1cm4gb3V0XG59XG5cbmZ1bmN0aW9uIHV0ZjE2bGVTbGljZSAoYnVmLCBzdGFydCwgZW5kKSB7XG4gIHZhciBieXRlcyA9IGJ1Zi5zbGljZShzdGFydCwgZW5kKVxuICB2YXIgcmVzID0gJydcbiAgZm9yICh2YXIgaSA9IDA7IGkgPCBieXRlcy5sZW5ndGg7IGkgKz0gMikge1xuICAgIHJlcyArPSBTdHJpbmcuZnJvbUNoYXJDb2RlKGJ5dGVzW2ldICsgYnl0ZXNbaSArIDFdICogMjU2KVxuICB9XG4gIHJldHVybiByZXNcbn1cblxuQnVmZmVyLnByb3RvdHlwZS5zbGljZSA9IGZ1bmN0aW9uIHNsaWNlIChzdGFydCwgZW5kKSB7XG4gIHZhciBsZW4gPSB0aGlzLmxlbmd0aFxuICBzdGFydCA9IH5+c3RhcnRcbiAgZW5kID0gZW5kID09PSB1bmRlZmluZWQgPyBsZW4gOiB+fmVuZFxuXG4gIGlmIChzdGFydCA8IDApIHtcbiAgICBzdGFydCArPSBsZW5cbiAgICBpZiAoc3RhcnQgPCAwKSBzdGFydCA9IDBcbiAgfSBlbHNlIGlmIChzdGFydCA+IGxlbikge1xuICAgIHN0YXJ0ID0gbGVuXG4gIH1cblxuICBpZiAoZW5kIDwgMCkge1xuICAgIGVuZCArPSBsZW5cbiAgICBpZiAoZW5kIDwgMCkgZW5kID0gMFxuICB9IGVsc2UgaWYgKGVuZCA+IGxlbikge1xuICAgIGVuZCA9IGxlblxuICB9XG5cbiAgaWYgKGVuZCA8IHN0YXJ0KSBlbmQgPSBzdGFydFxuXG4gIHZhciBuZXdCdWZcbiAgaWYgKEJ1ZmZlci5UWVBFRF9BUlJBWV9TVVBQT1JUKSB7XG4gICAgbmV3QnVmID0gQnVmZmVyLl9hdWdtZW50KHRoaXMuc3ViYXJyYXkoc3RhcnQsIGVuZCkpXG4gIH0gZWxzZSB7XG4gICAgdmFyIHNsaWNlTGVuID0gZW5kIC0gc3RhcnRcbiAgICBuZXdCdWYgPSBuZXcgQnVmZmVyKHNsaWNlTGVuLCB1bmRlZmluZWQpXG4gICAgZm9yICh2YXIgaSA9IDA7IGkgPCBzbGljZUxlbjsgaSsrKSB7XG4gICAgICBuZXdCdWZbaV0gPSB0aGlzW2kgKyBzdGFydF1cbiAgICB9XG4gIH1cblxuICBpZiAobmV3QnVmLmxlbmd0aCkgbmV3QnVmLnBhcmVudCA9IHRoaXMucGFyZW50IHx8IHRoaXNcblxuICByZXR1cm4gbmV3QnVmXG59XG5cbi8qXG4gKiBOZWVkIHRvIG1ha2Ugc3VyZSB0aGF0IGJ1ZmZlciBpc24ndCB0cnlpbmcgdG8gd3JpdGUgb3V0IG9mIGJvdW5kcy5cbiAqL1xuZnVuY3Rpb24gY2hlY2tPZmZzZXQgKG9mZnNldCwgZXh0LCBsZW5ndGgpIHtcbiAgaWYgKChvZmZzZXQgJSAxKSAhPT0gMCB8fCBvZmZzZXQgPCAwKSB0aHJvdyBuZXcgUmFuZ2VFcnJvcignb2Zmc2V0IGlzIG5vdCB1aW50JylcbiAgaWYgKG9mZnNldCArIGV4dCA+IGxlbmd0aCkgdGhyb3cgbmV3IFJhbmdlRXJyb3IoJ1RyeWluZyB0byBhY2Nlc3MgYmV5b25kIGJ1ZmZlciBsZW5ndGgnKVxufVxuXG5CdWZmZXIucHJvdG90eXBlLnJlYWRVSW50TEUgPSBmdW5jdGlvbiByZWFkVUludExFIChvZmZzZXQsIGJ5dGVMZW5ndGgsIG5vQXNzZXJ0KSB7XG4gIG9mZnNldCA9IG9mZnNldCB8IDBcbiAgYnl0ZUxlbmd0aCA9IGJ5dGVMZW5ndGggfCAwXG4gIGlmICghbm9Bc3NlcnQpIGNoZWNrT2Zmc2V0KG9mZnNldCwgYnl0ZUxlbmd0aCwgdGhpcy5sZW5ndGgpXG5cbiAgdmFyIHZhbCA9IHRoaXNbb2Zmc2V0XVxuICB2YXIgbXVsID0gMVxuICB2YXIgaSA9IDBcbiAgd2hpbGUgKCsraSA8IGJ5dGVMZW5ndGggJiYgKG11bCAqPSAweDEwMCkpIHtcbiAgICB2YWwgKz0gdGhpc1tvZmZzZXQgKyBpXSAqIG11bFxuICB9XG5cbiAgcmV0dXJuIHZhbFxufVxuXG5CdWZmZXIucHJvdG90eXBlLnJlYWRVSW50QkUgPSBmdW5jdGlvbiByZWFkVUludEJFIChvZmZzZXQsIGJ5dGVMZW5ndGgsIG5vQXNzZXJ0KSB7XG4gIG9mZnNldCA9IG9mZnNldCB8IDBcbiAgYnl0ZUxlbmd0aCA9IGJ5dGVMZW5ndGggfCAwXG4gIGlmICghbm9Bc3NlcnQpIHtcbiAgICBjaGVja09mZnNldChvZmZzZXQsIGJ5dGVMZW5ndGgsIHRoaXMubGVuZ3RoKVxuICB9XG5cbiAgdmFyIHZhbCA9IHRoaXNbb2Zmc2V0ICsgLS1ieXRlTGVuZ3RoXVxuICB2YXIgbXVsID0gMVxuICB3aGlsZSAoYnl0ZUxlbmd0aCA+IDAgJiYgKG11bCAqPSAweDEwMCkpIHtcbiAgICB2YWwgKz0gdGhpc1tvZmZzZXQgKyAtLWJ5dGVMZW5ndGhdICogbXVsXG4gIH1cblxuICByZXR1cm4gdmFsXG59XG5cbkJ1ZmZlci5wcm90b3R5cGUucmVhZFVJbnQ4ID0gZnVuY3Rpb24gcmVhZFVJbnQ4IChvZmZzZXQsIG5vQXNzZXJ0KSB7XG4gIGlmICghbm9Bc3NlcnQpIGNoZWNrT2Zmc2V0KG9mZnNldCwgMSwgdGhpcy5sZW5ndGgpXG4gIHJldHVybiB0aGlzW29mZnNldF1cbn1cblxuQnVmZmVyLnByb3RvdHlwZS5yZWFkVUludDE2TEUgPSBmdW5jdGlvbiByZWFkVUludDE2TEUgKG9mZnNldCwgbm9Bc3NlcnQpIHtcbiAgaWYgKCFub0Fzc2VydCkgY2hlY2tPZmZzZXQob2Zmc2V0LCAyLCB0aGlzLmxlbmd0aClcbiAgcmV0dXJuIHRoaXNbb2Zmc2V0XSB8ICh0aGlzW29mZnNldCArIDFdIDw8IDgpXG59XG5cbkJ1ZmZlci5wcm90b3R5cGUucmVhZFVJbnQxNkJFID0gZnVuY3Rpb24gcmVhZFVJbnQxNkJFIChvZmZzZXQsIG5vQXNzZXJ0KSB7XG4gIGlmICghbm9Bc3NlcnQpIGNoZWNrT2Zmc2V0KG9mZnNldCwgMiwgdGhpcy5sZW5ndGgpXG4gIHJldHVybiAodGhpc1tvZmZzZXRdIDw8IDgpIHwgdGhpc1tvZmZzZXQgKyAxXVxufVxuXG5CdWZmZXIucHJvdG90eXBlLnJlYWRVSW50MzJMRSA9IGZ1bmN0aW9uIHJlYWRVSW50MzJMRSAob2Zmc2V0LCBub0Fzc2VydCkge1xuICBpZiAoIW5vQXNzZXJ0KSBjaGVja09mZnNldChvZmZzZXQsIDQsIHRoaXMubGVuZ3RoKVxuXG4gIHJldHVybiAoKHRoaXNbb2Zmc2V0XSkgfFxuICAgICAgKHRoaXNbb2Zmc2V0ICsgMV0gPDwgOCkgfFxuICAgICAgKHRoaXNbb2Zmc2V0ICsgMl0gPDwgMTYpKSArXG4gICAgICAodGhpc1tvZmZzZXQgKyAzXSAqIDB4MTAwMDAwMClcbn1cblxuQnVmZmVyLnByb3RvdHlwZS5yZWFkVUludDMyQkUgPSBmdW5jdGlvbiByZWFkVUludDMyQkUgKG9mZnNldCwgbm9Bc3NlcnQpIHtcbiAgaWYgKCFub0Fzc2VydCkgY2hlY2tPZmZzZXQob2Zmc2V0LCA0LCB0aGlzLmxlbmd0aClcblxuICByZXR1cm4gKHRoaXNbb2Zmc2V0XSAqIDB4MTAwMDAwMCkgK1xuICAgICgodGhpc1tvZmZzZXQgKyAxXSA8PCAxNikgfFxuICAgICh0aGlzW29mZnNldCArIDJdIDw8IDgpIHxcbiAgICB0aGlzW29mZnNldCArIDNdKVxufVxuXG5CdWZmZXIucHJvdG90eXBlLnJlYWRJbnRMRSA9IGZ1bmN0aW9uIHJlYWRJbnRMRSAob2Zmc2V0LCBieXRlTGVuZ3RoLCBub0Fzc2VydCkge1xuICBvZmZzZXQgPSBvZmZzZXQgfCAwXG4gIGJ5dGVMZW5ndGggPSBieXRlTGVuZ3RoIHwgMFxuICBpZiAoIW5vQXNzZXJ0KSBjaGVja09mZnNldChvZmZzZXQsIGJ5dGVMZW5ndGgsIHRoaXMubGVuZ3RoKVxuXG4gIHZhciB2YWwgPSB0aGlzW29mZnNldF1cbiAgdmFyIG11bCA9IDFcbiAgdmFyIGkgPSAwXG4gIHdoaWxlICgrK2kgPCBieXRlTGVuZ3RoICYmIChtdWwgKj0gMHgxMDApKSB7XG4gICAgdmFsICs9IHRoaXNbb2Zmc2V0ICsgaV0gKiBtdWxcbiAgfVxuICBtdWwgKj0gMHg4MFxuXG4gIGlmICh2YWwgPj0gbXVsKSB2YWwgLT0gTWF0aC5wb3coMiwgOCAqIGJ5dGVMZW5ndGgpXG5cbiAgcmV0dXJuIHZhbFxufVxuXG5CdWZmZXIucHJvdG90eXBlLnJlYWRJbnRCRSA9IGZ1bmN0aW9uIHJlYWRJbnRCRSAob2Zmc2V0LCBieXRlTGVuZ3RoLCBub0Fzc2VydCkge1xuICBvZmZzZXQgPSBvZmZzZXQgfCAwXG4gIGJ5dGVMZW5ndGggPSBieXRlTGVuZ3RoIHwgMFxuICBpZiAoIW5vQXNzZXJ0KSBjaGVja09mZnNldChvZmZzZXQsIGJ5dGVMZW5ndGgsIHRoaXMubGVuZ3RoKVxuXG4gIHZhciBpID0gYnl0ZUxlbmd0aFxuICB2YXIgbXVsID0gMVxuICB2YXIgdmFsID0gdGhpc1tvZmZzZXQgKyAtLWldXG4gIHdoaWxlIChpID4gMCAmJiAobXVsICo9IDB4MTAwKSkge1xuICAgIHZhbCArPSB0aGlzW29mZnNldCArIC0taV0gKiBtdWxcbiAgfVxuICBtdWwgKj0gMHg4MFxuXG4gIGlmICh2YWwgPj0gbXVsKSB2YWwgLT0gTWF0aC5wb3coMiwgOCAqIGJ5dGVMZW5ndGgpXG5cbiAgcmV0dXJuIHZhbFxufVxuXG5CdWZmZXIucHJvdG90eXBlLnJlYWRJbnQ4ID0gZnVuY3Rpb24gcmVhZEludDggKG9mZnNldCwgbm9Bc3NlcnQpIHtcbiAgaWYgKCFub0Fzc2VydCkgY2hlY2tPZmZzZXQob2Zmc2V0LCAxLCB0aGlzLmxlbmd0aClcbiAgaWYgKCEodGhpc1tvZmZzZXRdICYgMHg4MCkpIHJldHVybiAodGhpc1tvZmZzZXRdKVxuICByZXR1cm4gKCgweGZmIC0gdGhpc1tvZmZzZXRdICsgMSkgKiAtMSlcbn1cblxuQnVmZmVyLnByb3RvdHlwZS5yZWFkSW50MTZMRSA9IGZ1bmN0aW9uIHJlYWRJbnQxNkxFIChvZmZzZXQsIG5vQXNzZXJ0KSB7XG4gIGlmICghbm9Bc3NlcnQpIGNoZWNrT2Zmc2V0KG9mZnNldCwgMiwgdGhpcy5sZW5ndGgpXG4gIHZhciB2YWwgPSB0aGlzW29mZnNldF0gfCAodGhpc1tvZmZzZXQgKyAxXSA8PCA4KVxuICByZXR1cm4gKHZhbCAmIDB4ODAwMCkgPyB2YWwgfCAweEZGRkYwMDAwIDogdmFsXG59XG5cbkJ1ZmZlci5wcm90b3R5cGUucmVhZEludDE2QkUgPSBmdW5jdGlvbiByZWFkSW50MTZCRSAob2Zmc2V0LCBub0Fzc2VydCkge1xuICBpZiAoIW5vQXNzZXJ0KSBjaGVja09mZnNldChvZmZzZXQsIDIsIHRoaXMubGVuZ3RoKVxuICB2YXIgdmFsID0gdGhpc1tvZmZzZXQgKyAxXSB8ICh0aGlzW29mZnNldF0gPDwgOClcbiAgcmV0dXJuICh2YWwgJiAweDgwMDApID8gdmFsIHwgMHhGRkZGMDAwMCA6IHZhbFxufVxuXG5CdWZmZXIucHJvdG90eXBlLnJlYWRJbnQzMkxFID0gZnVuY3Rpb24gcmVhZEludDMyTEUgKG9mZnNldCwgbm9Bc3NlcnQpIHtcbiAgaWYgKCFub0Fzc2VydCkgY2hlY2tPZmZzZXQob2Zmc2V0LCA0LCB0aGlzLmxlbmd0aClcblxuICByZXR1cm4gKHRoaXNbb2Zmc2V0XSkgfFxuICAgICh0aGlzW29mZnNldCArIDFdIDw8IDgpIHxcbiAgICAodGhpc1tvZmZzZXQgKyAyXSA8PCAxNikgfFxuICAgICh0aGlzW29mZnNldCArIDNdIDw8IDI0KVxufVxuXG5CdWZmZXIucHJvdG90eXBlLnJlYWRJbnQzMkJFID0gZnVuY3Rpb24gcmVhZEludDMyQkUgKG9mZnNldCwgbm9Bc3NlcnQpIHtcbiAgaWYgKCFub0Fzc2VydCkgY2hlY2tPZmZzZXQob2Zmc2V0LCA0LCB0aGlzLmxlbmd0aClcblxuICByZXR1cm4gKHRoaXNbb2Zmc2V0XSA8PCAyNCkgfFxuICAgICh0aGlzW29mZnNldCArIDFdIDw8IDE2KSB8XG4gICAgKHRoaXNbb2Zmc2V0ICsgMl0gPDwgOCkgfFxuICAgICh0aGlzW29mZnNldCArIDNdKVxufVxuXG5CdWZmZXIucHJvdG90eXBlLnJlYWRGbG9hdExFID0gZnVuY3Rpb24gcmVhZEZsb2F0TEUgKG9mZnNldCwgbm9Bc3NlcnQpIHtcbiAgaWYgKCFub0Fzc2VydCkgY2hlY2tPZmZzZXQob2Zmc2V0LCA0LCB0aGlzLmxlbmd0aClcbiAgcmV0dXJuIGllZWU3NTQucmVhZCh0aGlzLCBvZmZzZXQsIHRydWUsIDIzLCA0KVxufVxuXG5CdWZmZXIucHJvdG90eXBlLnJlYWRGbG9hdEJFID0gZnVuY3Rpb24gcmVhZEZsb2F0QkUgKG9mZnNldCwgbm9Bc3NlcnQpIHtcbiAgaWYgKCFub0Fzc2VydCkgY2hlY2tPZmZzZXQob2Zmc2V0LCA0LCB0aGlzLmxlbmd0aClcbiAgcmV0dXJuIGllZWU3NTQucmVhZCh0aGlzLCBvZmZzZXQsIGZhbHNlLCAyMywgNClcbn1cblxuQnVmZmVyLnByb3RvdHlwZS5yZWFkRG91YmxlTEUgPSBmdW5jdGlvbiByZWFkRG91YmxlTEUgKG9mZnNldCwgbm9Bc3NlcnQpIHtcbiAgaWYgKCFub0Fzc2VydCkgY2hlY2tPZmZzZXQob2Zmc2V0LCA4LCB0aGlzLmxlbmd0aClcbiAgcmV0dXJuIGllZWU3NTQucmVhZCh0aGlzLCBvZmZzZXQsIHRydWUsIDUyLCA4KVxufVxuXG5CdWZmZXIucHJvdG90eXBlLnJlYWREb3VibGVCRSA9IGZ1bmN0aW9uIHJlYWREb3VibGVCRSAob2Zmc2V0LCBub0Fzc2VydCkge1xuICBpZiAoIW5vQXNzZXJ0KSBjaGVja09mZnNldChvZmZzZXQsIDgsIHRoaXMubGVuZ3RoKVxuICByZXR1cm4gaWVlZTc1NC5yZWFkKHRoaXMsIG9mZnNldCwgZmFsc2UsIDUyLCA4KVxufVxuXG5mdW5jdGlvbiBjaGVja0ludCAoYnVmLCB2YWx1ZSwgb2Zmc2V0LCBleHQsIG1heCwgbWluKSB7XG4gIGlmICghQnVmZmVyLmlzQnVmZmVyKGJ1ZikpIHRocm93IG5ldyBUeXBlRXJyb3IoJ2J1ZmZlciBtdXN0IGJlIGEgQnVmZmVyIGluc3RhbmNlJylcbiAgaWYgKHZhbHVlID4gbWF4IHx8IHZhbHVlIDwgbWluKSB0aHJvdyBuZXcgUmFuZ2VFcnJvcigndmFsdWUgaXMgb3V0IG9mIGJvdW5kcycpXG4gIGlmIChvZmZzZXQgKyBleHQgPiBidWYubGVuZ3RoKSB0aHJvdyBuZXcgUmFuZ2VFcnJvcignaW5kZXggb3V0IG9mIHJhbmdlJylcbn1cblxuQnVmZmVyLnByb3RvdHlwZS53cml0ZVVJbnRMRSA9IGZ1bmN0aW9uIHdyaXRlVUludExFICh2YWx1ZSwgb2Zmc2V0LCBieXRlTGVuZ3RoLCBub0Fzc2VydCkge1xuICB2YWx1ZSA9ICt2YWx1ZVxuICBvZmZzZXQgPSBvZmZzZXQgfCAwXG4gIGJ5dGVMZW5ndGggPSBieXRlTGVuZ3RoIHwgMFxuICBpZiAoIW5vQXNzZXJ0KSBjaGVja0ludCh0aGlzLCB2YWx1ZSwgb2Zmc2V0LCBieXRlTGVuZ3RoLCBNYXRoLnBvdygyLCA4ICogYnl0ZUxlbmd0aCksIDApXG5cbiAgdmFyIG11bCA9IDFcbiAgdmFyIGkgPSAwXG4gIHRoaXNbb2Zmc2V0XSA9IHZhbHVlICYgMHhGRlxuICB3aGlsZSAoKytpIDwgYnl0ZUxlbmd0aCAmJiAobXVsICo9IDB4MTAwKSkge1xuICAgIHRoaXNbb2Zmc2V0ICsgaV0gPSAodmFsdWUgLyBtdWwpICYgMHhGRlxuICB9XG5cbiAgcmV0dXJuIG9mZnNldCArIGJ5dGVMZW5ndGhcbn1cblxuQnVmZmVyLnByb3RvdHlwZS53cml0ZVVJbnRCRSA9IGZ1bmN0aW9uIHdyaXRlVUludEJFICh2YWx1ZSwgb2Zmc2V0LCBieXRlTGVuZ3RoLCBub0Fzc2VydCkge1xuICB2YWx1ZSA9ICt2YWx1ZVxuICBvZmZzZXQgPSBvZmZzZXQgfCAwXG4gIGJ5dGVMZW5ndGggPSBieXRlTGVuZ3RoIHwgMFxuICBpZiAoIW5vQXNzZXJ0KSBjaGVja0ludCh0aGlzLCB2YWx1ZSwgb2Zmc2V0LCBieXRlTGVuZ3RoLCBNYXRoLnBvdygyLCA4ICogYnl0ZUxlbmd0aCksIDApXG5cbiAgdmFyIGkgPSBieXRlTGVuZ3RoIC0gMVxuICB2YXIgbXVsID0gMVxuICB0aGlzW29mZnNldCArIGldID0gdmFsdWUgJiAweEZGXG4gIHdoaWxlICgtLWkgPj0gMCAmJiAobXVsICo9IDB4MTAwKSkge1xuICAgIHRoaXNbb2Zmc2V0ICsgaV0gPSAodmFsdWUgLyBtdWwpICYgMHhGRlxuICB9XG5cbiAgcmV0dXJuIG9mZnNldCArIGJ5dGVMZW5ndGhcbn1cblxuQnVmZmVyLnByb3RvdHlwZS53cml0ZVVJbnQ4ID0gZnVuY3Rpb24gd3JpdGVVSW50OCAodmFsdWUsIG9mZnNldCwgbm9Bc3NlcnQpIHtcbiAgdmFsdWUgPSArdmFsdWVcbiAgb2Zmc2V0ID0gb2Zmc2V0IHwgMFxuICBpZiAoIW5vQXNzZXJ0KSBjaGVja0ludCh0aGlzLCB2YWx1ZSwgb2Zmc2V0LCAxLCAweGZmLCAwKVxuICBpZiAoIUJ1ZmZlci5UWVBFRF9BUlJBWV9TVVBQT1JUKSB2YWx1ZSA9IE1hdGguZmxvb3IodmFsdWUpXG4gIHRoaXNbb2Zmc2V0XSA9ICh2YWx1ZSAmIDB4ZmYpXG4gIHJldHVybiBvZmZzZXQgKyAxXG59XG5cbmZ1bmN0aW9uIG9iamVjdFdyaXRlVUludDE2IChidWYsIHZhbHVlLCBvZmZzZXQsIGxpdHRsZUVuZGlhbikge1xuICBpZiAodmFsdWUgPCAwKSB2YWx1ZSA9IDB4ZmZmZiArIHZhbHVlICsgMVxuICBmb3IgKHZhciBpID0gMCwgaiA9IE1hdGgubWluKGJ1Zi5sZW5ndGggLSBvZmZzZXQsIDIpOyBpIDwgajsgaSsrKSB7XG4gICAgYnVmW29mZnNldCArIGldID0gKHZhbHVlICYgKDB4ZmYgPDwgKDggKiAobGl0dGxlRW5kaWFuID8gaSA6IDEgLSBpKSkpKSA+Pj5cbiAgICAgIChsaXR0bGVFbmRpYW4gPyBpIDogMSAtIGkpICogOFxuICB9XG59XG5cbkJ1ZmZlci5wcm90b3R5cGUud3JpdGVVSW50MTZMRSA9IGZ1bmN0aW9uIHdyaXRlVUludDE2TEUgKHZhbHVlLCBvZmZzZXQsIG5vQXNzZXJ0KSB7XG4gIHZhbHVlID0gK3ZhbHVlXG4gIG9mZnNldCA9IG9mZnNldCB8IDBcbiAgaWYgKCFub0Fzc2VydCkgY2hlY2tJbnQodGhpcywgdmFsdWUsIG9mZnNldCwgMiwgMHhmZmZmLCAwKVxuICBpZiAoQnVmZmVyLlRZUEVEX0FSUkFZX1NVUFBPUlQpIHtcbiAgICB0aGlzW29mZnNldF0gPSAodmFsdWUgJiAweGZmKVxuICAgIHRoaXNbb2Zmc2V0ICsgMV0gPSAodmFsdWUgPj4+IDgpXG4gIH0gZWxzZSB7XG4gICAgb2JqZWN0V3JpdGVVSW50MTYodGhpcywgdmFsdWUsIG9mZnNldCwgdHJ1ZSlcbiAgfVxuICByZXR1cm4gb2Zmc2V0ICsgMlxufVxuXG5CdWZmZXIucHJvdG90eXBlLndyaXRlVUludDE2QkUgPSBmdW5jdGlvbiB3cml0ZVVJbnQxNkJFICh2YWx1ZSwgb2Zmc2V0LCBub0Fzc2VydCkge1xuICB2YWx1ZSA9ICt2YWx1ZVxuICBvZmZzZXQgPSBvZmZzZXQgfCAwXG4gIGlmICghbm9Bc3NlcnQpIGNoZWNrSW50KHRoaXMsIHZhbHVlLCBvZmZzZXQsIDIsIDB4ZmZmZiwgMClcbiAgaWYgKEJ1ZmZlci5UWVBFRF9BUlJBWV9TVVBQT1JUKSB7XG4gICAgdGhpc1tvZmZzZXRdID0gKHZhbHVlID4+PiA4KVxuICAgIHRoaXNbb2Zmc2V0ICsgMV0gPSAodmFsdWUgJiAweGZmKVxuICB9IGVsc2Uge1xuICAgIG9iamVjdFdyaXRlVUludDE2KHRoaXMsIHZhbHVlLCBvZmZzZXQsIGZhbHNlKVxuICB9XG4gIHJldHVybiBvZmZzZXQgKyAyXG59XG5cbmZ1bmN0aW9uIG9iamVjdFdyaXRlVUludDMyIChidWYsIHZhbHVlLCBvZmZzZXQsIGxpdHRsZUVuZGlhbikge1xuICBpZiAodmFsdWUgPCAwKSB2YWx1ZSA9IDB4ZmZmZmZmZmYgKyB2YWx1ZSArIDFcbiAgZm9yICh2YXIgaSA9IDAsIGogPSBNYXRoLm1pbihidWYubGVuZ3RoIC0gb2Zmc2V0LCA0KTsgaSA8IGo7IGkrKykge1xuICAgIGJ1ZltvZmZzZXQgKyBpXSA9ICh2YWx1ZSA+Pj4gKGxpdHRsZUVuZGlhbiA/IGkgOiAzIC0gaSkgKiA4KSAmIDB4ZmZcbiAgfVxufVxuXG5CdWZmZXIucHJvdG90eXBlLndyaXRlVUludDMyTEUgPSBmdW5jdGlvbiB3cml0ZVVJbnQzMkxFICh2YWx1ZSwgb2Zmc2V0LCBub0Fzc2VydCkge1xuICB2YWx1ZSA9ICt2YWx1ZVxuICBvZmZzZXQgPSBvZmZzZXQgfCAwXG4gIGlmICghbm9Bc3NlcnQpIGNoZWNrSW50KHRoaXMsIHZhbHVlLCBvZmZzZXQsIDQsIDB4ZmZmZmZmZmYsIDApXG4gIGlmIChCdWZmZXIuVFlQRURfQVJSQVlfU1VQUE9SVCkge1xuICAgIHRoaXNbb2Zmc2V0ICsgM10gPSAodmFsdWUgPj4+IDI0KVxuICAgIHRoaXNbb2Zmc2V0ICsgMl0gPSAodmFsdWUgPj4+IDE2KVxuICAgIHRoaXNbb2Zmc2V0ICsgMV0gPSAodmFsdWUgPj4+IDgpXG4gICAgdGhpc1tvZmZzZXRdID0gKHZhbHVlICYgMHhmZilcbiAgfSBlbHNlIHtcbiAgICBvYmplY3RXcml0ZVVJbnQzMih0aGlzLCB2YWx1ZSwgb2Zmc2V0LCB0cnVlKVxuICB9XG4gIHJldHVybiBvZmZzZXQgKyA0XG59XG5cbkJ1ZmZlci5wcm90b3R5cGUud3JpdGVVSW50MzJCRSA9IGZ1bmN0aW9uIHdyaXRlVUludDMyQkUgKHZhbHVlLCBvZmZzZXQsIG5vQXNzZXJ0KSB7XG4gIHZhbHVlID0gK3ZhbHVlXG4gIG9mZnNldCA9IG9mZnNldCB8IDBcbiAgaWYgKCFub0Fzc2VydCkgY2hlY2tJbnQodGhpcywgdmFsdWUsIG9mZnNldCwgNCwgMHhmZmZmZmZmZiwgMClcbiAgaWYgKEJ1ZmZlci5UWVBFRF9BUlJBWV9TVVBQT1JUKSB7XG4gICAgdGhpc1tvZmZzZXRdID0gKHZhbHVlID4+PiAyNClcbiAgICB0aGlzW29mZnNldCArIDFdID0gKHZhbHVlID4+PiAxNilcbiAgICB0aGlzW29mZnNldCArIDJdID0gKHZhbHVlID4+PiA4KVxuICAgIHRoaXNbb2Zmc2V0ICsgM10gPSAodmFsdWUgJiAweGZmKVxuICB9IGVsc2Uge1xuICAgIG9iamVjdFdyaXRlVUludDMyKHRoaXMsIHZhbHVlLCBvZmZzZXQsIGZhbHNlKVxuICB9XG4gIHJldHVybiBvZmZzZXQgKyA0XG59XG5cbkJ1ZmZlci5wcm90b3R5cGUud3JpdGVJbnRMRSA9IGZ1bmN0aW9uIHdyaXRlSW50TEUgKHZhbHVlLCBvZmZzZXQsIGJ5dGVMZW5ndGgsIG5vQXNzZXJ0KSB7XG4gIHZhbHVlID0gK3ZhbHVlXG4gIG9mZnNldCA9IG9mZnNldCB8IDBcbiAgaWYgKCFub0Fzc2VydCkge1xuICAgIHZhciBsaW1pdCA9IE1hdGgucG93KDIsIDggKiBieXRlTGVuZ3RoIC0gMSlcblxuICAgIGNoZWNrSW50KHRoaXMsIHZhbHVlLCBvZmZzZXQsIGJ5dGVMZW5ndGgsIGxpbWl0IC0gMSwgLWxpbWl0KVxuICB9XG5cbiAgdmFyIGkgPSAwXG4gIHZhciBtdWwgPSAxXG4gIHZhciBzdWIgPSB2YWx1ZSA8IDAgPyAxIDogMFxuICB0aGlzW29mZnNldF0gPSB2YWx1ZSAmIDB4RkZcbiAgd2hpbGUgKCsraSA8IGJ5dGVMZW5ndGggJiYgKG11bCAqPSAweDEwMCkpIHtcbiAgICB0aGlzW29mZnNldCArIGldID0gKCh2YWx1ZSAvIG11bCkgPj4gMCkgLSBzdWIgJiAweEZGXG4gIH1cblxuICByZXR1cm4gb2Zmc2V0ICsgYnl0ZUxlbmd0aFxufVxuXG5CdWZmZXIucHJvdG90eXBlLndyaXRlSW50QkUgPSBmdW5jdGlvbiB3cml0ZUludEJFICh2YWx1ZSwgb2Zmc2V0LCBieXRlTGVuZ3RoLCBub0Fzc2VydCkge1xuICB2YWx1ZSA9ICt2YWx1ZVxuICBvZmZzZXQgPSBvZmZzZXQgfCAwXG4gIGlmICghbm9Bc3NlcnQpIHtcbiAgICB2YXIgbGltaXQgPSBNYXRoLnBvdygyLCA4ICogYnl0ZUxlbmd0aCAtIDEpXG5cbiAgICBjaGVja0ludCh0aGlzLCB2YWx1ZSwgb2Zmc2V0LCBieXRlTGVuZ3RoLCBsaW1pdCAtIDEsIC1saW1pdClcbiAgfVxuXG4gIHZhciBpID0gYnl0ZUxlbmd0aCAtIDFcbiAgdmFyIG11bCA9IDFcbiAgdmFyIHN1YiA9IHZhbHVlIDwgMCA/IDEgOiAwXG4gIHRoaXNbb2Zmc2V0ICsgaV0gPSB2YWx1ZSAmIDB4RkZcbiAgd2hpbGUgKC0taSA+PSAwICYmIChtdWwgKj0gMHgxMDApKSB7XG4gICAgdGhpc1tvZmZzZXQgKyBpXSA9ICgodmFsdWUgLyBtdWwpID4+IDApIC0gc3ViICYgMHhGRlxuICB9XG5cbiAgcmV0dXJuIG9mZnNldCArIGJ5dGVMZW5ndGhcbn1cblxuQnVmZmVyLnByb3RvdHlwZS53cml0ZUludDggPSBmdW5jdGlvbiB3cml0ZUludDggKHZhbHVlLCBvZmZzZXQsIG5vQXNzZXJ0KSB7XG4gIHZhbHVlID0gK3ZhbHVlXG4gIG9mZnNldCA9IG9mZnNldCB8IDBcbiAgaWYgKCFub0Fzc2VydCkgY2hlY2tJbnQodGhpcywgdmFsdWUsIG9mZnNldCwgMSwgMHg3ZiwgLTB4ODApXG4gIGlmICghQnVmZmVyLlRZUEVEX0FSUkFZX1NVUFBPUlQpIHZhbHVlID0gTWF0aC5mbG9vcih2YWx1ZSlcbiAgaWYgKHZhbHVlIDwgMCkgdmFsdWUgPSAweGZmICsgdmFsdWUgKyAxXG4gIHRoaXNbb2Zmc2V0XSA9ICh2YWx1ZSAmIDB4ZmYpXG4gIHJldHVybiBvZmZzZXQgKyAxXG59XG5cbkJ1ZmZlci5wcm90b3R5cGUud3JpdGVJbnQxNkxFID0gZnVuY3Rpb24gd3JpdGVJbnQxNkxFICh2YWx1ZSwgb2Zmc2V0LCBub0Fzc2VydCkge1xuICB2YWx1ZSA9ICt2YWx1ZVxuICBvZmZzZXQgPSBvZmZzZXQgfCAwXG4gIGlmICghbm9Bc3NlcnQpIGNoZWNrSW50KHRoaXMsIHZhbHVlLCBvZmZzZXQsIDIsIDB4N2ZmZiwgLTB4ODAwMClcbiAgaWYgKEJ1ZmZlci5UWVBFRF9BUlJBWV9TVVBQT1JUKSB7XG4gICAgdGhpc1tvZmZzZXRdID0gKHZhbHVlICYgMHhmZilcbiAgICB0aGlzW29mZnNldCArIDFdID0gKHZhbHVlID4+PiA4KVxuICB9IGVsc2Uge1xuICAgIG9iamVjdFdyaXRlVUludDE2KHRoaXMsIHZhbHVlLCBvZmZzZXQsIHRydWUpXG4gIH1cbiAgcmV0dXJuIG9mZnNldCArIDJcbn1cblxuQnVmZmVyLnByb3RvdHlwZS53cml0ZUludDE2QkUgPSBmdW5jdGlvbiB3cml0ZUludDE2QkUgKHZhbHVlLCBvZmZzZXQsIG5vQXNzZXJ0KSB7XG4gIHZhbHVlID0gK3ZhbHVlXG4gIG9mZnNldCA9IG9mZnNldCB8IDBcbiAgaWYgKCFub0Fzc2VydCkgY2hlY2tJbnQodGhpcywgdmFsdWUsIG9mZnNldCwgMiwgMHg3ZmZmLCAtMHg4MDAwKVxuICBpZiAoQnVmZmVyLlRZUEVEX0FSUkFZX1NVUFBPUlQpIHtcbiAgICB0aGlzW29mZnNldF0gPSAodmFsdWUgPj4+IDgpXG4gICAgdGhpc1tvZmZzZXQgKyAxXSA9ICh2YWx1ZSAmIDB4ZmYpXG4gIH0gZWxzZSB7XG4gICAgb2JqZWN0V3JpdGVVSW50MTYodGhpcywgdmFsdWUsIG9mZnNldCwgZmFsc2UpXG4gIH1cbiAgcmV0dXJuIG9mZnNldCArIDJcbn1cblxuQnVmZmVyLnByb3RvdHlwZS53cml0ZUludDMyTEUgPSBmdW5jdGlvbiB3cml0ZUludDMyTEUgKHZhbHVlLCBvZmZzZXQsIG5vQXNzZXJ0KSB7XG4gIHZhbHVlID0gK3ZhbHVlXG4gIG9mZnNldCA9IG9mZnNldCB8IDBcbiAgaWYgKCFub0Fzc2VydCkgY2hlY2tJbnQodGhpcywgdmFsdWUsIG9mZnNldCwgNCwgMHg3ZmZmZmZmZiwgLTB4ODAwMDAwMDApXG4gIGlmIChCdWZmZXIuVFlQRURfQVJSQVlfU1VQUE9SVCkge1xuICAgIHRoaXNbb2Zmc2V0XSA9ICh2YWx1ZSAmIDB4ZmYpXG4gICAgdGhpc1tvZmZzZXQgKyAxXSA9ICh2YWx1ZSA+Pj4gOClcbiAgICB0aGlzW29mZnNldCArIDJdID0gKHZhbHVlID4+PiAxNilcbiAgICB0aGlzW29mZnNldCArIDNdID0gKHZhbHVlID4+PiAyNClcbiAgfSBlbHNlIHtcbiAgICBvYmplY3RXcml0ZVVJbnQzMih0aGlzLCB2YWx1ZSwgb2Zmc2V0LCB0cnVlKVxuICB9XG4gIHJldHVybiBvZmZzZXQgKyA0XG59XG5cbkJ1ZmZlci5wcm90b3R5cGUud3JpdGVJbnQzMkJFID0gZnVuY3Rpb24gd3JpdGVJbnQzMkJFICh2YWx1ZSwgb2Zmc2V0LCBub0Fzc2VydCkge1xuICB2YWx1ZSA9ICt2YWx1ZVxuICBvZmZzZXQgPSBvZmZzZXQgfCAwXG4gIGlmICghbm9Bc3NlcnQpIGNoZWNrSW50KHRoaXMsIHZhbHVlLCBvZmZzZXQsIDQsIDB4N2ZmZmZmZmYsIC0weDgwMDAwMDAwKVxuICBpZiAodmFsdWUgPCAwKSB2YWx1ZSA9IDB4ZmZmZmZmZmYgKyB2YWx1ZSArIDFcbiAgaWYgKEJ1ZmZlci5UWVBFRF9BUlJBWV9TVVBQT1JUKSB7XG4gICAgdGhpc1tvZmZzZXRdID0gKHZhbHVlID4+PiAyNClcbiAgICB0aGlzW29mZnNldCArIDFdID0gKHZhbHVlID4+PiAxNilcbiAgICB0aGlzW29mZnNldCArIDJdID0gKHZhbHVlID4+PiA4KVxuICAgIHRoaXNbb2Zmc2V0ICsgM10gPSAodmFsdWUgJiAweGZmKVxuICB9IGVsc2Uge1xuICAgIG9iamVjdFdyaXRlVUludDMyKHRoaXMsIHZhbHVlLCBvZmZzZXQsIGZhbHNlKVxuICB9XG4gIHJldHVybiBvZmZzZXQgKyA0XG59XG5cbmZ1bmN0aW9uIGNoZWNrSUVFRTc1NCAoYnVmLCB2YWx1ZSwgb2Zmc2V0LCBleHQsIG1heCwgbWluKSB7XG4gIGlmICh2YWx1ZSA+IG1heCB8fCB2YWx1ZSA8IG1pbikgdGhyb3cgbmV3IFJhbmdlRXJyb3IoJ3ZhbHVlIGlzIG91dCBvZiBib3VuZHMnKVxuICBpZiAob2Zmc2V0ICsgZXh0ID4gYnVmLmxlbmd0aCkgdGhyb3cgbmV3IFJhbmdlRXJyb3IoJ2luZGV4IG91dCBvZiByYW5nZScpXG4gIGlmIChvZmZzZXQgPCAwKSB0aHJvdyBuZXcgUmFuZ2VFcnJvcignaW5kZXggb3V0IG9mIHJhbmdlJylcbn1cblxuZnVuY3Rpb24gd3JpdGVGbG9hdCAoYnVmLCB2YWx1ZSwgb2Zmc2V0LCBsaXR0bGVFbmRpYW4sIG5vQXNzZXJ0KSB7XG4gIGlmICghbm9Bc3NlcnQpIHtcbiAgICBjaGVja0lFRUU3NTQoYnVmLCB2YWx1ZSwgb2Zmc2V0LCA0LCAzLjQwMjgyMzQ2NjM4NTI4ODZlKzM4LCAtMy40MDI4MjM0NjYzODUyODg2ZSszOClcbiAgfVxuICBpZWVlNzU0LndyaXRlKGJ1ZiwgdmFsdWUsIG9mZnNldCwgbGl0dGxlRW5kaWFuLCAyMywgNClcbiAgcmV0dXJuIG9mZnNldCArIDRcbn1cblxuQnVmZmVyLnByb3RvdHlwZS53cml0ZUZsb2F0TEUgPSBmdW5jdGlvbiB3cml0ZUZsb2F0TEUgKHZhbHVlLCBvZmZzZXQsIG5vQXNzZXJ0KSB7XG4gIHJldHVybiB3cml0ZUZsb2F0KHRoaXMsIHZhbHVlLCBvZmZzZXQsIHRydWUsIG5vQXNzZXJ0KVxufVxuXG5CdWZmZXIucHJvdG90eXBlLndyaXRlRmxvYXRCRSA9IGZ1bmN0aW9uIHdyaXRlRmxvYXRCRSAodmFsdWUsIG9mZnNldCwgbm9Bc3NlcnQpIHtcbiAgcmV0dXJuIHdyaXRlRmxvYXQodGhpcywgdmFsdWUsIG9mZnNldCwgZmFsc2UsIG5vQXNzZXJ0KVxufVxuXG5mdW5jdGlvbiB3cml0ZURvdWJsZSAoYnVmLCB2YWx1ZSwgb2Zmc2V0LCBsaXR0bGVFbmRpYW4sIG5vQXNzZXJ0KSB7XG4gIGlmICghbm9Bc3NlcnQpIHtcbiAgICBjaGVja0lFRUU3NTQoYnVmLCB2YWx1ZSwgb2Zmc2V0LCA4LCAxLjc5NzY5MzEzNDg2MjMxNTdFKzMwOCwgLTEuNzk3NjkzMTM0ODYyMzE1N0UrMzA4KVxuICB9XG4gIGllZWU3NTQud3JpdGUoYnVmLCB2YWx1ZSwgb2Zmc2V0LCBsaXR0bGVFbmRpYW4sIDUyLCA4KVxuICByZXR1cm4gb2Zmc2V0ICsgOFxufVxuXG5CdWZmZXIucHJvdG90eXBlLndyaXRlRG91YmxlTEUgPSBmdW5jdGlvbiB3cml0ZURvdWJsZUxFICh2YWx1ZSwgb2Zmc2V0LCBub0Fzc2VydCkge1xuICByZXR1cm4gd3JpdGVEb3VibGUodGhpcywgdmFsdWUsIG9mZnNldCwgdHJ1ZSwgbm9Bc3NlcnQpXG59XG5cbkJ1ZmZlci5wcm90b3R5cGUud3JpdGVEb3VibGVCRSA9IGZ1bmN0aW9uIHdyaXRlRG91YmxlQkUgKHZhbHVlLCBvZmZzZXQsIG5vQXNzZXJ0KSB7XG4gIHJldHVybiB3cml0ZURvdWJsZSh0aGlzLCB2YWx1ZSwgb2Zmc2V0LCBmYWxzZSwgbm9Bc3NlcnQpXG59XG5cbi8vIGNvcHkodGFyZ2V0QnVmZmVyLCB0YXJnZXRTdGFydD0wLCBzb3VyY2VTdGFydD0wLCBzb3VyY2VFbmQ9YnVmZmVyLmxlbmd0aClcbkJ1ZmZlci5wcm90b3R5cGUuY29weSA9IGZ1bmN0aW9uIGNvcHkgKHRhcmdldCwgdGFyZ2V0U3RhcnQsIHN0YXJ0LCBlbmQpIHtcbiAgaWYgKCFzdGFydCkgc3RhcnQgPSAwXG4gIGlmICghZW5kICYmIGVuZCAhPT0gMCkgZW5kID0gdGhpcy5sZW5ndGhcbiAgaWYgKHRhcmdldFN0YXJ0ID49IHRhcmdldC5sZW5ndGgpIHRhcmdldFN0YXJ0ID0gdGFyZ2V0Lmxlbmd0aFxuICBpZiAoIXRhcmdldFN0YXJ0KSB0YXJnZXRTdGFydCA9IDBcbiAgaWYgKGVuZCA+IDAgJiYgZW5kIDwgc3RhcnQpIGVuZCA9IHN0YXJ0XG5cbiAgLy8gQ29weSAwIGJ5dGVzOyB3ZSdyZSBkb25lXG4gIGlmIChlbmQgPT09IHN0YXJ0KSByZXR1cm4gMFxuICBpZiAodGFyZ2V0Lmxlbmd0aCA9PT0gMCB8fCB0aGlzLmxlbmd0aCA9PT0gMCkgcmV0dXJuIDBcblxuICAvLyBGYXRhbCBlcnJvciBjb25kaXRpb25zXG4gIGlmICh0YXJnZXRTdGFydCA8IDApIHtcbiAgICB0aHJvdyBuZXcgUmFuZ2VFcnJvcigndGFyZ2V0U3RhcnQgb3V0IG9mIGJvdW5kcycpXG4gIH1cbiAgaWYgKHN0YXJ0IDwgMCB8fCBzdGFydCA+PSB0aGlzLmxlbmd0aCkgdGhyb3cgbmV3IFJhbmdlRXJyb3IoJ3NvdXJjZVN0YXJ0IG91dCBvZiBib3VuZHMnKVxuICBpZiAoZW5kIDwgMCkgdGhyb3cgbmV3IFJhbmdlRXJyb3IoJ3NvdXJjZUVuZCBvdXQgb2YgYm91bmRzJylcblxuICAvLyBBcmUgd2Ugb29iP1xuICBpZiAoZW5kID4gdGhpcy5sZW5ndGgpIGVuZCA9IHRoaXMubGVuZ3RoXG4gIGlmICh0YXJnZXQubGVuZ3RoIC0gdGFyZ2V0U3RhcnQgPCBlbmQgLSBzdGFydCkge1xuICAgIGVuZCA9IHRhcmdldC5sZW5ndGggLSB0YXJnZXRTdGFydCArIHN0YXJ0XG4gIH1cblxuICB2YXIgbGVuID0gZW5kIC0gc3RhcnRcbiAgdmFyIGlcblxuICBpZiAodGhpcyA9PT0gdGFyZ2V0ICYmIHN0YXJ0IDwgdGFyZ2V0U3RhcnQgJiYgdGFyZ2V0U3RhcnQgPCBlbmQpIHtcbiAgICAvLyBkZXNjZW5kaW5nIGNvcHkgZnJvbSBlbmRcbiAgICBmb3IgKGkgPSBsZW4gLSAxOyBpID49IDA7IGktLSkge1xuICAgICAgdGFyZ2V0W2kgKyB0YXJnZXRTdGFydF0gPSB0aGlzW2kgKyBzdGFydF1cbiAgICB9XG4gIH0gZWxzZSBpZiAobGVuIDwgMTAwMCB8fCAhQnVmZmVyLlRZUEVEX0FSUkFZX1NVUFBPUlQpIHtcbiAgICAvLyBhc2NlbmRpbmcgY29weSBmcm9tIHN0YXJ0XG4gICAgZm9yIChpID0gMDsgaSA8IGxlbjsgaSsrKSB7XG4gICAgICB0YXJnZXRbaSArIHRhcmdldFN0YXJ0XSA9IHRoaXNbaSArIHN0YXJ0XVxuICAgIH1cbiAgfSBlbHNlIHtcbiAgICB0YXJnZXQuX3NldCh0aGlzLnN1YmFycmF5KHN0YXJ0LCBzdGFydCArIGxlbiksIHRhcmdldFN0YXJ0KVxuICB9XG5cbiAgcmV0dXJuIGxlblxufVxuXG4vLyBmaWxsKHZhbHVlLCBzdGFydD0wLCBlbmQ9YnVmZmVyLmxlbmd0aClcbkJ1ZmZlci5wcm90b3R5cGUuZmlsbCA9IGZ1bmN0aW9uIGZpbGwgKHZhbHVlLCBzdGFydCwgZW5kKSB7XG4gIGlmICghdmFsdWUpIHZhbHVlID0gMFxuICBpZiAoIXN0YXJ0KSBzdGFydCA9IDBcbiAgaWYgKCFlbmQpIGVuZCA9IHRoaXMubGVuZ3RoXG5cbiAgaWYgKGVuZCA8IHN0YXJ0KSB0aHJvdyBuZXcgUmFuZ2VFcnJvcignZW5kIDwgc3RhcnQnKVxuXG4gIC8vIEZpbGwgMCBieXRlczsgd2UncmUgZG9uZVxuICBpZiAoZW5kID09PSBzdGFydCkgcmV0dXJuXG4gIGlmICh0aGlzLmxlbmd0aCA9PT0gMCkgcmV0dXJuXG5cbiAgaWYgKHN0YXJ0IDwgMCB8fCBzdGFydCA+PSB0aGlzLmxlbmd0aCkgdGhyb3cgbmV3IFJhbmdlRXJyb3IoJ3N0YXJ0IG91dCBvZiBib3VuZHMnKVxuICBpZiAoZW5kIDwgMCB8fCBlbmQgPiB0aGlzLmxlbmd0aCkgdGhyb3cgbmV3IFJhbmdlRXJyb3IoJ2VuZCBvdXQgb2YgYm91bmRzJylcblxuICB2YXIgaVxuICBpZiAodHlwZW9mIHZhbHVlID09PSAnbnVtYmVyJykge1xuICAgIGZvciAoaSA9IHN0YXJ0OyBpIDwgZW5kOyBpKyspIHtcbiAgICAgIHRoaXNbaV0gPSB2YWx1ZVxuICAgIH1cbiAgfSBlbHNlIHtcbiAgICB2YXIgYnl0ZXMgPSB1dGY4VG9CeXRlcyh2YWx1ZS50b1N0cmluZygpKVxuICAgIHZhciBsZW4gPSBieXRlcy5sZW5ndGhcbiAgICBmb3IgKGkgPSBzdGFydDsgaSA8IGVuZDsgaSsrKSB7XG4gICAgICB0aGlzW2ldID0gYnl0ZXNbaSAlIGxlbl1cbiAgICB9XG4gIH1cblxuICByZXR1cm4gdGhpc1xufVxuXG4vKipcbiAqIENyZWF0ZXMgYSBuZXcgYEFycmF5QnVmZmVyYCB3aXRoIHRoZSAqY29waWVkKiBtZW1vcnkgb2YgdGhlIGJ1ZmZlciBpbnN0YW5jZS5cbiAqIEFkZGVkIGluIE5vZGUgMC4xMi4gT25seSBhdmFpbGFibGUgaW4gYnJvd3NlcnMgdGhhdCBzdXBwb3J0IEFycmF5QnVmZmVyLlxuICovXG5CdWZmZXIucHJvdG90eXBlLnRvQXJyYXlCdWZmZXIgPSBmdW5jdGlvbiB0b0FycmF5QnVmZmVyICgpIHtcbiAgaWYgKHR5cGVvZiBVaW50OEFycmF5ICE9PSAndW5kZWZpbmVkJykge1xuICAgIGlmIChCdWZmZXIuVFlQRURfQVJSQVlfU1VQUE9SVCkge1xuICAgICAgcmV0dXJuIChuZXcgQnVmZmVyKHRoaXMpKS5idWZmZXJcbiAgICB9IGVsc2Uge1xuICAgICAgdmFyIGJ1ZiA9IG5ldyBVaW50OEFycmF5KHRoaXMubGVuZ3RoKVxuICAgICAgZm9yICh2YXIgaSA9IDAsIGxlbiA9IGJ1Zi5sZW5ndGg7IGkgPCBsZW47IGkgKz0gMSkge1xuICAgICAgICBidWZbaV0gPSB0aGlzW2ldXG4gICAgICB9XG4gICAgICByZXR1cm4gYnVmLmJ1ZmZlclxuICAgIH1cbiAgfSBlbHNlIHtcbiAgICB0aHJvdyBuZXcgVHlwZUVycm9yKCdCdWZmZXIudG9BcnJheUJ1ZmZlciBub3Qgc3VwcG9ydGVkIGluIHRoaXMgYnJvd3NlcicpXG4gIH1cbn1cblxuLy8gSEVMUEVSIEZVTkNUSU9OU1xuLy8gPT09PT09PT09PT09PT09PVxuXG52YXIgQlAgPSBCdWZmZXIucHJvdG90eXBlXG5cbi8qKlxuICogQXVnbWVudCBhIFVpbnQ4QXJyYXkgKmluc3RhbmNlKiAobm90IHRoZSBVaW50OEFycmF5IGNsYXNzISkgd2l0aCBCdWZmZXIgbWV0aG9kc1xuICovXG5CdWZmZXIuX2F1Z21lbnQgPSBmdW5jdGlvbiBfYXVnbWVudCAoYXJyKSB7XG4gIGFyci5jb25zdHJ1Y3RvciA9IEJ1ZmZlclxuICBhcnIuX2lzQnVmZmVyID0gdHJ1ZVxuXG4gIC8vIHNhdmUgcmVmZXJlbmNlIHRvIG9yaWdpbmFsIFVpbnQ4QXJyYXkgc2V0IG1ldGhvZCBiZWZvcmUgb3ZlcndyaXRpbmdcbiAgYXJyLl9zZXQgPSBhcnIuc2V0XG5cbiAgLy8gZGVwcmVjYXRlZFxuICBhcnIuZ2V0ID0gQlAuZ2V0XG4gIGFyci5zZXQgPSBCUC5zZXRcblxuICBhcnIud3JpdGUgPSBCUC53cml0ZVxuICBhcnIudG9TdHJpbmcgPSBCUC50b1N0cmluZ1xuICBhcnIudG9Mb2NhbGVTdHJpbmcgPSBCUC50b1N0cmluZ1xuICBhcnIudG9KU09OID0gQlAudG9KU09OXG4gIGFyci5lcXVhbHMgPSBCUC5lcXVhbHNcbiAgYXJyLmNvbXBhcmUgPSBCUC5jb21wYXJlXG4gIGFyci5pbmRleE9mID0gQlAuaW5kZXhPZlxuICBhcnIuY29weSA9IEJQLmNvcHlcbiAgYXJyLnNsaWNlID0gQlAuc2xpY2VcbiAgYXJyLnJlYWRVSW50TEUgPSBCUC5yZWFkVUludExFXG4gIGFyci5yZWFkVUludEJFID0gQlAucmVhZFVJbnRCRVxuICBhcnIucmVhZFVJbnQ4ID0gQlAucmVhZFVJbnQ4XG4gIGFyci5yZWFkVUludDE2TEUgPSBCUC5yZWFkVUludDE2TEVcbiAgYXJyLnJlYWRVSW50MTZCRSA9IEJQLnJlYWRVSW50MTZCRVxuICBhcnIucmVhZFVJbnQzMkxFID0gQlAucmVhZFVJbnQzMkxFXG4gIGFyci5yZWFkVUludDMyQkUgPSBCUC5yZWFkVUludDMyQkVcbiAgYXJyLnJlYWRJbnRMRSA9IEJQLnJlYWRJbnRMRVxuICBhcnIucmVhZEludEJFID0gQlAucmVhZEludEJFXG4gIGFyci5yZWFkSW50OCA9IEJQLnJlYWRJbnQ4XG4gIGFyci5yZWFkSW50MTZMRSA9IEJQLnJlYWRJbnQxNkxFXG4gIGFyci5yZWFkSW50MTZCRSA9IEJQLnJlYWRJbnQxNkJFXG4gIGFyci5yZWFkSW50MzJMRSA9IEJQLnJlYWRJbnQzMkxFXG4gIGFyci5yZWFkSW50MzJCRSA9IEJQLnJlYWRJbnQzMkJFXG4gIGFyci5yZWFkRmxvYXRMRSA9IEJQLnJlYWRGbG9hdExFXG4gIGFyci5yZWFkRmxvYXRCRSA9IEJQLnJlYWRGbG9hdEJFXG4gIGFyci5yZWFkRG91YmxlTEUgPSBCUC5yZWFkRG91YmxlTEVcbiAgYXJyLnJlYWREb3VibGVCRSA9IEJQLnJlYWREb3VibGVCRVxuICBhcnIud3JpdGVVSW50OCA9IEJQLndyaXRlVUludDhcbiAgYXJyLndyaXRlVUludExFID0gQlAud3JpdGVVSW50TEVcbiAgYXJyLndyaXRlVUludEJFID0gQlAud3JpdGVVSW50QkVcbiAgYXJyLndyaXRlVUludDE2TEUgPSBCUC53cml0ZVVJbnQxNkxFXG4gIGFyci53cml0ZVVJbnQxNkJFID0gQlAud3JpdGVVSW50MTZCRVxuICBhcnIud3JpdGVVSW50MzJMRSA9IEJQLndyaXRlVUludDMyTEVcbiAgYXJyLndyaXRlVUludDMyQkUgPSBCUC53cml0ZVVJbnQzMkJFXG4gIGFyci53cml0ZUludExFID0gQlAud3JpdGVJbnRMRVxuICBhcnIud3JpdGVJbnRCRSA9IEJQLndyaXRlSW50QkVcbiAgYXJyLndyaXRlSW50OCA9IEJQLndyaXRlSW50OFxuICBhcnIud3JpdGVJbnQxNkxFID0gQlAud3JpdGVJbnQxNkxFXG4gIGFyci53cml0ZUludDE2QkUgPSBCUC53cml0ZUludDE2QkVcbiAgYXJyLndyaXRlSW50MzJMRSA9IEJQLndyaXRlSW50MzJMRVxuICBhcnIud3JpdGVJbnQzMkJFID0gQlAud3JpdGVJbnQzMkJFXG4gIGFyci53cml0ZUZsb2F0TEUgPSBCUC53cml0ZUZsb2F0TEVcbiAgYXJyLndyaXRlRmxvYXRCRSA9IEJQLndyaXRlRmxvYXRCRVxuICBhcnIud3JpdGVEb3VibGVMRSA9IEJQLndyaXRlRG91YmxlTEVcbiAgYXJyLndyaXRlRG91YmxlQkUgPSBCUC53cml0ZURvdWJsZUJFXG4gIGFyci5maWxsID0gQlAuZmlsbFxuICBhcnIuaW5zcGVjdCA9IEJQLmluc3BlY3RcbiAgYXJyLnRvQXJyYXlCdWZmZXIgPSBCUC50b0FycmF5QnVmZmVyXG5cbiAgcmV0dXJuIGFyclxufVxuXG52YXIgSU5WQUxJRF9CQVNFNjRfUkUgPSAvW14rXFwvMC05QS1aYS16LV9dL2dcblxuZnVuY3Rpb24gYmFzZTY0Y2xlYW4gKHN0cikge1xuICAvLyBOb2RlIHN0cmlwcyBvdXQgaW52YWxpZCBjaGFyYWN0ZXJzIGxpa2UgXFxuIGFuZCBcXHQgZnJvbSB0aGUgc3RyaW5nLCBiYXNlNjQtanMgZG9lcyBub3RcbiAgc3RyID0gc3RyaW5ndHJpbShzdHIpLnJlcGxhY2UoSU5WQUxJRF9CQVNFNjRfUkUsICcnKVxuICAvLyBOb2RlIGNvbnZlcnRzIHN0cmluZ3Mgd2l0aCBsZW5ndGggPCAyIHRvICcnXG4gIGlmIChzdHIubGVuZ3RoIDwgMikgcmV0dXJuICcnXG4gIC8vIE5vZGUgYWxsb3dzIGZvciBub24tcGFkZGVkIGJhc2U2NCBzdHJpbmdzIChtaXNzaW5nIHRyYWlsaW5nID09PSksIGJhc2U2NC1qcyBkb2VzIG5vdFxuICB3aGlsZSAoc3RyLmxlbmd0aCAlIDQgIT09IDApIHtcbiAgICBzdHIgPSBzdHIgKyAnPSdcbiAgfVxuICByZXR1cm4gc3RyXG59XG5cbmZ1bmN0aW9uIHN0cmluZ3RyaW0gKHN0cikge1xuICBpZiAoc3RyLnRyaW0pIHJldHVybiBzdHIudHJpbSgpXG4gIHJldHVybiBzdHIucmVwbGFjZSgvXlxccyt8XFxzKyQvZywgJycpXG59XG5cbmZ1bmN0aW9uIHRvSGV4IChuKSB7XG4gIGlmIChuIDwgMTYpIHJldHVybiAnMCcgKyBuLnRvU3RyaW5nKDE2KVxuICByZXR1cm4gbi50b1N0cmluZygxNilcbn1cblxuZnVuY3Rpb24gdXRmOFRvQnl0ZXMgKHN0cmluZywgdW5pdHMpIHtcbiAgdW5pdHMgPSB1bml0cyB8fCBJbmZpbml0eVxuICB2YXIgY29kZVBvaW50XG4gIHZhciBsZW5ndGggPSBzdHJpbmcubGVuZ3RoXG4gIHZhciBsZWFkU3Vycm9nYXRlID0gbnVsbFxuICB2YXIgYnl0ZXMgPSBbXVxuXG4gIGZvciAodmFyIGkgPSAwOyBpIDwgbGVuZ3RoOyBpKyspIHtcbiAgICBjb2RlUG9pbnQgPSBzdHJpbmcuY2hhckNvZGVBdChpKVxuXG4gICAgLy8gaXMgc3Vycm9nYXRlIGNvbXBvbmVudFxuICAgIGlmIChjb2RlUG9pbnQgPiAweEQ3RkYgJiYgY29kZVBvaW50IDwgMHhFMDAwKSB7XG4gICAgICAvLyBsYXN0IGNoYXIgd2FzIGEgbGVhZFxuICAgICAgaWYgKCFsZWFkU3Vycm9nYXRlKSB7XG4gICAgICAgIC8vIG5vIGxlYWQgeWV0XG4gICAgICAgIGlmIChjb2RlUG9pbnQgPiAweERCRkYpIHtcbiAgICAgICAgICAvLyB1bmV4cGVjdGVkIHRyYWlsXG4gICAgICAgICAgaWYgKCh1bml0cyAtPSAzKSA+IC0xKSBieXRlcy5wdXNoKDB4RUYsIDB4QkYsIDB4QkQpXG4gICAgICAgICAgY29udGludWVcbiAgICAgICAgfSBlbHNlIGlmIChpICsgMSA9PT0gbGVuZ3RoKSB7XG4gICAgICAgICAgLy8gdW5wYWlyZWQgbGVhZFxuICAgICAgICAgIGlmICgodW5pdHMgLT0gMykgPiAtMSkgYnl0ZXMucHVzaCgweEVGLCAweEJGLCAweEJEKVxuICAgICAgICAgIGNvbnRpbnVlXG4gICAgICAgIH1cblxuICAgICAgICAvLyB2YWxpZCBsZWFkXG4gICAgICAgIGxlYWRTdXJyb2dhdGUgPSBjb2RlUG9pbnRcblxuICAgICAgICBjb250aW51ZVxuICAgICAgfVxuXG4gICAgICAvLyAyIGxlYWRzIGluIGEgcm93XG4gICAgICBpZiAoY29kZVBvaW50IDwgMHhEQzAwKSB7XG4gICAgICAgIGlmICgodW5pdHMgLT0gMykgPiAtMSkgYnl0ZXMucHVzaCgweEVGLCAweEJGLCAweEJEKVxuICAgICAgICBsZWFkU3Vycm9nYXRlID0gY29kZVBvaW50XG4gICAgICAgIGNvbnRpbnVlXG4gICAgICB9XG5cbiAgICAgIC8vIHZhbGlkIHN1cnJvZ2F0ZSBwYWlyXG4gICAgICBjb2RlUG9pbnQgPSAobGVhZFN1cnJvZ2F0ZSAtIDB4RDgwMCA8PCAxMCB8IGNvZGVQb2ludCAtIDB4REMwMCkgKyAweDEwMDAwXG4gICAgfSBlbHNlIGlmIChsZWFkU3Vycm9nYXRlKSB7XG4gICAgICAvLyB2YWxpZCBibXAgY2hhciwgYnV0IGxhc3QgY2hhciB3YXMgYSBsZWFkXG4gICAgICBpZiAoKHVuaXRzIC09IDMpID4gLTEpIGJ5dGVzLnB1c2goMHhFRiwgMHhCRiwgMHhCRClcbiAgICB9XG5cbiAgICBsZWFkU3Vycm9nYXRlID0gbnVsbFxuXG4gICAgLy8gZW5jb2RlIHV0ZjhcbiAgICBpZiAoY29kZVBvaW50IDwgMHg4MCkge1xuICAgICAgaWYgKCh1bml0cyAtPSAxKSA8IDApIGJyZWFrXG4gICAgICBieXRlcy5wdXNoKGNvZGVQb2ludClcbiAgICB9IGVsc2UgaWYgKGNvZGVQb2ludCA8IDB4ODAwKSB7XG4gICAgICBpZiAoKHVuaXRzIC09IDIpIDwgMCkgYnJlYWtcbiAgICAgIGJ5dGVzLnB1c2goXG4gICAgICAgIGNvZGVQb2ludCA+PiAweDYgfCAweEMwLFxuICAgICAgICBjb2RlUG9pbnQgJiAweDNGIHwgMHg4MFxuICAgICAgKVxuICAgIH0gZWxzZSBpZiAoY29kZVBvaW50IDwgMHgxMDAwMCkge1xuICAgICAgaWYgKCh1bml0cyAtPSAzKSA8IDApIGJyZWFrXG4gICAgICBieXRlcy5wdXNoKFxuICAgICAgICBjb2RlUG9pbnQgPj4gMHhDIHwgMHhFMCxcbiAgICAgICAgY29kZVBvaW50ID4+IDB4NiAmIDB4M0YgfCAweDgwLFxuICAgICAgICBjb2RlUG9pbnQgJiAweDNGIHwgMHg4MFxuICAgICAgKVxuICAgIH0gZWxzZSBpZiAoY29kZVBvaW50IDwgMHgxMTAwMDApIHtcbiAgICAgIGlmICgodW5pdHMgLT0gNCkgPCAwKSBicmVha1xuICAgICAgYnl0ZXMucHVzaChcbiAgICAgICAgY29kZVBvaW50ID4+IDB4MTIgfCAweEYwLFxuICAgICAgICBjb2RlUG9pbnQgPj4gMHhDICYgMHgzRiB8IDB4ODAsXG4gICAgICAgIGNvZGVQb2ludCA+PiAweDYgJiAweDNGIHwgMHg4MCxcbiAgICAgICAgY29kZVBvaW50ICYgMHgzRiB8IDB4ODBcbiAgICAgIClcbiAgICB9IGVsc2Uge1xuICAgICAgdGhyb3cgbmV3IEVycm9yKCdJbnZhbGlkIGNvZGUgcG9pbnQnKVxuICAgIH1cbiAgfVxuXG4gIHJldHVybiBieXRlc1xufVxuXG5mdW5jdGlvbiBhc2NpaVRvQnl0ZXMgKHN0cikge1xuICB2YXIgYnl0ZUFycmF5ID0gW11cbiAgZm9yICh2YXIgaSA9IDA7IGkgPCBzdHIubGVuZ3RoOyBpKyspIHtcbiAgICAvLyBOb2RlJ3MgY29kZSBzZWVtcyB0byBiZSBkb2luZyB0aGlzIGFuZCBub3QgJiAweDdGLi5cbiAgICBieXRlQXJyYXkucHVzaChzdHIuY2hhckNvZGVBdChpKSAmIDB4RkYpXG4gIH1cbiAgcmV0dXJuIGJ5dGVBcnJheVxufVxuXG5mdW5jdGlvbiB1dGYxNmxlVG9CeXRlcyAoc3RyLCB1bml0cykge1xuICB2YXIgYywgaGksIGxvXG4gIHZhciBieXRlQXJyYXkgPSBbXVxuICBmb3IgKHZhciBpID0gMDsgaSA8IHN0ci5sZW5ndGg7IGkrKykge1xuICAgIGlmICgodW5pdHMgLT0gMikgPCAwKSBicmVha1xuXG4gICAgYyA9IHN0ci5jaGFyQ29kZUF0KGkpXG4gICAgaGkgPSBjID4+IDhcbiAgICBsbyA9IGMgJSAyNTZcbiAgICBieXRlQXJyYXkucHVzaChsbylcbiAgICBieXRlQXJyYXkucHVzaChoaSlcbiAgfVxuXG4gIHJldHVybiBieXRlQXJyYXlcbn1cblxuZnVuY3Rpb24gYmFzZTY0VG9CeXRlcyAoc3RyKSB7XG4gIHJldHVybiBiYXNlNjQudG9CeXRlQXJyYXkoYmFzZTY0Y2xlYW4oc3RyKSlcbn1cblxuZnVuY3Rpb24gYmxpdEJ1ZmZlciAoc3JjLCBkc3QsIG9mZnNldCwgbGVuZ3RoKSB7XG4gIGZvciAodmFyIGkgPSAwOyBpIDwgbGVuZ3RoOyBpKyspIHtcbiAgICBpZiAoKGkgKyBvZmZzZXQgPj0gZHN0Lmxlbmd0aCkgfHwgKGkgPj0gc3JjLmxlbmd0aCkpIGJyZWFrXG4gICAgZHN0W2kgKyBvZmZzZXRdID0gc3JjW2ldXG4gIH1cbiAgcmV0dXJuIGlcbn1cbiIsInZhciB0b1N0cmluZyA9IHt9LnRvU3RyaW5nO1xuXG5tb2R1bGUuZXhwb3J0cyA9IEFycmF5LmlzQXJyYXkgfHwgZnVuY3Rpb24gKGFycikge1xuICByZXR1cm4gdG9TdHJpbmcuY2FsbChhcnIpID09ICdbb2JqZWN0IEFycmF5XSc7XG59O1xuIiwidmFyIGNsb25lID0gKGZ1bmN0aW9uKCkge1xuJ3VzZSBzdHJpY3QnO1xuXG4vKipcbiAqIENsb25lcyAoY29waWVzKSBhbiBPYmplY3QgdXNpbmcgZGVlcCBjb3B5aW5nLlxuICpcbiAqIFRoaXMgZnVuY3Rpb24gc3VwcG9ydHMgY2lyY3VsYXIgcmVmZXJlbmNlcyBieSBkZWZhdWx0LCBidXQgaWYgeW91IGFyZSBjZXJ0YWluXG4gKiB0aGVyZSBhcmUgbm8gY2lyY3VsYXIgcmVmZXJlbmNlcyBpbiB5b3VyIG9iamVjdCwgeW91IGNhbiBzYXZlIHNvbWUgQ1BVIHRpbWVcbiAqIGJ5IGNhbGxpbmcgY2xvbmUob2JqLCBmYWxzZSkuXG4gKlxuICogQ2F1dGlvbjogaWYgYGNpcmN1bGFyYCBpcyBmYWxzZSBhbmQgYHBhcmVudGAgY29udGFpbnMgY2lyY3VsYXIgcmVmZXJlbmNlcyxcbiAqIHlvdXIgcHJvZ3JhbSBtYXkgZW50ZXIgYW4gaW5maW5pdGUgbG9vcCBhbmQgY3Jhc2guXG4gKlxuICogQHBhcmFtIGBwYXJlbnRgIC0gdGhlIG9iamVjdCB0byBiZSBjbG9uZWRcbiAqIEBwYXJhbSBgY2lyY3VsYXJgIC0gc2V0IHRvIHRydWUgaWYgdGhlIG9iamVjdCB0byBiZSBjbG9uZWQgbWF5IGNvbnRhaW5cbiAqICAgIGNpcmN1bGFyIHJlZmVyZW5jZXMuIChvcHRpb25hbCAtIHRydWUgYnkgZGVmYXVsdClcbiAqIEBwYXJhbSBgZGVwdGhgIC0gc2V0IHRvIGEgbnVtYmVyIGlmIHRoZSBvYmplY3QgaXMgb25seSB0byBiZSBjbG9uZWQgdG9cbiAqICAgIGEgcGFydGljdWxhciBkZXB0aC4gKG9wdGlvbmFsIC0gZGVmYXVsdHMgdG8gSW5maW5pdHkpXG4gKiBAcGFyYW0gYHByb3RvdHlwZWAgLSBzZXRzIHRoZSBwcm90b3R5cGUgdG8gYmUgdXNlZCB3aGVuIGNsb25pbmcgYW4gb2JqZWN0LlxuICogICAgKG9wdGlvbmFsIC0gZGVmYXVsdHMgdG8gcGFyZW50IHByb3RvdHlwZSkuXG4qL1xuZnVuY3Rpb24gY2xvbmUocGFyZW50LCBjaXJjdWxhciwgZGVwdGgsIHByb3RvdHlwZSkge1xuICB2YXIgZmlsdGVyO1xuICBpZiAodHlwZW9mIGNpcmN1bGFyID09PSAnb2JqZWN0Jykge1xuICAgIGRlcHRoID0gY2lyY3VsYXIuZGVwdGg7XG4gICAgcHJvdG90eXBlID0gY2lyY3VsYXIucHJvdG90eXBlO1xuICAgIGZpbHRlciA9IGNpcmN1bGFyLmZpbHRlcjtcbiAgICBjaXJjdWxhciA9IGNpcmN1bGFyLmNpcmN1bGFyXG4gIH1cbiAgLy8gbWFpbnRhaW4gdHdvIGFycmF5cyBmb3IgY2lyY3VsYXIgcmVmZXJlbmNlcywgd2hlcmUgY29ycmVzcG9uZGluZyBwYXJlbnRzXG4gIC8vIGFuZCBjaGlsZHJlbiBoYXZlIHRoZSBzYW1lIGluZGV4XG4gIHZhciBhbGxQYXJlbnRzID0gW107XG4gIHZhciBhbGxDaGlsZHJlbiA9IFtdO1xuXG4gIHZhciB1c2VCdWZmZXIgPSB0eXBlb2YgQnVmZmVyICE9ICd1bmRlZmluZWQnO1xuXG4gIGlmICh0eXBlb2YgY2lyY3VsYXIgPT0gJ3VuZGVmaW5lZCcpXG4gICAgY2lyY3VsYXIgPSB0cnVlO1xuXG4gIGlmICh0eXBlb2YgZGVwdGggPT0gJ3VuZGVmaW5lZCcpXG4gICAgZGVwdGggPSBJbmZpbml0eTtcblxuICAvLyByZWN1cnNlIHRoaXMgZnVuY3Rpb24gc28gd2UgZG9uJ3QgcmVzZXQgYWxsUGFyZW50cyBhbmQgYWxsQ2hpbGRyZW5cbiAgZnVuY3Rpb24gX2Nsb25lKHBhcmVudCwgZGVwdGgpIHtcbiAgICAvLyBjbG9uaW5nIG51bGwgYWx3YXlzIHJldHVybnMgbnVsbFxuICAgIGlmIChwYXJlbnQgPT09IG51bGwpXG4gICAgICByZXR1cm4gbnVsbDtcblxuICAgIGlmIChkZXB0aCA9PSAwKVxuICAgICAgcmV0dXJuIHBhcmVudDtcblxuICAgIHZhciBjaGlsZDtcbiAgICB2YXIgcHJvdG87XG4gICAgaWYgKHR5cGVvZiBwYXJlbnQgIT0gJ29iamVjdCcpIHtcbiAgICAgIHJldHVybiBwYXJlbnQ7XG4gICAgfVxuXG4gICAgaWYgKGNsb25lLl9faXNBcnJheShwYXJlbnQpKSB7XG4gICAgICBjaGlsZCA9IFtdO1xuICAgIH0gZWxzZSBpZiAoY2xvbmUuX19pc1JlZ0V4cChwYXJlbnQpKSB7XG4gICAgICBjaGlsZCA9IG5ldyBSZWdFeHAocGFyZW50LnNvdXJjZSwgX19nZXRSZWdFeHBGbGFncyhwYXJlbnQpKTtcbiAgICAgIGlmIChwYXJlbnQubGFzdEluZGV4KSBjaGlsZC5sYXN0SW5kZXggPSBwYXJlbnQubGFzdEluZGV4O1xuICAgIH0gZWxzZSBpZiAoY2xvbmUuX19pc0RhdGUocGFyZW50KSkge1xuICAgICAgY2hpbGQgPSBuZXcgRGF0ZShwYXJlbnQuZ2V0VGltZSgpKTtcbiAgICB9IGVsc2UgaWYgKHVzZUJ1ZmZlciAmJiBCdWZmZXIuaXNCdWZmZXIocGFyZW50KSkge1xuICAgICAgY2hpbGQgPSBuZXcgQnVmZmVyKHBhcmVudC5sZW5ndGgpO1xuICAgICAgcGFyZW50LmNvcHkoY2hpbGQpO1xuICAgICAgcmV0dXJuIGNoaWxkO1xuICAgIH0gZWxzZSB7XG4gICAgICBpZiAodHlwZW9mIHByb3RvdHlwZSA9PSAndW5kZWZpbmVkJykge1xuICAgICAgICBwcm90byA9IE9iamVjdC5nZXRQcm90b3R5cGVPZihwYXJlbnQpO1xuICAgICAgICBjaGlsZCA9IE9iamVjdC5jcmVhdGUocHJvdG8pO1xuICAgICAgfVxuICAgICAgZWxzZSB7XG4gICAgICAgIGNoaWxkID0gT2JqZWN0LmNyZWF0ZShwcm90b3R5cGUpO1xuICAgICAgICBwcm90byA9IHByb3RvdHlwZTtcbiAgICAgIH1cbiAgICB9XG5cbiAgICBpZiAoY2lyY3VsYXIpIHtcbiAgICAgIHZhciBpbmRleCA9IGFsbFBhcmVudHMuaW5kZXhPZihwYXJlbnQpO1xuXG4gICAgICBpZiAoaW5kZXggIT0gLTEpIHtcbiAgICAgICAgcmV0dXJuIGFsbENoaWxkcmVuW2luZGV4XTtcbiAgICAgIH1cbiAgICAgIGFsbFBhcmVudHMucHVzaChwYXJlbnQpO1xuICAgICAgYWxsQ2hpbGRyZW4ucHVzaChjaGlsZCk7XG4gICAgfVxuXG4gICAgZm9yICh2YXIgaSBpbiBwYXJlbnQpIHtcbiAgICAgIHZhciBhdHRycztcbiAgICAgIGlmIChwcm90bykge1xuICAgICAgICBhdHRycyA9IE9iamVjdC5nZXRPd25Qcm9wZXJ0eURlc2NyaXB0b3IocHJvdG8sIGkpO1xuICAgICAgfVxuXG4gICAgICBpZiAoYXR0cnMgJiYgYXR0cnMuc2V0ID09IG51bGwpIHtcbiAgICAgICAgY29udGludWU7XG4gICAgICB9XG4gICAgICBjaGlsZFtpXSA9IF9jbG9uZShwYXJlbnRbaV0sIGRlcHRoIC0gMSk7XG4gICAgfVxuXG4gICAgcmV0dXJuIGNoaWxkO1xuICB9XG5cbiAgcmV0dXJuIF9jbG9uZShwYXJlbnQsIGRlcHRoKTtcbn1cblxuLyoqXG4gKiBTaW1wbGUgZmxhdCBjbG9uZSB1c2luZyBwcm90b3R5cGUsIGFjY2VwdHMgb25seSBvYmplY3RzLCB1c2VmdWxsIGZvciBwcm9wZXJ0eVxuICogb3ZlcnJpZGUgb24gRkxBVCBjb25maWd1cmF0aW9uIG9iamVjdCAobm8gbmVzdGVkIHByb3BzKS5cbiAqXG4gKiBVU0UgV0lUSCBDQVVUSU9OISBUaGlzIG1heSBub3QgYmVoYXZlIGFzIHlvdSB3aXNoIGlmIHlvdSBkbyBub3Qga25vdyBob3cgdGhpc1xuICogd29ya3MuXG4gKi9cbmNsb25lLmNsb25lUHJvdG90eXBlID0gZnVuY3Rpb24gY2xvbmVQcm90b3R5cGUocGFyZW50KSB7XG4gIGlmIChwYXJlbnQgPT09IG51bGwpXG4gICAgcmV0dXJuIG51bGw7XG5cbiAgdmFyIGMgPSBmdW5jdGlvbiAoKSB7fTtcbiAgYy5wcm90b3R5cGUgPSBwYXJlbnQ7XG4gIHJldHVybiBuZXcgYygpO1xufTtcblxuLy8gcHJpdmF0ZSB1dGlsaXR5IGZ1bmN0aW9uc1xuXG5mdW5jdGlvbiBfX29ialRvU3RyKG8pIHtcbiAgcmV0dXJuIE9iamVjdC5wcm90b3R5cGUudG9TdHJpbmcuY2FsbChvKTtcbn07XG5jbG9uZS5fX29ialRvU3RyID0gX19vYmpUb1N0cjtcblxuZnVuY3Rpb24gX19pc0RhdGUobykge1xuICByZXR1cm4gdHlwZW9mIG8gPT09ICdvYmplY3QnICYmIF9fb2JqVG9TdHIobykgPT09ICdbb2JqZWN0IERhdGVdJztcbn07XG5jbG9uZS5fX2lzRGF0ZSA9IF9faXNEYXRlO1xuXG5mdW5jdGlvbiBfX2lzQXJyYXkobykge1xuICByZXR1cm4gdHlwZW9mIG8gPT09ICdvYmplY3QnICYmIF9fb2JqVG9TdHIobykgPT09ICdbb2JqZWN0IEFycmF5XSc7XG59O1xuY2xvbmUuX19pc0FycmF5ID0gX19pc0FycmF5O1xuXG5mdW5jdGlvbiBfX2lzUmVnRXhwKG8pIHtcbiAgcmV0dXJuIHR5cGVvZiBvID09PSAnb2JqZWN0JyAmJiBfX29ialRvU3RyKG8pID09PSAnW29iamVjdCBSZWdFeHBdJztcbn07XG5jbG9uZS5fX2lzUmVnRXhwID0gX19pc1JlZ0V4cDtcblxuZnVuY3Rpb24gX19nZXRSZWdFeHBGbGFncyhyZSkge1xuICB2YXIgZmxhZ3MgPSAnJztcbiAgaWYgKHJlLmdsb2JhbCkgZmxhZ3MgKz0gJ2cnO1xuICBpZiAocmUuaWdub3JlQ2FzZSkgZmxhZ3MgKz0gJ2knO1xuICBpZiAocmUubXVsdGlsaW5lKSBmbGFncyArPSAnbSc7XG4gIHJldHVybiBmbGFncztcbn07XG5jbG9uZS5fX2dldFJlZ0V4cEZsYWdzID0gX19nZXRSZWdFeHBGbGFncztcblxucmV0dXJuIGNsb25lO1xufSkoKTtcblxuaWYgKHR5cGVvZiBtb2R1bGUgPT09ICdvYmplY3QnICYmIG1vZHVsZS5leHBvcnRzKSB7XG4gIG1vZHVsZS5leHBvcnRzID0gY2xvbmU7XG59XG4iLCJ2YXIgcFNsaWNlID0gQXJyYXkucHJvdG90eXBlLnNsaWNlO1xudmFyIG9iamVjdEtleXMgPSByZXF1aXJlKCcuL2xpYi9rZXlzLmpzJyk7XG52YXIgaXNBcmd1bWVudHMgPSByZXF1aXJlKCcuL2xpYi9pc19hcmd1bWVudHMuanMnKTtcblxudmFyIGRlZXBFcXVhbCA9IG1vZHVsZS5leHBvcnRzID0gZnVuY3Rpb24gKGFjdHVhbCwgZXhwZWN0ZWQsIG9wdHMpIHtcbiAgaWYgKCFvcHRzKSBvcHRzID0ge307XG4gIC8vIDcuMS4gQWxsIGlkZW50aWNhbCB2YWx1ZXMgYXJlIGVxdWl2YWxlbnQsIGFzIGRldGVybWluZWQgYnkgPT09LlxuICBpZiAoYWN0dWFsID09PSBleHBlY3RlZCkge1xuICAgIHJldHVybiB0cnVlO1xuXG4gIH0gZWxzZSBpZiAoYWN0dWFsIGluc3RhbmNlb2YgRGF0ZSAmJiBleHBlY3RlZCBpbnN0YW5jZW9mIERhdGUpIHtcbiAgICByZXR1cm4gYWN0dWFsLmdldFRpbWUoKSA9PT0gZXhwZWN0ZWQuZ2V0VGltZSgpO1xuXG4gIC8vIDcuMy4gT3RoZXIgcGFpcnMgdGhhdCBkbyBub3QgYm90aCBwYXNzIHR5cGVvZiB2YWx1ZSA9PSAnb2JqZWN0JyxcbiAgLy8gZXF1aXZhbGVuY2UgaXMgZGV0ZXJtaW5lZCBieSA9PS5cbiAgfSBlbHNlIGlmICghYWN0dWFsIHx8ICFleHBlY3RlZCB8fCB0eXBlb2YgYWN0dWFsICE9ICdvYmplY3QnICYmIHR5cGVvZiBleHBlY3RlZCAhPSAnb2JqZWN0Jykge1xuICAgIHJldHVybiBvcHRzLnN0cmljdCA/IGFjdHVhbCA9PT0gZXhwZWN0ZWQgOiBhY3R1YWwgPT0gZXhwZWN0ZWQ7XG5cbiAgLy8gNy40LiBGb3IgYWxsIG90aGVyIE9iamVjdCBwYWlycywgaW5jbHVkaW5nIEFycmF5IG9iamVjdHMsIGVxdWl2YWxlbmNlIGlzXG4gIC8vIGRldGVybWluZWQgYnkgaGF2aW5nIHRoZSBzYW1lIG51bWJlciBvZiBvd25lZCBwcm9wZXJ0aWVzIChhcyB2ZXJpZmllZFxuICAvLyB3aXRoIE9iamVjdC5wcm90b3R5cGUuaGFzT3duUHJvcGVydHkuY2FsbCksIHRoZSBzYW1lIHNldCBvZiBrZXlzXG4gIC8vIChhbHRob3VnaCBub3QgbmVjZXNzYXJpbHkgdGhlIHNhbWUgb3JkZXIpLCBlcXVpdmFsZW50IHZhbHVlcyBmb3IgZXZlcnlcbiAgLy8gY29ycmVzcG9uZGluZyBrZXksIGFuZCBhbiBpZGVudGljYWwgJ3Byb3RvdHlwZScgcHJvcGVydHkuIE5vdGU6IHRoaXNcbiAgLy8gYWNjb3VudHMgZm9yIGJvdGggbmFtZWQgYW5kIGluZGV4ZWQgcHJvcGVydGllcyBvbiBBcnJheXMuXG4gIH0gZWxzZSB7XG4gICAgcmV0dXJuIG9iakVxdWl2KGFjdHVhbCwgZXhwZWN0ZWQsIG9wdHMpO1xuICB9XG59XG5cbmZ1bmN0aW9uIGlzVW5kZWZpbmVkT3JOdWxsKHZhbHVlKSB7XG4gIHJldHVybiB2YWx1ZSA9PT0gbnVsbCB8fCB2YWx1ZSA9PT0gdW5kZWZpbmVkO1xufVxuXG5mdW5jdGlvbiBpc0J1ZmZlciAoeCkge1xuICBpZiAoIXggfHwgdHlwZW9mIHggIT09ICdvYmplY3QnIHx8IHR5cGVvZiB4Lmxlbmd0aCAhPT0gJ251bWJlcicpIHJldHVybiBmYWxzZTtcbiAgaWYgKHR5cGVvZiB4LmNvcHkgIT09ICdmdW5jdGlvbicgfHwgdHlwZW9mIHguc2xpY2UgIT09ICdmdW5jdGlvbicpIHtcbiAgICByZXR1cm4gZmFsc2U7XG4gIH1cbiAgaWYgKHgubGVuZ3RoID4gMCAmJiB0eXBlb2YgeFswXSAhPT0gJ251bWJlcicpIHJldHVybiBmYWxzZTtcbiAgcmV0dXJuIHRydWU7XG59XG5cbmZ1bmN0aW9uIG9iakVxdWl2KGEsIGIsIG9wdHMpIHtcbiAgdmFyIGksIGtleTtcbiAgaWYgKGlzVW5kZWZpbmVkT3JOdWxsKGEpIHx8IGlzVW5kZWZpbmVkT3JOdWxsKGIpKVxuICAgIHJldHVybiBmYWxzZTtcbiAgLy8gYW4gaWRlbnRpY2FsICdwcm90b3R5cGUnIHByb3BlcnR5LlxuICBpZiAoYS5wcm90b3R5cGUgIT09IGIucHJvdG90eXBlKSByZXR1cm4gZmFsc2U7XG4gIC8vfn5+SSd2ZSBtYW5hZ2VkIHRvIGJyZWFrIE9iamVjdC5rZXlzIHRocm91Z2ggc2NyZXd5IGFyZ3VtZW50cyBwYXNzaW5nLlxuICAvLyAgIENvbnZlcnRpbmcgdG8gYXJyYXkgc29sdmVzIHRoZSBwcm9ibGVtLlxuICBpZiAoaXNBcmd1bWVudHMoYSkpIHtcbiAgICBpZiAoIWlzQXJndW1lbnRzKGIpKSB7XG4gICAgICByZXR1cm4gZmFsc2U7XG4gICAgfVxuICAgIGEgPSBwU2xpY2UuY2FsbChhKTtcbiAgICBiID0gcFNsaWNlLmNhbGwoYik7XG4gICAgcmV0dXJuIGRlZXBFcXVhbChhLCBiLCBvcHRzKTtcbiAgfVxuICBpZiAoaXNCdWZmZXIoYSkpIHtcbiAgICBpZiAoIWlzQnVmZmVyKGIpKSB7XG4gICAgICByZXR1cm4gZmFsc2U7XG4gICAgfVxuICAgIGlmIChhLmxlbmd0aCAhPT0gYi5sZW5ndGgpIHJldHVybiBmYWxzZTtcbiAgICBmb3IgKGkgPSAwOyBpIDwgYS5sZW5ndGg7IGkrKykge1xuICAgICAgaWYgKGFbaV0gIT09IGJbaV0pIHJldHVybiBmYWxzZTtcbiAgICB9XG4gICAgcmV0dXJuIHRydWU7XG4gIH1cbiAgdHJ5IHtcbiAgICB2YXIga2EgPSBvYmplY3RLZXlzKGEpLFxuICAgICAgICBrYiA9IG9iamVjdEtleXMoYik7XG4gIH0gY2F0Y2ggKGUpIHsvL2hhcHBlbnMgd2hlbiBvbmUgaXMgYSBzdHJpbmcgbGl0ZXJhbCBhbmQgdGhlIG90aGVyIGlzbid0XG4gICAgcmV0dXJuIGZhbHNlO1xuICB9XG4gIC8vIGhhdmluZyB0aGUgc2FtZSBudW1iZXIgb2Ygb3duZWQgcHJvcGVydGllcyAoa2V5cyBpbmNvcnBvcmF0ZXNcbiAgLy8gaGFzT3duUHJvcGVydHkpXG4gIGlmIChrYS5sZW5ndGggIT0ga2IubGVuZ3RoKVxuICAgIHJldHVybiBmYWxzZTtcbiAgLy90aGUgc2FtZSBzZXQgb2Yga2V5cyAoYWx0aG91Z2ggbm90IG5lY2Vzc2FyaWx5IHRoZSBzYW1lIG9yZGVyKSxcbiAga2Euc29ydCgpO1xuICBrYi5zb3J0KCk7XG4gIC8vfn5+Y2hlYXAga2V5IHRlc3RcbiAgZm9yIChpID0ga2EubGVuZ3RoIC0gMTsgaSA+PSAwOyBpLS0pIHtcbiAgICBpZiAoa2FbaV0gIT0ga2JbaV0pXG4gICAgICByZXR1cm4gZmFsc2U7XG4gIH1cbiAgLy9lcXVpdmFsZW50IHZhbHVlcyBmb3IgZXZlcnkgY29ycmVzcG9uZGluZyBrZXksIGFuZFxuICAvL35+fnBvc3NpYmx5IGV4cGVuc2l2ZSBkZWVwIHRlc3RcbiAgZm9yIChpID0ga2EubGVuZ3RoIC0gMTsgaSA+PSAwOyBpLS0pIHtcbiAgICBrZXkgPSBrYVtpXTtcbiAgICBpZiAoIWRlZXBFcXVhbChhW2tleV0sIGJba2V5XSwgb3B0cykpIHJldHVybiBmYWxzZTtcbiAgfVxuICByZXR1cm4gdHlwZW9mIGEgPT09IHR5cGVvZiBiO1xufVxuIiwidmFyIHN1cHBvcnRzQXJndW1lbnRzQ2xhc3MgPSAoZnVuY3Rpb24oKXtcbiAgcmV0dXJuIE9iamVjdC5wcm90b3R5cGUudG9TdHJpbmcuY2FsbChhcmd1bWVudHMpXG59KSgpID09ICdbb2JqZWN0IEFyZ3VtZW50c10nO1xuXG5leHBvcnRzID0gbW9kdWxlLmV4cG9ydHMgPSBzdXBwb3J0c0FyZ3VtZW50c0NsYXNzID8gc3VwcG9ydGVkIDogdW5zdXBwb3J0ZWQ7XG5cbmV4cG9ydHMuc3VwcG9ydGVkID0gc3VwcG9ydGVkO1xuZnVuY3Rpb24gc3VwcG9ydGVkKG9iamVjdCkge1xuICByZXR1cm4gT2JqZWN0LnByb3RvdHlwZS50b1N0cmluZy5jYWxsKG9iamVjdCkgPT0gJ1tvYmplY3QgQXJndW1lbnRzXSc7XG59O1xuXG5leHBvcnRzLnVuc3VwcG9ydGVkID0gdW5zdXBwb3J0ZWQ7XG5mdW5jdGlvbiB1bnN1cHBvcnRlZChvYmplY3Qpe1xuICByZXR1cm4gb2JqZWN0ICYmXG4gICAgdHlwZW9mIG9iamVjdCA9PSAnb2JqZWN0JyAmJlxuICAgIHR5cGVvZiBvYmplY3QubGVuZ3RoID09ICdudW1iZXInICYmXG4gICAgT2JqZWN0LnByb3RvdHlwZS5oYXNPd25Qcm9wZXJ0eS5jYWxsKG9iamVjdCwgJ2NhbGxlZScpICYmXG4gICAgIU9iamVjdC5wcm90b3R5cGUucHJvcGVydHlJc0VudW1lcmFibGUuY2FsbChvYmplY3QsICdjYWxsZWUnKSB8fFxuICAgIGZhbHNlO1xufTtcbiIsImV4cG9ydHMgPSBtb2R1bGUuZXhwb3J0cyA9IHR5cGVvZiBPYmplY3Qua2V5cyA9PT0gJ2Z1bmN0aW9uJ1xuICA/IE9iamVjdC5rZXlzIDogc2hpbTtcblxuZXhwb3J0cy5zaGltID0gc2hpbTtcbmZ1bmN0aW9uIHNoaW0gKG9iaikge1xuICB2YXIga2V5cyA9IFtdO1xuICBmb3IgKHZhciBrZXkgaW4gb2JqKSBrZXlzLnB1c2goa2V5KTtcbiAgcmV0dXJuIGtleXM7XG59XG4iLCIvLyBDb3B5cmlnaHQgSm95ZW50LCBJbmMuIGFuZCBvdGhlciBOb2RlIGNvbnRyaWJ1dG9ycy5cbi8vXG4vLyBQZXJtaXNzaW9uIGlzIGhlcmVieSBncmFudGVkLCBmcmVlIG9mIGNoYXJnZSwgdG8gYW55IHBlcnNvbiBvYnRhaW5pbmcgYVxuLy8gY29weSBvZiB0aGlzIHNvZnR3YXJlIGFuZCBhc3NvY2lhdGVkIGRvY3VtZW50YXRpb24gZmlsZXMgKHRoZVxuLy8gXCJTb2Z0d2FyZVwiKSwgdG8gZGVhbCBpbiB0aGUgU29mdHdhcmUgd2l0aG91dCByZXN0cmljdGlvbiwgaW5jbHVkaW5nXG4vLyB3aXRob3V0IGxpbWl0YXRpb24gdGhlIHJpZ2h0cyB0byB1c2UsIGNvcHksIG1vZGlmeSwgbWVyZ2UsIHB1Ymxpc2gsXG4vLyBkaXN0cmlidXRlLCBzdWJsaWNlbnNlLCBhbmQvb3Igc2VsbCBjb3BpZXMgb2YgdGhlIFNvZnR3YXJlLCBhbmQgdG8gcGVybWl0XG4vLyBwZXJzb25zIHRvIHdob20gdGhlIFNvZnR3YXJlIGlzIGZ1cm5pc2hlZCB0byBkbyBzbywgc3ViamVjdCB0byB0aGVcbi8vIGZvbGxvd2luZyBjb25kaXRpb25zOlxuLy9cbi8vIFRoZSBhYm92ZSBjb3B5cmlnaHQgbm90aWNlIGFuZCB0aGlzIHBlcm1pc3Npb24gbm90aWNlIHNoYWxsIGJlIGluY2x1ZGVkXG4vLyBpbiBhbGwgY29waWVzIG9yIHN1YnN0YW50aWFsIHBvcnRpb25zIG9mIHRoZSBTb2Z0d2FyZS5cbi8vXG4vLyBUSEUgU09GVFdBUkUgSVMgUFJPVklERUQgXCJBUyBJU1wiLCBXSVRIT1VUIFdBUlJBTlRZIE9GIEFOWSBLSU5ELCBFWFBSRVNTXG4vLyBPUiBJTVBMSUVELCBJTkNMVURJTkcgQlVUIE5PVCBMSU1JVEVEIFRPIFRIRSBXQVJSQU5USUVTIE9GXG4vLyBNRVJDSEFOVEFCSUxJVFksIEZJVE5FU1MgRk9SIEEgUEFSVElDVUxBUiBQVVJQT1NFIEFORCBOT05JTkZSSU5HRU1FTlQuIElOXG4vLyBOTyBFVkVOVCBTSEFMTCBUSEUgQVVUSE9SUyBPUiBDT1BZUklHSFQgSE9MREVSUyBCRSBMSUFCTEUgRk9SIEFOWSBDTEFJTSxcbi8vIERBTUFHRVMgT1IgT1RIRVIgTElBQklMSVRZLCBXSEVUSEVSIElOIEFOIEFDVElPTiBPRiBDT05UUkFDVCwgVE9SVCBPUlxuLy8gT1RIRVJXSVNFLCBBUklTSU5HIEZST00sIE9VVCBPRiBPUiBJTiBDT05ORUNUSU9OIFdJVEggVEhFIFNPRlRXQVJFIE9SIFRIRVxuLy8gVVNFIE9SIE9USEVSIERFQUxJTkdTIElOIFRIRSBTT0ZUV0FSRS5cblxuZnVuY3Rpb24gRXZlbnRFbWl0dGVyKCkge1xuICB0aGlzLl9ldmVudHMgPSB0aGlzLl9ldmVudHMgfHwge307XG4gIHRoaXMuX21heExpc3RlbmVycyA9IHRoaXMuX21heExpc3RlbmVycyB8fCB1bmRlZmluZWQ7XG59XG5tb2R1bGUuZXhwb3J0cyA9IEV2ZW50RW1pdHRlcjtcblxuLy8gQmFja3dhcmRzLWNvbXBhdCB3aXRoIG5vZGUgMC4xMC54XG5FdmVudEVtaXR0ZXIuRXZlbnRFbWl0dGVyID0gRXZlbnRFbWl0dGVyO1xuXG5FdmVudEVtaXR0ZXIucHJvdG90eXBlLl9ldmVudHMgPSB1bmRlZmluZWQ7XG5FdmVudEVtaXR0ZXIucHJvdG90eXBlLl9tYXhMaXN0ZW5lcnMgPSB1bmRlZmluZWQ7XG5cbi8vIEJ5IGRlZmF1bHQgRXZlbnRFbWl0dGVycyB3aWxsIHByaW50IGEgd2FybmluZyBpZiBtb3JlIHRoYW4gMTAgbGlzdGVuZXJzIGFyZVxuLy8gYWRkZWQgdG8gaXQuIFRoaXMgaXMgYSB1c2VmdWwgZGVmYXVsdCB3aGljaCBoZWxwcyBmaW5kaW5nIG1lbW9yeSBsZWFrcy5cbkV2ZW50RW1pdHRlci5kZWZhdWx0TWF4TGlzdGVuZXJzID0gMTA7XG5cbi8vIE9idmlvdXNseSBub3QgYWxsIEVtaXR0ZXJzIHNob3VsZCBiZSBsaW1pdGVkIHRvIDEwLiBUaGlzIGZ1bmN0aW9uIGFsbG93c1xuLy8gdGhhdCB0byBiZSBpbmNyZWFzZWQuIFNldCB0byB6ZXJvIGZvciB1bmxpbWl0ZWQuXG5FdmVudEVtaXR0ZXIucHJvdG90eXBlLnNldE1heExpc3RlbmVycyA9IGZ1bmN0aW9uKG4pIHtcbiAgaWYgKCFpc051bWJlcihuKSB8fCBuIDwgMCB8fCBpc05hTihuKSlcbiAgICB0aHJvdyBUeXBlRXJyb3IoJ24gbXVzdCBiZSBhIHBvc2l0aXZlIG51bWJlcicpO1xuICB0aGlzLl9tYXhMaXN0ZW5lcnMgPSBuO1xuICByZXR1cm4gdGhpcztcbn07XG5cbkV2ZW50RW1pdHRlci5wcm90b3R5cGUuZW1pdCA9IGZ1bmN0aW9uKHR5cGUpIHtcbiAgdmFyIGVyLCBoYW5kbGVyLCBsZW4sIGFyZ3MsIGksIGxpc3RlbmVycztcblxuICBpZiAoIXRoaXMuX2V2ZW50cylcbiAgICB0aGlzLl9ldmVudHMgPSB7fTtcblxuICAvLyBJZiB0aGVyZSBpcyBubyAnZXJyb3InIGV2ZW50IGxpc3RlbmVyIHRoZW4gdGhyb3cuXG4gIGlmICh0eXBlID09PSAnZXJyb3InKSB7XG4gICAgaWYgKCF0aGlzLl9ldmVudHMuZXJyb3IgfHxcbiAgICAgICAgKGlzT2JqZWN0KHRoaXMuX2V2ZW50cy5lcnJvcikgJiYgIXRoaXMuX2V2ZW50cy5lcnJvci5sZW5ndGgpKSB7XG4gICAgICBlciA9IGFyZ3VtZW50c1sxXTtcbiAgICAgIGlmIChlciBpbnN0YW5jZW9mIEVycm9yKSB7XG4gICAgICAgIHRocm93IGVyOyAvLyBVbmhhbmRsZWQgJ2Vycm9yJyBldmVudFxuICAgICAgfVxuICAgICAgdGhyb3cgVHlwZUVycm9yKCdVbmNhdWdodCwgdW5zcGVjaWZpZWQgXCJlcnJvclwiIGV2ZW50LicpO1xuICAgIH1cbiAgfVxuXG4gIGhhbmRsZXIgPSB0aGlzLl9ldmVudHNbdHlwZV07XG5cbiAgaWYgKGlzVW5kZWZpbmVkKGhhbmRsZXIpKVxuICAgIHJldHVybiBmYWxzZTtcblxuICBpZiAoaXNGdW5jdGlvbihoYW5kbGVyKSkge1xuICAgIHN3aXRjaCAoYXJndW1lbnRzLmxlbmd0aCkge1xuICAgICAgLy8gZmFzdCBjYXNlc1xuICAgICAgY2FzZSAxOlxuICAgICAgICBoYW5kbGVyLmNhbGwodGhpcyk7XG4gICAgICAgIGJyZWFrO1xuICAgICAgY2FzZSAyOlxuICAgICAgICBoYW5kbGVyLmNhbGwodGhpcywgYXJndW1lbnRzWzFdKTtcbiAgICAgICAgYnJlYWs7XG4gICAgICBjYXNlIDM6XG4gICAgICAgIGhhbmRsZXIuY2FsbCh0aGlzLCBhcmd1bWVudHNbMV0sIGFyZ3VtZW50c1syXSk7XG4gICAgICAgIGJyZWFrO1xuICAgICAgLy8gc2xvd2VyXG4gICAgICBkZWZhdWx0OlxuICAgICAgICBsZW4gPSBhcmd1bWVudHMubGVuZ3RoO1xuICAgICAgICBhcmdzID0gbmV3IEFycmF5KGxlbiAtIDEpO1xuICAgICAgICBmb3IgKGkgPSAxOyBpIDwgbGVuOyBpKyspXG4gICAgICAgICAgYXJnc1tpIC0gMV0gPSBhcmd1bWVudHNbaV07XG4gICAgICAgIGhhbmRsZXIuYXBwbHkodGhpcywgYXJncyk7XG4gICAgfVxuICB9IGVsc2UgaWYgKGlzT2JqZWN0KGhhbmRsZXIpKSB7XG4gICAgbGVuID0gYXJndW1lbnRzLmxlbmd0aDtcbiAgICBhcmdzID0gbmV3IEFycmF5KGxlbiAtIDEpO1xuICAgIGZvciAoaSA9IDE7IGkgPCBsZW47IGkrKylcbiAgICAgIGFyZ3NbaSAtIDFdID0gYXJndW1lbnRzW2ldO1xuXG4gICAgbGlzdGVuZXJzID0gaGFuZGxlci5zbGljZSgpO1xuICAgIGxlbiA9IGxpc3RlbmVycy5sZW5ndGg7XG4gICAgZm9yIChpID0gMDsgaSA8IGxlbjsgaSsrKVxuICAgICAgbGlzdGVuZXJzW2ldLmFwcGx5KHRoaXMsIGFyZ3MpO1xuICB9XG5cbiAgcmV0dXJuIHRydWU7XG59O1xuXG5FdmVudEVtaXR0ZXIucHJvdG90eXBlLmFkZExpc3RlbmVyID0gZnVuY3Rpb24odHlwZSwgbGlzdGVuZXIpIHtcbiAgdmFyIG07XG5cbiAgaWYgKCFpc0Z1bmN0aW9uKGxpc3RlbmVyKSlcbiAgICB0aHJvdyBUeXBlRXJyb3IoJ2xpc3RlbmVyIG11c3QgYmUgYSBmdW5jdGlvbicpO1xuXG4gIGlmICghdGhpcy5fZXZlbnRzKVxuICAgIHRoaXMuX2V2ZW50cyA9IHt9O1xuXG4gIC8vIFRvIGF2b2lkIHJlY3Vyc2lvbiBpbiB0aGUgY2FzZSB0aGF0IHR5cGUgPT09IFwibmV3TGlzdGVuZXJcIiEgQmVmb3JlXG4gIC8vIGFkZGluZyBpdCB0byB0aGUgbGlzdGVuZXJzLCBmaXJzdCBlbWl0IFwibmV3TGlzdGVuZXJcIi5cbiAgaWYgKHRoaXMuX2V2ZW50cy5uZXdMaXN0ZW5lcilcbiAgICB0aGlzLmVtaXQoJ25ld0xpc3RlbmVyJywgdHlwZSxcbiAgICAgICAgICAgICAgaXNGdW5jdGlvbihsaXN0ZW5lci5saXN0ZW5lcikgP1xuICAgICAgICAgICAgICBsaXN0ZW5lci5saXN0ZW5lciA6IGxpc3RlbmVyKTtcblxuICBpZiAoIXRoaXMuX2V2ZW50c1t0eXBlXSlcbiAgICAvLyBPcHRpbWl6ZSB0aGUgY2FzZSBvZiBvbmUgbGlzdGVuZXIuIERvbid0IG5lZWQgdGhlIGV4dHJhIGFycmF5IG9iamVjdC5cbiAgICB0aGlzLl9ldmVudHNbdHlwZV0gPSBsaXN0ZW5lcjtcbiAgZWxzZSBpZiAoaXNPYmplY3QodGhpcy5fZXZlbnRzW3R5cGVdKSlcbiAgICAvLyBJZiB3ZSd2ZSBhbHJlYWR5IGdvdCBhbiBhcnJheSwganVzdCBhcHBlbmQuXG4gICAgdGhpcy5fZXZlbnRzW3R5cGVdLnB1c2gobGlzdGVuZXIpO1xuICBlbHNlXG4gICAgLy8gQWRkaW5nIHRoZSBzZWNvbmQgZWxlbWVudCwgbmVlZCB0byBjaGFuZ2UgdG8gYXJyYXkuXG4gICAgdGhpcy5fZXZlbnRzW3R5cGVdID0gW3RoaXMuX2V2ZW50c1t0eXBlXSwgbGlzdGVuZXJdO1xuXG4gIC8vIENoZWNrIGZvciBsaXN0ZW5lciBsZWFrXG4gIGlmIChpc09iamVjdCh0aGlzLl9ldmVudHNbdHlwZV0pICYmICF0aGlzLl9ldmVudHNbdHlwZV0ud2FybmVkKSB7XG4gICAgdmFyIG07XG4gICAgaWYgKCFpc1VuZGVmaW5lZCh0aGlzLl9tYXhMaXN0ZW5lcnMpKSB7XG4gICAgICBtID0gdGhpcy5fbWF4TGlzdGVuZXJzO1xuICAgIH0gZWxzZSB7XG4gICAgICBtID0gRXZlbnRFbWl0dGVyLmRlZmF1bHRNYXhMaXN0ZW5lcnM7XG4gICAgfVxuXG4gICAgaWYgKG0gJiYgbSA+IDAgJiYgdGhpcy5fZXZlbnRzW3R5cGVdLmxlbmd0aCA+IG0pIHtcbiAgICAgIHRoaXMuX2V2ZW50c1t0eXBlXS53YXJuZWQgPSB0cnVlO1xuICAgICAgY29uc29sZS5lcnJvcignKG5vZGUpIHdhcm5pbmc6IHBvc3NpYmxlIEV2ZW50RW1pdHRlciBtZW1vcnkgJyArXG4gICAgICAgICAgICAgICAgICAgICdsZWFrIGRldGVjdGVkLiAlZCBsaXN0ZW5lcnMgYWRkZWQuICcgK1xuICAgICAgICAgICAgICAgICAgICAnVXNlIGVtaXR0ZXIuc2V0TWF4TGlzdGVuZXJzKCkgdG8gaW5jcmVhc2UgbGltaXQuJyxcbiAgICAgICAgICAgICAgICAgICAgdGhpcy5fZXZlbnRzW3R5cGVdLmxlbmd0aCk7XG4gICAgICBpZiAodHlwZW9mIGNvbnNvbGUudHJhY2UgPT09ICdmdW5jdGlvbicpIHtcbiAgICAgICAgLy8gbm90IHN1cHBvcnRlZCBpbiBJRSAxMFxuICAgICAgICBjb25zb2xlLnRyYWNlKCk7XG4gICAgICB9XG4gICAgfVxuICB9XG5cbiAgcmV0dXJuIHRoaXM7XG59O1xuXG5FdmVudEVtaXR0ZXIucHJvdG90eXBlLm9uID0gRXZlbnRFbWl0dGVyLnByb3RvdHlwZS5hZGRMaXN0ZW5lcjtcblxuRXZlbnRFbWl0dGVyLnByb3RvdHlwZS5vbmNlID0gZnVuY3Rpb24odHlwZSwgbGlzdGVuZXIpIHtcbiAgaWYgKCFpc0Z1bmN0aW9uKGxpc3RlbmVyKSlcbiAgICB0aHJvdyBUeXBlRXJyb3IoJ2xpc3RlbmVyIG11c3QgYmUgYSBmdW5jdGlvbicpO1xuXG4gIHZhciBmaXJlZCA9IGZhbHNlO1xuXG4gIGZ1bmN0aW9uIGcoKSB7XG4gICAgdGhpcy5yZW1vdmVMaXN0ZW5lcih0eXBlLCBnKTtcblxuICAgIGlmICghZmlyZWQpIHtcbiAgICAgIGZpcmVkID0gdHJ1ZTtcbiAgICAgIGxpc3RlbmVyLmFwcGx5KHRoaXMsIGFyZ3VtZW50cyk7XG4gICAgfVxuICB9XG5cbiAgZy5saXN0ZW5lciA9IGxpc3RlbmVyO1xuICB0aGlzLm9uKHR5cGUsIGcpO1xuXG4gIHJldHVybiB0aGlzO1xufTtcblxuLy8gZW1pdHMgYSAncmVtb3ZlTGlzdGVuZXInIGV2ZW50IGlmZiB0aGUgbGlzdGVuZXIgd2FzIHJlbW92ZWRcbkV2ZW50RW1pdHRlci5wcm90b3R5cGUucmVtb3ZlTGlzdGVuZXIgPSBmdW5jdGlvbih0eXBlLCBsaXN0ZW5lcikge1xuICB2YXIgbGlzdCwgcG9zaXRpb24sIGxlbmd0aCwgaTtcblxuICBpZiAoIWlzRnVuY3Rpb24obGlzdGVuZXIpKVxuICAgIHRocm93IFR5cGVFcnJvcignbGlzdGVuZXIgbXVzdCBiZSBhIGZ1bmN0aW9uJyk7XG5cbiAgaWYgKCF0aGlzLl9ldmVudHMgfHwgIXRoaXMuX2V2ZW50c1t0eXBlXSlcbiAgICByZXR1cm4gdGhpcztcblxuICBsaXN0ID0gdGhpcy5fZXZlbnRzW3R5cGVdO1xuICBsZW5ndGggPSBsaXN0Lmxlbmd0aDtcbiAgcG9zaXRpb24gPSAtMTtcblxuICBpZiAobGlzdCA9PT0gbGlzdGVuZXIgfHxcbiAgICAgIChpc0Z1bmN0aW9uKGxpc3QubGlzdGVuZXIpICYmIGxpc3QubGlzdGVuZXIgPT09IGxpc3RlbmVyKSkge1xuICAgIGRlbGV0ZSB0aGlzLl9ldmVudHNbdHlwZV07XG4gICAgaWYgKHRoaXMuX2V2ZW50cy5yZW1vdmVMaXN0ZW5lcilcbiAgICAgIHRoaXMuZW1pdCgncmVtb3ZlTGlzdGVuZXInLCB0eXBlLCBsaXN0ZW5lcik7XG5cbiAgfSBlbHNlIGlmIChpc09iamVjdChsaXN0KSkge1xuICAgIGZvciAoaSA9IGxlbmd0aDsgaS0tID4gMDspIHtcbiAgICAgIGlmIChsaXN0W2ldID09PSBsaXN0ZW5lciB8fFxuICAgICAgICAgIChsaXN0W2ldLmxpc3RlbmVyICYmIGxpc3RbaV0ubGlzdGVuZXIgPT09IGxpc3RlbmVyKSkge1xuICAgICAgICBwb3NpdGlvbiA9IGk7XG4gICAgICAgIGJyZWFrO1xuICAgICAgfVxuICAgIH1cblxuICAgIGlmIChwb3NpdGlvbiA8IDApXG4gICAgICByZXR1cm4gdGhpcztcblxuICAgIGlmIChsaXN0Lmxlbmd0aCA9PT0gMSkge1xuICAgICAgbGlzdC5sZW5ndGggPSAwO1xuICAgICAgZGVsZXRlIHRoaXMuX2V2ZW50c1t0eXBlXTtcbiAgICB9IGVsc2Uge1xuICAgICAgbGlzdC5zcGxpY2UocG9zaXRpb24sIDEpO1xuICAgIH1cblxuICAgIGlmICh0aGlzLl9ldmVudHMucmVtb3ZlTGlzdGVuZXIpXG4gICAgICB0aGlzLmVtaXQoJ3JlbW92ZUxpc3RlbmVyJywgdHlwZSwgbGlzdGVuZXIpO1xuICB9XG5cbiAgcmV0dXJuIHRoaXM7XG59O1xuXG5FdmVudEVtaXR0ZXIucHJvdG90eXBlLnJlbW92ZUFsbExpc3RlbmVycyA9IGZ1bmN0aW9uKHR5cGUpIHtcbiAgdmFyIGtleSwgbGlzdGVuZXJzO1xuXG4gIGlmICghdGhpcy5fZXZlbnRzKVxuICAgIHJldHVybiB0aGlzO1xuXG4gIC8vIG5vdCBsaXN0ZW5pbmcgZm9yIHJlbW92ZUxpc3RlbmVyLCBubyBuZWVkIHRvIGVtaXRcbiAgaWYgKCF0aGlzLl9ldmVudHMucmVtb3ZlTGlzdGVuZXIpIHtcbiAgICBpZiAoYXJndW1lbnRzLmxlbmd0aCA9PT0gMClcbiAgICAgIHRoaXMuX2V2ZW50cyA9IHt9O1xuICAgIGVsc2UgaWYgKHRoaXMuX2V2ZW50c1t0eXBlXSlcbiAgICAgIGRlbGV0ZSB0aGlzLl9ldmVudHNbdHlwZV07XG4gICAgcmV0dXJuIHRoaXM7XG4gIH1cblxuICAvLyBlbWl0IHJlbW92ZUxpc3RlbmVyIGZvciBhbGwgbGlzdGVuZXJzIG9uIGFsbCBldmVudHNcbiAgaWYgKGFyZ3VtZW50cy5sZW5ndGggPT09IDApIHtcbiAgICBmb3IgKGtleSBpbiB0aGlzLl9ldmVudHMpIHtcbiAgICAgIGlmIChrZXkgPT09ICdyZW1vdmVMaXN0ZW5lcicpIGNvbnRpbnVlO1xuICAgICAgdGhpcy5yZW1vdmVBbGxMaXN0ZW5lcnMoa2V5KTtcbiAgICB9XG4gICAgdGhpcy5yZW1vdmVBbGxMaXN0ZW5lcnMoJ3JlbW92ZUxpc3RlbmVyJyk7XG4gICAgdGhpcy5fZXZlbnRzID0ge307XG4gICAgcmV0dXJuIHRoaXM7XG4gIH1cblxuICBsaXN0ZW5lcnMgPSB0aGlzLl9ldmVudHNbdHlwZV07XG5cbiAgaWYgKGlzRnVuY3Rpb24obGlzdGVuZXJzKSkge1xuICAgIHRoaXMucmVtb3ZlTGlzdGVuZXIodHlwZSwgbGlzdGVuZXJzKTtcbiAgfSBlbHNlIHtcbiAgICAvLyBMSUZPIG9yZGVyXG4gICAgd2hpbGUgKGxpc3RlbmVycy5sZW5ndGgpXG4gICAgICB0aGlzLnJlbW92ZUxpc3RlbmVyKHR5cGUsIGxpc3RlbmVyc1tsaXN0ZW5lcnMubGVuZ3RoIC0gMV0pO1xuICB9XG4gIGRlbGV0ZSB0aGlzLl9ldmVudHNbdHlwZV07XG5cbiAgcmV0dXJuIHRoaXM7XG59O1xuXG5FdmVudEVtaXR0ZXIucHJvdG90eXBlLmxpc3RlbmVycyA9IGZ1bmN0aW9uKHR5cGUpIHtcbiAgdmFyIHJldDtcbiAgaWYgKCF0aGlzLl9ldmVudHMgfHwgIXRoaXMuX2V2ZW50c1t0eXBlXSlcbiAgICByZXQgPSBbXTtcbiAgZWxzZSBpZiAoaXNGdW5jdGlvbih0aGlzLl9ldmVudHNbdHlwZV0pKVxuICAgIHJldCA9IFt0aGlzLl9ldmVudHNbdHlwZV1dO1xuICBlbHNlXG4gICAgcmV0ID0gdGhpcy5fZXZlbnRzW3R5cGVdLnNsaWNlKCk7XG4gIHJldHVybiByZXQ7XG59O1xuXG5FdmVudEVtaXR0ZXIubGlzdGVuZXJDb3VudCA9IGZ1bmN0aW9uKGVtaXR0ZXIsIHR5cGUpIHtcbiAgdmFyIHJldDtcbiAgaWYgKCFlbWl0dGVyLl9ldmVudHMgfHwgIWVtaXR0ZXIuX2V2ZW50c1t0eXBlXSlcbiAgICByZXQgPSAwO1xuICBlbHNlIGlmIChpc0Z1bmN0aW9uKGVtaXR0ZXIuX2V2ZW50c1t0eXBlXSkpXG4gICAgcmV0ID0gMTtcbiAgZWxzZVxuICAgIHJldCA9IGVtaXR0ZXIuX2V2ZW50c1t0eXBlXS5sZW5ndGg7XG4gIHJldHVybiByZXQ7XG59O1xuXG5mdW5jdGlvbiBpc0Z1bmN0aW9uKGFyZykge1xuICByZXR1cm4gdHlwZW9mIGFyZyA9PT0gJ2Z1bmN0aW9uJztcbn1cblxuZnVuY3Rpb24gaXNOdW1iZXIoYXJnKSB7XG4gIHJldHVybiB0eXBlb2YgYXJnID09PSAnbnVtYmVyJztcbn1cblxuZnVuY3Rpb24gaXNPYmplY3QoYXJnKSB7XG4gIHJldHVybiB0eXBlb2YgYXJnID09PSAnb2JqZWN0JyAmJiBhcmcgIT09IG51bGw7XG59XG5cbmZ1bmN0aW9uIGlzVW5kZWZpbmVkKGFyZykge1xuICByZXR1cm4gYXJnID09PSB2b2lkIDA7XG59XG4iLCJleHBvcnRzLnJlYWQgPSBmdW5jdGlvbiAoYnVmZmVyLCBvZmZzZXQsIGlzTEUsIG1MZW4sIG5CeXRlcykge1xuICB2YXIgZSwgbVxuICB2YXIgZUxlbiA9IG5CeXRlcyAqIDggLSBtTGVuIC0gMVxuICB2YXIgZU1heCA9ICgxIDw8IGVMZW4pIC0gMVxuICB2YXIgZUJpYXMgPSBlTWF4ID4+IDFcbiAgdmFyIG5CaXRzID0gLTdcbiAgdmFyIGkgPSBpc0xFID8gKG5CeXRlcyAtIDEpIDogMFxuICB2YXIgZCA9IGlzTEUgPyAtMSA6IDFcbiAgdmFyIHMgPSBidWZmZXJbb2Zmc2V0ICsgaV1cblxuICBpICs9IGRcblxuICBlID0gcyAmICgoMSA8PCAoLW5CaXRzKSkgLSAxKVxuICBzID4+PSAoLW5CaXRzKVxuICBuQml0cyArPSBlTGVuXG4gIGZvciAoOyBuQml0cyA+IDA7IGUgPSBlICogMjU2ICsgYnVmZmVyW29mZnNldCArIGldLCBpICs9IGQsIG5CaXRzIC09IDgpIHt9XG5cbiAgbSA9IGUgJiAoKDEgPDwgKC1uQml0cykpIC0gMSlcbiAgZSA+Pj0gKC1uQml0cylcbiAgbkJpdHMgKz0gbUxlblxuICBmb3IgKDsgbkJpdHMgPiAwOyBtID0gbSAqIDI1NiArIGJ1ZmZlcltvZmZzZXQgKyBpXSwgaSArPSBkLCBuQml0cyAtPSA4KSB7fVxuXG4gIGlmIChlID09PSAwKSB7XG4gICAgZSA9IDEgLSBlQmlhc1xuICB9IGVsc2UgaWYgKGUgPT09IGVNYXgpIHtcbiAgICByZXR1cm4gbSA/IE5hTiA6ICgocyA/IC0xIDogMSkgKiBJbmZpbml0eSlcbiAgfSBlbHNlIHtcbiAgICBtID0gbSArIE1hdGgucG93KDIsIG1MZW4pXG4gICAgZSA9IGUgLSBlQmlhc1xuICB9XG4gIHJldHVybiAocyA/IC0xIDogMSkgKiBtICogTWF0aC5wb3coMiwgZSAtIG1MZW4pXG59XG5cbmV4cG9ydHMud3JpdGUgPSBmdW5jdGlvbiAoYnVmZmVyLCB2YWx1ZSwgb2Zmc2V0LCBpc0xFLCBtTGVuLCBuQnl0ZXMpIHtcbiAgdmFyIGUsIG0sIGNcbiAgdmFyIGVMZW4gPSBuQnl0ZXMgKiA4IC0gbUxlbiAtIDFcbiAgdmFyIGVNYXggPSAoMSA8PCBlTGVuKSAtIDFcbiAgdmFyIGVCaWFzID0gZU1heCA+PiAxXG4gIHZhciBydCA9IChtTGVuID09PSAyMyA/IE1hdGgucG93KDIsIC0yNCkgLSBNYXRoLnBvdygyLCAtNzcpIDogMClcbiAgdmFyIGkgPSBpc0xFID8gMCA6IChuQnl0ZXMgLSAxKVxuICB2YXIgZCA9IGlzTEUgPyAxIDogLTFcbiAgdmFyIHMgPSB2YWx1ZSA8IDAgfHwgKHZhbHVlID09PSAwICYmIDEgLyB2YWx1ZSA8IDApID8gMSA6IDBcblxuICB2YWx1ZSA9IE1hdGguYWJzKHZhbHVlKVxuXG4gIGlmIChpc05hTih2YWx1ZSkgfHwgdmFsdWUgPT09IEluZmluaXR5KSB7XG4gICAgbSA9IGlzTmFOKHZhbHVlKSA/IDEgOiAwXG4gICAgZSA9IGVNYXhcbiAgfSBlbHNlIHtcbiAgICBlID0gTWF0aC5mbG9vcihNYXRoLmxvZyh2YWx1ZSkgLyBNYXRoLkxOMilcbiAgICBpZiAodmFsdWUgKiAoYyA9IE1hdGgucG93KDIsIC1lKSkgPCAxKSB7XG4gICAgICBlLS1cbiAgICAgIGMgKj0gMlxuICAgIH1cbiAgICBpZiAoZSArIGVCaWFzID49IDEpIHtcbiAgICAgIHZhbHVlICs9IHJ0IC8gY1xuICAgIH0gZWxzZSB7XG4gICAgICB2YWx1ZSArPSBydCAqIE1hdGgucG93KDIsIDEgLSBlQmlhcylcbiAgICB9XG4gICAgaWYgKHZhbHVlICogYyA+PSAyKSB7XG4gICAgICBlKytcbiAgICAgIGMgLz0gMlxuICAgIH1cblxuICAgIGlmIChlICsgZUJpYXMgPj0gZU1heCkge1xuICAgICAgbSA9IDBcbiAgICAgIGUgPSBlTWF4XG4gICAgfSBlbHNlIGlmIChlICsgZUJpYXMgPj0gMSkge1xuICAgICAgbSA9ICh2YWx1ZSAqIGMgLSAxKSAqIE1hdGgucG93KDIsIG1MZW4pXG4gICAgICBlID0gZSArIGVCaWFzXG4gICAgfSBlbHNlIHtcbiAgICAgIG0gPSB2YWx1ZSAqIE1hdGgucG93KDIsIGVCaWFzIC0gMSkgKiBNYXRoLnBvdygyLCBtTGVuKVxuICAgICAgZSA9IDBcbiAgICB9XG4gIH1cblxuICBmb3IgKDsgbUxlbiA+PSA4OyBidWZmZXJbb2Zmc2V0ICsgaV0gPSBtICYgMHhmZiwgaSArPSBkLCBtIC89IDI1NiwgbUxlbiAtPSA4KSB7fVxuXG4gIGUgPSAoZSA8PCBtTGVuKSB8IG1cbiAgZUxlbiArPSBtTGVuXG4gIGZvciAoOyBlTGVuID4gMDsgYnVmZmVyW29mZnNldCArIGldID0gZSAmIDB4ZmYsIGkgKz0gZCwgZSAvPSAyNTYsIGVMZW4gLT0gOCkge31cblxuICBidWZmZXJbb2Zmc2V0ICsgaSAtIGRdIHw9IHMgKiAxMjhcbn1cbiIsImlmICh0eXBlb2YgT2JqZWN0LmNyZWF0ZSA9PT0gJ2Z1bmN0aW9uJykge1xuICAvLyBpbXBsZW1lbnRhdGlvbiBmcm9tIHN0YW5kYXJkIG5vZGUuanMgJ3V0aWwnIG1vZHVsZVxuICBtb2R1bGUuZXhwb3J0cyA9IGZ1bmN0aW9uIGluaGVyaXRzKGN0b3IsIHN1cGVyQ3Rvcikge1xuICAgIGN0b3Iuc3VwZXJfID0gc3VwZXJDdG9yXG4gICAgY3Rvci5wcm90b3R5cGUgPSBPYmplY3QuY3JlYXRlKHN1cGVyQ3Rvci5wcm90b3R5cGUsIHtcbiAgICAgIGNvbnN0cnVjdG9yOiB7XG4gICAgICAgIHZhbHVlOiBjdG9yLFxuICAgICAgICBlbnVtZXJhYmxlOiBmYWxzZSxcbiAgICAgICAgd3JpdGFibGU6IHRydWUsXG4gICAgICAgIGNvbmZpZ3VyYWJsZTogdHJ1ZVxuICAgICAgfVxuICAgIH0pO1xuICB9O1xufSBlbHNlIHtcbiAgLy8gb2xkIHNjaG9vbCBzaGltIGZvciBvbGQgYnJvd3NlcnNcbiAgbW9kdWxlLmV4cG9ydHMgPSBmdW5jdGlvbiBpbmhlcml0cyhjdG9yLCBzdXBlckN0b3IpIHtcbiAgICBjdG9yLnN1cGVyXyA9IHN1cGVyQ3RvclxuICAgIHZhciBUZW1wQ3RvciA9IGZ1bmN0aW9uICgpIHt9XG4gICAgVGVtcEN0b3IucHJvdG90eXBlID0gc3VwZXJDdG9yLnByb3RvdHlwZVxuICAgIGN0b3IucHJvdG90eXBlID0gbmV3IFRlbXBDdG9yKClcbiAgICBjdG9yLnByb3RvdHlwZS5jb25zdHJ1Y3RvciA9IGN0b3JcbiAgfVxufVxuIiwibW9kdWxlLmV4cG9ydHMgPSByZXF1aXJlKCcuL2xpYicpWydkZWZhdWx0J10iLCJcInVzZSBzdHJpY3RcIjtcbnZhciB1dGlscyQkID0gcmVxdWlyZShcIi4vdXRpbHNcIik7XG5cbi8vIHdoZXRoZXIgdG8gbG9nIGV4Y2VwdGlvbnMgdGhyb3duIGR1cmluZyBjaGFuZ2UgcmVjb3JkIGRlbGl2ZXJ5XG52YXIgZGVidWcgPSBmYWxzZTtcblxuLy8gVGhpcyB3ZWFrIG1hcCBpcyB1c2VkIGZvciBgLmRlbGl2ZXJDaGFuZ2VSZWNvcmRzKGNhbGxiYWNrKWAgY2FsbHMsIHdoZXJlIHRoZVxuLy8gcHJvdmlkZWQgY2FsbGJhY2sgaGFzIHRvIG1hcHBlZCB0byBpdHMgY29ycmVzcG9uZGluZyBkZWxlZ2F0ZS5cbi8vIDxjYWxsYmFjaywgZGVsZWdhdGU+XG52YXIgZGVsZWdhdGVzID0gbmV3IFdlYWtNYXA7XG5cbi8vIFdoZW4gdXNpbmcgYC5vYnNlcnZlKG9iaiwgY2FsbGJhY2spYCwgaW5zdGVhZCBvZiBmb3J3YXJkaW5nIHRoZSBwcm92aWRlZFxuLy8gYGNhbGxiYWNrYCB0byBgT2JqZWN0Lm9ic2VydmUob2JqLCBjYWxsYmFjaylgIGRpcmVjdGx5LCBhIGRlbGVnYXRlIGZvciB0aGVcbi8vIGBjYWxsYmFja2AgaXMgY3JlYXRlZC4gVGhpcyBkZWxlZ2F0ZSB0cmFuc2Zvcm1zIGNoYW5nZXMgYmVmb3JlIGZvcndhcmRpbmdcbi8vIHRoZW0gdG8gdGhlIGFjdHVhbCBgY2FsbGJhY2tgLlxudmFyIERlbGVnYXRlID0gZnVuY3Rpb24oY2FsbGJhY2spIHtcbiAgdGhpcy5jYWxsYmFjayAgPSBjYWxsYmFja1xuICB0aGlzLm9ic2VydmVycyA9IG5ldyB1dGlscyQkLldlYWtNVk1hcFxuXG4gIHZhciBzZWxmID0gdGhpc1xuICB0aGlzLmhhbmRsZUNoYW5nZVJlY29yZHMgPSBmdW5jdGlvbihyZWNvcmRzKSB7XG4gICAgdHJ5IHtcbiAgICAgIHZhciBjaGFuZ2VzID0gcmVjb3Jkcy5tYXAoc2VsZi50cmFuc2Zvcm0sIHNlbGYpXG4gICAgICBjaGFuZ2VzID0gQXJyYXkucHJvdG90eXBlLmNvbmNhdC5hcHBseShbXSwgY2hhbmdlcykgLy8gZmxhdHRlblxuICAgICAgc2VsZi5jYWxsYmFjayhjaGFuZ2VzKVxuICAgIH0gY2F0Y2ggKGVycikge1xuICAgICAgaWYgKGRlYnVnKSBjb25zb2xlLmVycm9yKGVyci5zdGFjaylcbiAgICB9XG4gIH1cbn1cblxuLy8gVGhpcyBtZXRob2QgdHJhbnNmb3JtcyB0aGUgcmVjZWl2ZWQgY2hhbmdlIHJlY29yZCB3aXRoIHVzaW5nIHRoZVxuLy8gY29ycmVzcG9uZGluZyBvYnNlcnZlciBmb3IgdGhlIG9iamVjdCB0aGF0IGdvdCBjaGFuZ2VkLlxuRGVsZWdhdGUucHJvdG90eXBlLnRyYW5zZm9ybSA9IGZ1bmN0aW9uKHJlY29yZCkge1xuICBpZiAoIXRoaXMub2JzZXJ2ZXJzLmhhcyhyZWNvcmQub2JqZWN0KSkge1xuICAgIHJldHVybiBbXVxuICB9XG5cbiAgdmFyIG9ic2VydmVycyA9IHRoaXMub2JzZXJ2ZXJzLmdldChyZWNvcmQub2JqZWN0KVxuICBvYnNlcnZlcnMgPSBvYnNlcnZlcnMuZmlsdGVyKGZ1bmN0aW9uKHZhbHVlLCBpbmRleCwgc2VsZikge1xuICAgIHJldHVybiBzZWxmLmluZGV4T2YodmFsdWUpID09PSBpbmRleFxuICB9KVxuICByZXR1cm4gb2JzZXJ2ZXJzLm1hcChmdW5jdGlvbihvYnNlcnZlcikge1xuICAgIHJldHVybiBvYnNlcnZlci50cmFuc2Zvcm0ocmVjb3JkKVxuICB9KVxufVxuXG4vLyBFYWNoIGNhbGxiYWNrL29iamVjdCBwYWlyIGdldHMgaXRzIG93biBvYnNlcnZlciwgd2hpY2ggaXMgdXNlZCB0byB0cmFja1xuLy8gcG9zaXRpb25zIG9mIG5lc3RlZCBvYmplY3RzIGFuZCB0cmFuc2Zvcm1zIGNoYW5nZSByZWNvcmRzIGFjY29yZGluZ2x5LlxudmFyIE9ic2VydmVyID0gZnVuY3Rpb24ocm9vdCwgZGVsZWdhdGUsIGFjY2VwdCkge1xuICB0aGlzLnJvb3QgICAgID0gcm9vdFxuICB0aGlzLmRlbGVnYXRlID0gZGVsZWdhdGVcbiAgdGhpcy5jYWxsYmFjayA9IGRlbGVnYXRlLmhhbmRsZUNoYW5nZVJlY29yZHNcbiAgdGhpcy5hY2NlcHQgICA9IGFjY2VwdFxuICB0aGlzLnBhcmVudHMgID0gbmV3IHV0aWxzJCQuUGFyZW50c01hcHBpbmdcbn1cblxuLy8gUmVjdXJzaXZlbHkgb2JzZXJ2ZSBhbiBvYmplY3QgYW5kIGl0cyBuZXN0ZWQgb2JqZWN0cy5cbk9ic2VydmVyLnByb3RvdHlwZS5vYnNlcnZlID0gZnVuY3Rpb24ob2JqLCBwYXJlbnQsIGtleSwgdmlzaXRlZCkge1xuICBpZiAoIW9iaiB8fCB0eXBlb2Ygb2JqICE9PSAnb2JqZWN0Jykge1xuICAgIHJldHVyblxuICB9XG5cbiAgaWYgKCF2aXNpdGVkKSB7XG4gICAgdmlzaXRlZCA9IG5ldyBXZWFrTWFwXG4gIH1cblxuICBpZiAodmlzaXRlZC5oYXMob2JqKSkge1xuICAgIHJldHVyblxuICB9XG5cbiAgdmlzaXRlZC5zZXQob2JqLCB0cnVlKVxuXG4gIC8vIGlmIHRoZSBvYmplY3QgaXMgYWxyZWFkeSBvYnNlcnZlZCwgaS5lLiwgYWxyZWFkeSBzb21ld2hlcmUgZWxzZSBpbiB0aGVcbiAgLy8gbmVzdGVkIHN0cnVjdHVyZSAtPiBkbyBub3Qgb2JzZXJ2ZSBpdCBhZ2FpblxuICBpZiAoIXRoaXMuZGVsZWdhdGUub2JzZXJ2ZXJzLmhhcyhvYmosIHRoaXMpKSB7XG4gICAgaWYgKEFycmF5LmlzQXJyYXkob2JqKSAmJiAhdGhpcy5hY2NlcHQpIHtcbiAgICAgIE9iamVjdC5vYnNlcnZlKG9iaiwgdGhpcy5jYWxsYmFjaywgWydhZGQnLCAndXBkYXRlJywgJ2RlbGV0ZScsICdzcGxpY2UnXSlcbiAgICB9IGVsc2Uge1xuICAgICAgT2JqZWN0Lm9ic2VydmUob2JqLCB0aGlzLmNhbGxiYWNrLCB0aGlzLmFjY2VwdClcbiAgICB9XG4gIH1cblxuICAvLyB0cmFjayBwYXJlbnQgYW5kIGJlbG9uZ2luZ1xuICB0aGlzLnBhcmVudHMuYWRkKG9iaiwgcGFyZW50LCBrZXkpXG4gIHRoaXMuZGVsZWdhdGUub2JzZXJ2ZXJzLmFkZChvYmosIHRoaXMpXG5cbiAgLy8gdHJhdmVyc2UgdGhlIHByb3BlcnRpZXMgdG8gZmluZCBuZXN0ZWQgb2JqZWN0cyBhbmQgb2JzZXJ2ZSB0aGVtLCB0b29cbiAgdmFyIGlzQXJyYXkgPSBBcnJheS5pc0FycmF5KG9iailcbiAgZm9yICh2YXIgcHJvcCBpbiBvYmopIHtcbiAgICBpZiAodHlwZW9mIG9ialtwcm9wXSA9PT0gJ29iamVjdCcpIHtcbiAgICAgIHRoaXMub2JzZXJ2ZShvYmpbcHJvcF0sIG9iaiwgaXNBcnJheSA/IEFycmF5IDogcHJvcCwgdmlzaXRlZClcbiAgICB9XG4gIH1cblxuICBpZiAodHlwZW9mIG9iai5lbnRyaWVzID09PSAnZnVuY3Rpb24nKSB7XG4gICAgdmFyIGVudHJpZXMgPSBvYmouZW50cmllcygpXG4gICAgaWYgKHR5cGVvZiBlbnRyaWVzLm5leHQgPT09ICdmdW5jdGlvbicpIHtcbiAgICAgIC8vIGZvciAodmFyIHBhaXIgb2YgZW50cmllcylcbiAgICAgIHZhciBwYWlyXG4gICAgICB3aGlsZSAoKHBhaXIgPSBlbnRyaWVzLm5leHQoKSkuZG9uZSA9PT0gZmFsc2UpIHtcbiAgICAgICAgaWYgKHR5cGVvZiBwYWlyLnZhbHVlWzFdID09PSAnb2JqZWN0Jykge1xuICAgICAgICAgIHRoaXMub2JzZXJ2ZShwYWlyLnZhbHVlWzFdLCBvYmosIHBhaXIudmFsdWVbMF0sIHZpc2l0ZWQpXG4gICAgICAgIH1cbiAgICAgIH1cbiAgICB9XG4gIH1cbn1cblxuLy8gUmVjdXJzaXZlbHkgdW5vYnNlcnZlIGFuIG9iamVjdCBhbmQgaXRzIG5lc3RlZCBvYmplY3RzLlxuT2JzZXJ2ZXIucHJvdG90eXBlLnVub2JzZXJ2ZSA9IGZ1bmN0aW9uKG9iaiwgcGFyZW50LCBrZXkpIHtcbiAgaWYgKG9iaiA9PT0gdW5kZWZpbmVkKSBvYmogPSB0aGlzLnJvb3RcbiAgZWxzZSBpZiAoIW9iaikgcmV0dXJuXG5cbiAgaWYgKCF0aGlzLmRlbGVnYXRlLm9ic2VydmVycy5oYXMob2JqLCB0aGlzKSkge1xuICAgIHJldHVyblxuICB9XG5cbiAgLy8gY2xlYW4gdXBcbiAgdGhpcy5wYXJlbnRzLnJlbW92ZShvYmosIHBhcmVudCwga2V5KVxuICB0aGlzLmRlbGVnYXRlLm9ic2VydmVycy5yZW1vdmUob2JqLCB0aGlzKVxuXG4gIGlmICghdGhpcy5kZWxlZ2F0ZS5vYnNlcnZlcnMuaGFzKG9iaikpIHtcbiAgICBPYmplY3QudW5vYnNlcnZlKG9iaiwgdGhpcy5jYWxsYmFjaylcbiAgfVxuXG4gIC8vIHRyYXZlcnNlIHRoZSBwcm9wZXJ0aWVzIHRvIGZpbmQgbmVzdGVkIG9iamVjdHMgYW5kIHVub2JzZXJ2ZSB0aGVtLCB0b29cbiAgdmFyIGlzQXJyYXkgPSBBcnJheS5pc0FycmF5KG9iailcbiAgZm9yICh2YXIgcHJvcCBpbiBvYmopIHtcbiAgICBpZiAodHlwZW9mIG9ialtwcm9wXSA9PT0gJ29iamVjdCcpIHtcbiAgICAgIHRoaXMudW5vYnNlcnZlKG9ialtwcm9wXSwgb2JqLCBpc0FycmF5ID8gQXJyYXkgOiBwcm9wKVxuICAgIH1cbiAgfVxufVxuXG4vLyBUcmFuc2Zvcm0gYSBjaGFuZ2UgcmVjb3JkLCBpZS4sIGFkZCB0aGUgZm9sbG93aW5nIHByb3BlcnRpZXM6XG4vLyAtICoqcm9vdCoqIC0gdGhlIHJvb3Qgb2YgdGhlIG5lc3RlZCBzdHJ1Y3R1cmVcbi8vIC0gKipwYXRoKiogLSBhIFtKU09OIFBvaW50ZXJdKGh0dHA6Ly90b29scy5pZXRmLm9yZy9odG1sL3JmYzY5MDEpXG4vLyAgICAgICAgICAgICAgKGFic29sdXRlIGZyb20gdGhlIHJvb3QpIHRvIHRoZSBjaGFuZ2VkIHByb3BlcnR5XG5PYnNlcnZlci5wcm90b3R5cGUudHJhbnNmb3JtID0gZnVuY3Rpb24oY2hhbmdlKSB7XG4gIHZhciBzZWxmID0gdGhpc1xuXG4gIHZhciByZWNvcmQgPSB7XG4gICAgcm9vdDogdGhpcy5yb290LFxuICAgIGdldCBwYXRoKCkge1xuICAgICAgdmFyIHBhdGggPSBzZWxmLnBhcmVudHMucGF0aChjaGFuZ2Uub2JqZWN0KVxuICAgICAgaWYgKGNoYW5nZS5uYW1lKSBwYXRoLnB1c2goY2hhbmdlLm5hbWUpXG4gICAgICByZXR1cm4gJy8nICsgcGF0aC5tYXAoZnVuY3Rpb24oaykge1xuICAgICAgICByZXR1cm4gay50b1N0cmluZygpLnJlcGxhY2UoL34vZywgJ34wJykucmVwbGFjZSgvXFwvL2csICd+MScpXG4gICAgICB9KS5qb2luKCcvJylcbiAgICB9XG4gIH1cblxuICAvLyB0aGUgb3JpZ2luYWwgY2hhbmdlIHJlY29yZCBpc3Qgbm90IGV4dGVuc2libGUgLT4gY29weVxuICBmb3IgKHZhciBwcm9wIGluIGNoYW5nZSkge1xuICAgIHJlY29yZFtwcm9wXSA9IGNoYW5nZVtwcm9wXVxuICB9XG5cbiAgLy8gdW5vYnNlcnZlIGRlbGV0ZWQvcmVwbGFjZWQgb2JqZWN0c1xuICB2YXIgZGVsZXRlZCA9IGNoYW5nZS5vbGRWYWx1ZSAmJiBbY2hhbmdlLm9sZFZhbHVlXSB8fCBjaGFuZ2UucmVtb3ZlZCB8fCBbXVxuICBkZWxldGVkLmZvckVhY2goZnVuY3Rpb24ob2xkVmFsdWUsIGkpIHtcbiAgICBpZiAob2xkVmFsdWUgPT09IG51bGwgfHwgdHlwZW9mIG9sZFZhbHVlICE9PSAnb2JqZWN0Jykge1xuICAgICAgcmV0dXJuXG4gICAgfVxuXG4gICAgdGhpcy51bm9ic2VydmUob2xkVmFsdWUsIGNoYW5nZS5vYmplY3QsIGNoYW5nZS5uYW1lIHx8IGNoYW5nZS5pbmRleCArIGkpXG4gIH0sIHRoaXMpXG5cbiAgLy8gb2JzZXJ2ZSBhZGRlZC91cGRhdGVkIG9iamVjdHNcbiAgZnVuY3Rpb24gaGFuZGxlQ2hhbmdlKHZhbHVlLCBwYXJlbnQsIGtleSkge1xuICAgIGlmICh0eXBlb2YgdmFsdWUgPT09ICdvYmplY3QnKSB7XG4gICAgICB2YXIgZGVzYyA9IGtleSAhPT0gQXJyYXkgJiYgT2JqZWN0LmdldE93blByb3BlcnR5RGVzY3JpcHRvcihwYXJlbnQsIGtleSlcbiAgICAgIGlmICghZGVzYyB8fCBkZXNjLmVudW1lcmFibGUgPT09IHRydWUpIHtcbiAgICAgICAgc2VsZi5vYnNlcnZlKHZhbHVlLCBwYXJlbnQsIGtleSlcbiAgICAgIH0gZWxzZSB7XG4gICAgICAgIHNlbGYudW5vYnNlcnZlKHZhbHVlLCBwYXJlbnQsIGtleSlcbiAgICAgIH1cbiAgICB9XG4gIH1cblxuICBpZiAoY2hhbmdlLm5hbWUpIHtcbiAgICBpZiAoY2hhbmdlLm5hbWUgaW4gY2hhbmdlLm9iamVjdCkge1xuICAgICAgaGFuZGxlQ2hhbmdlKGNoYW5nZS5vYmplY3RbY2hhbmdlLm5hbWVdLCBjaGFuZ2Uub2JqZWN0LCBjaGFuZ2UubmFtZSlcbiAgICB9IGVsc2UgaWYgKHR5cGVvZiBjaGFuZ2Uub2JqZWN0LmdldCA9PT0gJ2Z1bmN0aW9uJykge1xuICAgICAgaGFuZGxlQ2hhbmdlKGNoYW5nZS5vYmplY3QuZ2V0KGNoYW5nZS5uYW1lKSwgY2hhbmdlLm9iamVjdCwgY2hhbmdlLm5hbWUpXG4gICAgfVxuICB9IGVsc2UgaWYgKGNoYW5nZS50eXBlID09PSAnc3BsaWNlJyAmJiBjaGFuZ2UuYWRkZWRDb3VudCkge1xuICAgIHZhciBhZGRlZCA9IGNoYW5nZS5vYmplY3Quc2xpY2UoY2hhbmdlLmluZGV4LCBjaGFuZ2UuaW5kZXggKyBjaGFuZ2UuYWRkZWRDb3VudClcbiAgICBhZGRlZC5mb3JFYWNoKGZ1bmN0aW9uKHZhbHVlKSB7XG4gICAgICBoYW5kbGVDaGFuZ2UodmFsdWUsIGNoYW5nZS5vYmplY3QsIEFycmF5KVxuICAgIH0pXG4gIH1cblxuICBPYmplY3QucHJldmVudEV4dGVuc2lvbnMocmVjb3JkKVxuXG4gIHJldHVybiByZWNvcmRcbn1cblxuZXhwb3J0c1tcImRlZmF1bHRcIl0gPSB7XG4gIC8vIENvcnJlc3BvbmRzIHRvIGBPYmplY3Qub2JzZXJ2ZSgpYCBidXQgZm9yIG5lc3RlZCBvYmplY3RzLlxuICBvYnNlcnZlOiBmdW5jdGlvbiBvYnNlcnZlKG9iaiwgY2FsbGJhY2ssIGFjY2VwdCkge1xuICAgIHZhciBkZWxlZ2F0ZVxuXG4gICAgaWYgKCFkZWxlZ2F0ZXMuaGFzKGNhbGxiYWNrKSkge1xuICAgICAgZGVsZWdhdGUgPSBuZXcgRGVsZWdhdGUoY2FsbGJhY2spXG4gICAgICBkZWxlZ2F0ZXMuc2V0KGNhbGxiYWNrLCBkZWxlZ2F0ZSlcbiAgICB9IGVsc2Uge1xuICAgICAgZGVsZWdhdGUgPSBkZWxlZ2F0ZXMuZ2V0KGNhbGxiYWNrKVxuICAgIH1cblxuICAgIHZhciBvYnNlcnZlcnMgPSBkZWxlZ2F0ZS5vYnNlcnZlcnNcbiAgICBpZiAob2JzZXJ2ZXJzLmhhcyhvYmopKSB7XG4gICAgICByZXR1cm5cbiAgICB9XG5cbiAgICB2YXIgb2JzZXJ2ZXIgPSBuZXcgT2JzZXJ2ZXIob2JqLCBkZWxlZ2F0ZSwgYWNjZXB0KVxuICAgIG9ic2VydmVyLm9ic2VydmUob2JqKVxuICB9LFxuXG4gIC8vIENvcnJlc3BvbmRzIHRvIGBPYmplY3QudW5vYnNlcnZlKClgIGJ1dCBmb3IgbmVzdGVkIG9iamVjdHMuXG4gIHVub2JzZXJ2ZTogZnVuY3Rpb24gdW5vYnNlcnZlKG9iaiwgY2FsbGJhY2spIHtcbiAgICBpZiAoIWRlbGVnYXRlcy5oYXMoY2FsbGJhY2spKSByZXR1cm5cbiAgICB2YXIgZGVsZWdhdGUgPSBkZWxlZ2F0ZXMuZ2V0KGNhbGxiYWNrKVxuXG4gICAgaWYgKCFkZWxlZ2F0ZS5vYnNlcnZlcnMuaGFzKG9iaikpIHtcbiAgICAgIHJldHVyblxuICAgIH1cblxuICAgIHZhciBvYnNlcnZlcnMgPSBkZWxlZ2F0ZS5vYnNlcnZlcnMuZ2V0KG9iailcbiAgICBvYnNlcnZlcnMuZm9yRWFjaChmdW5jdGlvbihvYnNlcnZlcikge1xuICAgICAgb2JzZXJ2ZXIudW5vYnNlcnZlKClcbiAgICB9KVxuICB9LFxuXG4gIC8vIENvcnJlc3BvbmRzIHRvIGBPYmplY3QuZGVsaXZlckNoYW5nZVJlY29yZHMoKWAgYnV0IGZvciBuZXN0ZWQgb2JqZWN0cy5cbiAgZGVsaXZlckNoYW5nZVJlY29yZHM6IGZ1bmN0aW9uIGRlbGl2ZXJDaGFuZ2VSZWNvcmRzKGNhbGxiYWNrKSB7XG4gICAgaWYgKHR5cGVvZiBjYWxsYmFjayAhPT0gJ2Z1bmN0aW9uJykge1xuICAgICAgdGhyb3cgbmV3IFR5cGVFcnJvcignQ2FsbGJhY2sgbXVzdCBiZSBhIGZ1bmN0aW9uLCBnaXZlbjogJyArIGNhbGxiYWNrKVxuICAgIH1cblxuICAgIGlmICghZGVsZWdhdGVzLmhhcyhjYWxsYmFjaykpIHJldHVyblxuXG4gICAgdmFyIGRlbGVnYXRlID0gZGVsZWdhdGVzLmdldChjYWxsYmFjaylcbiAgICBPYmplY3QuZGVsaXZlckNoYW5nZVJlY29yZHMoZGVsZWdhdGUuaGFuZGxlQ2hhbmdlUmVjb3JkcylcbiAgfSxcblxuICBnZXQgZGVidWcoKSB7XG4gICAgcmV0dXJuIGRlYnVnXG4gIH0sXG5cbiAgc2V0IGRlYnVnKHZhbCkge1xuICAgIGRlYnVnID0gdmFsXG4gIH1cbn07IiwiXCJ1c2Ugc3RyaWN0XCI7XG52YXIgV2Vha01WTWFwID0gZnVuY3Rpb24oKSB7XG4gIHRoaXMubWFwID0gbmV3IFdlYWtNYXBcbn1cblxuV2Vha01WTWFwLnByb3RvdHlwZS5nZXQgPSBmdW5jdGlvbihrZXkpIHtcbiAgcmV0dXJuIHRoaXMubWFwLmdldChrZXkpXG59XG5cbldlYWtNVk1hcC5wcm90b3R5cGUuaGFzID0gZnVuY3Rpb24oa2V5LCB2YWx1ZSkge1xuICBpZiAoIXRoaXMubWFwLmhhcyhrZXkpKSByZXR1cm4gZmFsc2VcbiAgdmFyIHZhbHVlcyA9IHRoaXMubWFwLmdldChrZXkpXG4gIGlmICh2YWx1ZSA9PT0gdW5kZWZpbmVkICYmIHZhbHVlcy5sZW5ndGgpIHtcbiAgICByZXR1cm4gdHJ1ZVxuICB9XG4gIHJldHVybiB2YWx1ZXMuaW5kZXhPZih2YWx1ZSkgPiAtMVxufVxuXG5XZWFrTVZNYXAucHJvdG90eXBlLmFkZCA9IGZ1bmN0aW9uKGtleSwgdmFsdWUpIHtcbiAgaWYgKCF0aGlzLm1hcC5oYXMoa2V5KSkge1xuICAgIHRoaXMubWFwLnNldChrZXksIFtdKVxuICB9XG5cbiAgdmFyIHZhbHVlcyA9IHRoaXMubWFwLmdldChrZXkpXG4gIHZhbHVlcy5wdXNoKHZhbHVlKVxufVxuXG5XZWFrTVZNYXAucHJvdG90eXBlLnJlbW92ZSA9IGZ1bmN0aW9uKGtleSwgdmFsdWUpIHtcbiAgdmFyIHZhbHVlcyA9IHRoaXMubWFwLmdldChrZXkpXG5cbiAgdmFyIGluZGV4ID0gdmFsdWVzLmluZGV4T2YodmFsdWUpXG4gIHZhbHVlcy5zcGxpY2UoaW5kZXgsIDEpXG5cbiAgLy8gaWYgdGhlIHNldCBpcyBlbXB0eSwgcmVtb3ZlIGl0IGZyb20gdGhlIFdlYWtNYXBcbiAgaWYgKCF2YWx1ZXMubGVuZ3RoKSB0aGlzLm1hcC5kZWxldGUoa2V5KVxufVxuXG52YXIgUGFyZW50c01hcHBpbmcgPSBmdW5jdGlvbigpIHtcbiAgdGhpcy5tYXBwaW5nID0gbmV3IFdlYWtNYXBcbn1cblxuUGFyZW50c01hcHBpbmcucHJvdG90eXBlLmFkZCA9IGZ1bmN0aW9uKG9iaiwgcGFyZW50LCBrZXkpIHtcbiAgaWYgKCFwYXJlbnQgfHwga2V5ID09PSB1bmRlZmluZWQpIHJldHVyblxuXG4gIGlmICghdGhpcy5tYXBwaW5nLmhhcyhvYmopKSB7XG4gICAgdGhpcy5tYXBwaW5nLnNldChvYmosIFtdKVxuICB9XG5cbiAgdmFyIHBhcmVudHMgPSB0aGlzLm1hcHBpbmcuZ2V0KG9iailcbiAgcGFyZW50cy5wdXNoKHsgb2JqOiBwYXJlbnQsIGtleToga2V5IH0pXG59XG5cblBhcmVudHNNYXBwaW5nLnByb3RvdHlwZS5yZW1vdmUgPSBmdW5jdGlvbihvYmosIHBhcmVudCwga2V5KSB7XG4gIGlmICghcGFyZW50IHx8ICFrZXkgPT09IHVuZGVmaW5lZCkgcmV0dXJuXG5cbiAgdmFyIHBhcmVudHMgPSB0aGlzLm1hcHBpbmcuZ2V0KG9iailcblxuICBmb3IgKHZhciBpID0gMCwgbGVuID0gcGFyZW50cy5sZW5ndGg7IGkgPCBsZW47ICsraSkge1xuICAgIGlmIChwYXJlbnRzW2ldLm9iaiA9PT0gcGFyZW50ICYmIHBhcmVudHNbaV0ua2V5ID09PSBrZXkpIHtcbiAgICAgIHBhcmVudHMuc3BsaWNlKGksIDEpXG4gICAgICBicmVha1xuICAgIH1cbiAgfVxuXG4gIGlmICghcGFyZW50cy5sZW5ndGgpIHRoaXMubWFwcGluZy5kZWxldGUob2JqKVxufVxuXG5QYXJlbnRzTWFwcGluZy5wcm90b3R5cGUucGF0aCA9IGZ1bmN0aW9uKG9iaikge1xuICB2YXIgcGF0aCA9IFtdXG4gIHdoaWxlICh0aGlzLm1hcHBpbmcuaGFzKG9iaikpIHtcbiAgICB2YXIgcGFyZW50ID0gdGhpcy5tYXBwaW5nLmdldChvYmopWzBdXG4gICAgdmFyIGtleSA9IHBhcmVudC5rZXkgPT09IEFycmF5ID8gcGFyZW50Lm9iai5pbmRleE9mKG9iaikgOiBwYXJlbnQua2V5XG4gICAgcGF0aC51bnNoaWZ0KGtleSlcbiAgICBvYmogPSBwYXJlbnQub2JqXG4gIH1cbiAgcmV0dXJuIHBhdGhcbn1cbmV4cG9ydHMuV2Vha01WTWFwID0gV2Vha01WTWFwLCBleHBvcnRzLlBhcmVudHNNYXBwaW5nID0gUGFyZW50c01hcHBpbmc7IiwiKGZ1bmN0aW9uIChyb290LCBmYWN0b3J5KXtcbiAgJ3VzZSBzdHJpY3QnO1xuXG4gIC8qaXN0YW5idWwgaWdub3JlIG5leHQ6Y2FudCB0ZXN0Ki9cbiAgaWYgKHR5cGVvZiBtb2R1bGUgPT09ICdvYmplY3QnICYmIHR5cGVvZiBtb2R1bGUuZXhwb3J0cyA9PT0gJ29iamVjdCcpIHtcbiAgICBtb2R1bGUuZXhwb3J0cyA9IGZhY3RvcnkoKTtcbiAgfSBlbHNlIGlmICh0eXBlb2YgZGVmaW5lID09PSAnZnVuY3Rpb24nICYmIGRlZmluZS5hbWQpIHtcbiAgICAvLyBBTUQuIFJlZ2lzdGVyIGFzIGFuIGFub255bW91cyBtb2R1bGUuXG4gICAgZGVmaW5lKFtdLCBmYWN0b3J5KTtcbiAgfSBlbHNlIHtcbiAgICAvLyBCcm93c2VyIGdsb2JhbHNcbiAgICByb290Lm9iamVjdFBhdGggPSBmYWN0b3J5KCk7XG4gIH1cbn0pKHRoaXMsIGZ1bmN0aW9uKCl7XG4gICd1c2Ugc3RyaWN0JztcblxuICB2YXJcbiAgICB0b1N0ciA9IE9iamVjdC5wcm90b3R5cGUudG9TdHJpbmcsXG4gICAgX2hhc093blByb3BlcnR5ID0gT2JqZWN0LnByb3RvdHlwZS5oYXNPd25Qcm9wZXJ0eTtcblxuICBmdW5jdGlvbiBpc0VtcHR5KHZhbHVlKXtcbiAgICBpZiAoIXZhbHVlKSB7XG4gICAgICByZXR1cm4gdHJ1ZTtcbiAgICB9XG4gICAgaWYgKGlzQXJyYXkodmFsdWUpICYmIHZhbHVlLmxlbmd0aCA9PT0gMCkge1xuICAgICAgICByZXR1cm4gdHJ1ZTtcbiAgICB9IGVsc2UgaWYgKCFpc1N0cmluZyh2YWx1ZSkpIHtcbiAgICAgICAgZm9yICh2YXIgaSBpbiB2YWx1ZSkge1xuICAgICAgICAgICAgaWYgKF9oYXNPd25Qcm9wZXJ0eS5jYWxsKHZhbHVlLCBpKSkge1xuICAgICAgICAgICAgICAgIHJldHVybiBmYWxzZTtcbiAgICAgICAgICAgIH1cbiAgICAgICAgfVxuICAgICAgICByZXR1cm4gdHJ1ZTtcbiAgICB9XG4gICAgcmV0dXJuIGZhbHNlO1xuICB9XG5cbiAgZnVuY3Rpb24gdG9TdHJpbmcodHlwZSl7XG4gICAgcmV0dXJuIHRvU3RyLmNhbGwodHlwZSk7XG4gIH1cblxuICBmdW5jdGlvbiBpc051bWJlcih2YWx1ZSl7XG4gICAgcmV0dXJuIHR5cGVvZiB2YWx1ZSA9PT0gJ251bWJlcicgfHwgdG9TdHJpbmcodmFsdWUpID09PSBcIltvYmplY3QgTnVtYmVyXVwiO1xuICB9XG5cbiAgZnVuY3Rpb24gaXNTdHJpbmcob2JqKXtcbiAgICByZXR1cm4gdHlwZW9mIG9iaiA9PT0gJ3N0cmluZycgfHwgdG9TdHJpbmcob2JqKSA9PT0gXCJbb2JqZWN0IFN0cmluZ11cIjtcbiAgfVxuXG4gIGZ1bmN0aW9uIGlzT2JqZWN0KG9iail7XG4gICAgcmV0dXJuIHR5cGVvZiBvYmogPT09ICdvYmplY3QnICYmIHRvU3RyaW5nKG9iaikgPT09IFwiW29iamVjdCBPYmplY3RdXCI7XG4gIH1cblxuICBmdW5jdGlvbiBpc0FycmF5KG9iail7XG4gICAgcmV0dXJuIHR5cGVvZiBvYmogPT09ICdvYmplY3QnICYmIHR5cGVvZiBvYmoubGVuZ3RoID09PSAnbnVtYmVyJyAmJiB0b1N0cmluZyhvYmopID09PSAnW29iamVjdCBBcnJheV0nO1xuICB9XG5cbiAgZnVuY3Rpb24gaXNCb29sZWFuKG9iail7XG4gICAgcmV0dXJuIHR5cGVvZiBvYmogPT09ICdib29sZWFuJyB8fCB0b1N0cmluZyhvYmopID09PSAnW29iamVjdCBCb29sZWFuXSc7XG4gIH1cblxuICBmdW5jdGlvbiBnZXRLZXkoa2V5KXtcbiAgICB2YXIgaW50S2V5ID0gcGFyc2VJbnQoa2V5KTtcbiAgICBpZiAoaW50S2V5LnRvU3RyaW5nKCkgPT09IGtleSkge1xuICAgICAgcmV0dXJuIGludEtleTtcbiAgICB9XG4gICAgcmV0dXJuIGtleTtcbiAgfVxuXG4gIGZ1bmN0aW9uIHNldChvYmosIHBhdGgsIHZhbHVlLCBkb05vdFJlcGxhY2Upe1xuICAgIGlmIChpc051bWJlcihwYXRoKSkge1xuICAgICAgcGF0aCA9IFtwYXRoXTtcbiAgICB9XG4gICAgaWYgKGlzRW1wdHkocGF0aCkpIHtcbiAgICAgIHJldHVybiBvYmo7XG4gICAgfVxuICAgIGlmIChpc1N0cmluZyhwYXRoKSkge1xuICAgICAgcmV0dXJuIHNldChvYmosIHBhdGguc3BsaXQoJy4nKS5tYXAoZ2V0S2V5KSwgdmFsdWUsIGRvTm90UmVwbGFjZSk7XG4gICAgfVxuICAgIHZhciBjdXJyZW50UGF0aCA9IHBhdGhbMF07XG5cbiAgICBpZiAocGF0aC5sZW5ndGggPT09IDEpIHtcbiAgICAgIHZhciBvbGRWYWwgPSBvYmpbY3VycmVudFBhdGhdO1xuICAgICAgaWYgKG9sZFZhbCA9PT0gdm9pZCAwIHx8ICFkb05vdFJlcGxhY2UpIHtcbiAgICAgICAgb2JqW2N1cnJlbnRQYXRoXSA9IHZhbHVlO1xuICAgICAgfVxuICAgICAgcmV0dXJuIG9sZFZhbDtcbiAgICB9XG5cbiAgICBpZiAob2JqW2N1cnJlbnRQYXRoXSA9PT0gdm9pZCAwKSB7XG4gICAgICAvL2NoZWNrIGlmIHdlIGFzc3VtZSBhbiBhcnJheVxuICAgICAgaWYoaXNOdW1iZXIocGF0aFsxXSkpIHtcbiAgICAgICAgb2JqW2N1cnJlbnRQYXRoXSA9IFtdO1xuICAgICAgfSBlbHNlIHtcbiAgICAgICAgb2JqW2N1cnJlbnRQYXRoXSA9IHt9O1xuICAgICAgfVxuICAgIH1cblxuICAgIHJldHVybiBzZXQob2JqW2N1cnJlbnRQYXRoXSwgcGF0aC5zbGljZSgxKSwgdmFsdWUsIGRvTm90UmVwbGFjZSk7XG4gIH1cblxuICBmdW5jdGlvbiBkZWwob2JqLCBwYXRoKSB7XG4gICAgaWYgKGlzTnVtYmVyKHBhdGgpKSB7XG4gICAgICBwYXRoID0gW3BhdGhdO1xuICAgIH1cblxuICAgIGlmIChpc0VtcHR5KG9iaikpIHtcbiAgICAgIHJldHVybiB2b2lkIDA7XG4gICAgfVxuXG4gICAgaWYgKGlzRW1wdHkocGF0aCkpIHtcbiAgICAgIHJldHVybiBvYmo7XG4gICAgfVxuICAgIGlmKGlzU3RyaW5nKHBhdGgpKSB7XG4gICAgICByZXR1cm4gZGVsKG9iaiwgcGF0aC5zcGxpdCgnLicpKTtcbiAgICB9XG5cbiAgICB2YXIgY3VycmVudFBhdGggPSBnZXRLZXkocGF0aFswXSk7XG4gICAgdmFyIG9sZFZhbCA9IG9ialtjdXJyZW50UGF0aF07XG5cbiAgICBpZihwYXRoLmxlbmd0aCA9PT0gMSkge1xuICAgICAgaWYgKG9sZFZhbCAhPT0gdm9pZCAwKSB7XG4gICAgICAgIGlmIChpc0FycmF5KG9iaikpIHtcbiAgICAgICAgICBvYmouc3BsaWNlKGN1cnJlbnRQYXRoLCAxKTtcbiAgICAgICAgfSBlbHNlIHtcbiAgICAgICAgICBkZWxldGUgb2JqW2N1cnJlbnRQYXRoXTtcbiAgICAgICAgfVxuICAgICAgfVxuICAgIH0gZWxzZSB7XG4gICAgICBpZiAob2JqW2N1cnJlbnRQYXRoXSAhPT0gdm9pZCAwKSB7XG4gICAgICAgIHJldHVybiBkZWwob2JqW2N1cnJlbnRQYXRoXSwgcGF0aC5zbGljZSgxKSk7XG4gICAgICB9XG4gICAgfVxuXG4gICAgcmV0dXJuIG9iajtcbiAgfVxuXG4gIHZhciBvYmplY3RQYXRoID0gZnVuY3Rpb24ob2JqKSB7XG4gICAgcmV0dXJuIE9iamVjdC5rZXlzKG9iamVjdFBhdGgpLnJlZHVjZShmdW5jdGlvbihwcm94eSwgcHJvcCkge1xuICAgICAgaWYgKHR5cGVvZiBvYmplY3RQYXRoW3Byb3BdID09PSAnZnVuY3Rpb24nKSB7XG4gICAgICAgIHByb3h5W3Byb3BdID0gb2JqZWN0UGF0aFtwcm9wXS5iaW5kKG9iamVjdFBhdGgsIG9iaik7XG4gICAgICB9XG5cbiAgICAgIHJldHVybiBwcm94eTtcbiAgICB9LCB7fSk7XG4gIH07XG5cbiAgb2JqZWN0UGF0aC5oYXMgPSBmdW5jdGlvbiAob2JqLCBwYXRoKSB7XG4gICAgaWYgKGlzRW1wdHkob2JqKSkge1xuICAgICAgcmV0dXJuIGZhbHNlO1xuICAgIH1cblxuICAgIGlmIChpc051bWJlcihwYXRoKSkge1xuICAgICAgcGF0aCA9IFtwYXRoXTtcbiAgICB9IGVsc2UgaWYgKGlzU3RyaW5nKHBhdGgpKSB7XG4gICAgICBwYXRoID0gcGF0aC5zcGxpdCgnLicpO1xuICAgIH1cblxuICAgIGlmIChpc0VtcHR5KHBhdGgpIHx8IHBhdGgubGVuZ3RoID09PSAwKSB7XG4gICAgICByZXR1cm4gZmFsc2U7XG4gICAgfVxuXG4gICAgZm9yICh2YXIgaSA9IDA7IGkgPCBwYXRoLmxlbmd0aDsgaSsrKSB7XG4gICAgICB2YXIgaiA9IHBhdGhbaV07XG4gICAgICBpZiAoKGlzT2JqZWN0KG9iaikgfHwgaXNBcnJheShvYmopKSAmJiBfaGFzT3duUHJvcGVydHkuY2FsbChvYmosIGopKSB7XG4gICAgICAgIG9iaiA9IG9ialtqXTtcbiAgICAgIH0gZWxzZSB7XG4gICAgICAgIHJldHVybiBmYWxzZTtcbiAgICAgIH1cbiAgICB9XG5cbiAgICByZXR1cm4gdHJ1ZTtcbiAgfTtcblxuICBvYmplY3RQYXRoLmVuc3VyZUV4aXN0cyA9IGZ1bmN0aW9uIChvYmosIHBhdGgsIHZhbHVlKXtcbiAgICByZXR1cm4gc2V0KG9iaiwgcGF0aCwgdmFsdWUsIHRydWUpO1xuICB9O1xuXG4gIG9iamVjdFBhdGguc2V0ID0gZnVuY3Rpb24gKG9iaiwgcGF0aCwgdmFsdWUsIGRvTm90UmVwbGFjZSl7XG4gICAgcmV0dXJuIHNldChvYmosIHBhdGgsIHZhbHVlLCBkb05vdFJlcGxhY2UpO1xuICB9O1xuXG4gIG9iamVjdFBhdGguaW5zZXJ0ID0gZnVuY3Rpb24gKG9iaiwgcGF0aCwgdmFsdWUsIGF0KXtcbiAgICB2YXIgYXJyID0gb2JqZWN0UGF0aC5nZXQob2JqLCBwYXRoKTtcbiAgICBhdCA9IH5+YXQ7XG4gICAgaWYgKCFpc0FycmF5KGFycikpIHtcbiAgICAgIGFyciA9IFtdO1xuICAgICAgb2JqZWN0UGF0aC5zZXQob2JqLCBwYXRoLCBhcnIpO1xuICAgIH1cbiAgICBhcnIuc3BsaWNlKGF0LCAwLCB2YWx1ZSk7XG4gIH07XG5cbiAgb2JqZWN0UGF0aC5lbXB0eSA9IGZ1bmN0aW9uKG9iaiwgcGF0aCkge1xuICAgIGlmIChpc0VtcHR5KHBhdGgpKSB7XG4gICAgICByZXR1cm4gb2JqO1xuICAgIH1cbiAgICBpZiAoaXNFbXB0eShvYmopKSB7XG4gICAgICByZXR1cm4gdm9pZCAwO1xuICAgIH1cblxuICAgIHZhciB2YWx1ZSwgaTtcbiAgICBpZiAoISh2YWx1ZSA9IG9iamVjdFBhdGguZ2V0KG9iaiwgcGF0aCkpKSB7XG4gICAgICByZXR1cm4gb2JqO1xuICAgIH1cblxuICAgIGlmIChpc1N0cmluZyh2YWx1ZSkpIHtcbiAgICAgIHJldHVybiBvYmplY3RQYXRoLnNldChvYmosIHBhdGgsICcnKTtcbiAgICB9IGVsc2UgaWYgKGlzQm9vbGVhbih2YWx1ZSkpIHtcbiAgICAgIHJldHVybiBvYmplY3RQYXRoLnNldChvYmosIHBhdGgsIGZhbHNlKTtcbiAgICB9IGVsc2UgaWYgKGlzTnVtYmVyKHZhbHVlKSkge1xuICAgICAgcmV0dXJuIG9iamVjdFBhdGguc2V0KG9iaiwgcGF0aCwgMCk7XG4gICAgfSBlbHNlIGlmIChpc0FycmF5KHZhbHVlKSkge1xuICAgICAgdmFsdWUubGVuZ3RoID0gMDtcbiAgICB9IGVsc2UgaWYgKGlzT2JqZWN0KHZhbHVlKSkge1xuICAgICAgZm9yIChpIGluIHZhbHVlKSB7XG4gICAgICAgIGlmIChfaGFzT3duUHJvcGVydHkuY2FsbCh2YWx1ZSwgaSkpIHtcbiAgICAgICAgICBkZWxldGUgdmFsdWVbaV07XG4gICAgICAgIH1cbiAgICAgIH1cbiAgICB9IGVsc2Uge1xuICAgICAgcmV0dXJuIG9iamVjdFBhdGguc2V0KG9iaiwgcGF0aCwgbnVsbCk7XG4gICAgfVxuICB9O1xuXG4gIG9iamVjdFBhdGgucHVzaCA9IGZ1bmN0aW9uIChvYmosIHBhdGggLyosIHZhbHVlcyAqLyl7XG4gICAgdmFyIGFyciA9IG9iamVjdFBhdGguZ2V0KG9iaiwgcGF0aCk7XG4gICAgaWYgKCFpc0FycmF5KGFycikpIHtcbiAgICAgIGFyciA9IFtdO1xuICAgICAgb2JqZWN0UGF0aC5zZXQob2JqLCBwYXRoLCBhcnIpO1xuICAgIH1cblxuICAgIGFyci5wdXNoLmFwcGx5KGFyciwgQXJyYXkucHJvdG90eXBlLnNsaWNlLmNhbGwoYXJndW1lbnRzLCAyKSk7XG4gIH07XG5cbiAgb2JqZWN0UGF0aC5jb2FsZXNjZSA9IGZ1bmN0aW9uIChvYmosIHBhdGhzLCBkZWZhdWx0VmFsdWUpIHtcbiAgICB2YXIgdmFsdWU7XG5cbiAgICBmb3IgKHZhciBpID0gMCwgbGVuID0gcGF0aHMubGVuZ3RoOyBpIDwgbGVuOyBpKyspIHtcbiAgICAgIGlmICgodmFsdWUgPSBvYmplY3RQYXRoLmdldChvYmosIHBhdGhzW2ldKSkgIT09IHZvaWQgMCkge1xuICAgICAgICByZXR1cm4gdmFsdWU7XG4gICAgICB9XG4gICAgfVxuXG4gICAgcmV0dXJuIGRlZmF1bHRWYWx1ZTtcbiAgfTtcblxuICBvYmplY3RQYXRoLmdldCA9IGZ1bmN0aW9uIChvYmosIHBhdGgsIGRlZmF1bHRWYWx1ZSl7XG4gICAgaWYgKGlzTnVtYmVyKHBhdGgpKSB7XG4gICAgICBwYXRoID0gW3BhdGhdO1xuICAgIH1cbiAgICBpZiAoaXNFbXB0eShwYXRoKSkge1xuICAgICAgcmV0dXJuIG9iajtcbiAgICB9XG4gICAgaWYgKGlzRW1wdHkob2JqKSkge1xuICAgICAgcmV0dXJuIGRlZmF1bHRWYWx1ZTtcbiAgICB9XG4gICAgaWYgKGlzU3RyaW5nKHBhdGgpKSB7XG4gICAgICByZXR1cm4gb2JqZWN0UGF0aC5nZXQob2JqLCBwYXRoLnNwbGl0KCcuJyksIGRlZmF1bHRWYWx1ZSk7XG4gICAgfVxuXG4gICAgdmFyIGN1cnJlbnRQYXRoID0gZ2V0S2V5KHBhdGhbMF0pO1xuXG4gICAgaWYgKHBhdGgubGVuZ3RoID09PSAxKSB7XG4gICAgICBpZiAob2JqW2N1cnJlbnRQYXRoXSA9PT0gdm9pZCAwKSB7XG4gICAgICAgIHJldHVybiBkZWZhdWx0VmFsdWU7XG4gICAgICB9XG4gICAgICByZXR1cm4gb2JqW2N1cnJlbnRQYXRoXTtcbiAgICB9XG5cbiAgICByZXR1cm4gb2JqZWN0UGF0aC5nZXQob2JqW2N1cnJlbnRQYXRoXSwgcGF0aC5zbGljZSgxKSwgZGVmYXVsdFZhbHVlKTtcbiAgfTtcblxuICBvYmplY3RQYXRoLmRlbCA9IGZ1bmN0aW9uKG9iaiwgcGF0aCkge1xuICAgIHJldHVybiBkZWwob2JqLCBwYXRoKTtcbiAgfTtcblxuICByZXR1cm4gb2JqZWN0UGF0aDtcbn0pO1xuIiwiXG52YXIgcm5nO1xuXG5pZiAoZ2xvYmFsLmNyeXB0byAmJiBjcnlwdG8uZ2V0UmFuZG9tVmFsdWVzKSB7XG4gIC8vIFdIQVRXRyBjcnlwdG8tYmFzZWQgUk5HIC0gaHR0cDovL3dpa2kud2hhdHdnLm9yZy93aWtpL0NyeXB0b1xuICAvLyBNb2RlcmF0ZWx5IGZhc3QsIGhpZ2ggcXVhbGl0eVxuICB2YXIgX3JuZHM4ID0gbmV3IFVpbnQ4QXJyYXkoMTYpO1xuICBybmcgPSBmdW5jdGlvbiB3aGF0d2dSTkcoKSB7XG4gICAgY3J5cHRvLmdldFJhbmRvbVZhbHVlcyhfcm5kczgpO1xuICAgIHJldHVybiBfcm5kczg7XG4gIH07XG59XG5cbmlmICghcm5nKSB7XG4gIC8vIE1hdGgucmFuZG9tKCktYmFzZWQgKFJORylcbiAgLy9cbiAgLy8gSWYgYWxsIGVsc2UgZmFpbHMsIHVzZSBNYXRoLnJhbmRvbSgpLiAgSXQncyBmYXN0LCBidXQgaXMgb2YgdW5zcGVjaWZpZWRcbiAgLy8gcXVhbGl0eS5cbiAgdmFyICBfcm5kcyA9IG5ldyBBcnJheSgxNik7XG4gIHJuZyA9IGZ1bmN0aW9uKCkge1xuICAgIGZvciAodmFyIGkgPSAwLCByOyBpIDwgMTY7IGkrKykge1xuICAgICAgaWYgKChpICYgMHgwMykgPT09IDApIHIgPSBNYXRoLnJhbmRvbSgpICogMHgxMDAwMDAwMDA7XG4gICAgICBfcm5kc1tpXSA9IHIgPj4+ICgoaSAmIDB4MDMpIDw8IDMpICYgMHhmZjtcbiAgICB9XG5cbiAgICByZXR1cm4gX3JuZHM7XG4gIH07XG59XG5cbm1vZHVsZS5leHBvcnRzID0gcm5nO1xuXG4iLCIvLyAgICAgdXVpZC5qc1xuLy9cbi8vICAgICBDb3B5cmlnaHQgKGMpIDIwMTAtMjAxMiBSb2JlcnQgS2llZmZlclxuLy8gICAgIE1JVCBMaWNlbnNlIC0gaHR0cDovL29wZW5zb3VyY2Uub3JnL2xpY2Vuc2VzL21pdC1saWNlbnNlLnBocFxuXG4vLyBVbmlxdWUgSUQgY3JlYXRpb24gcmVxdWlyZXMgYSBoaWdoIHF1YWxpdHkgcmFuZG9tICMgZ2VuZXJhdG9yLiAgV2UgZmVhdHVyZVxuLy8gZGV0ZWN0IHRvIGRldGVybWluZSB0aGUgYmVzdCBSTkcgc291cmNlLCBub3JtYWxpemluZyB0byBhIGZ1bmN0aW9uIHRoYXRcbi8vIHJldHVybnMgMTI4LWJpdHMgb2YgcmFuZG9tbmVzcywgc2luY2UgdGhhdCdzIHdoYXQncyB1c3VhbGx5IHJlcXVpcmVkXG52YXIgX3JuZyA9IHJlcXVpcmUoJy4vcm5nJyk7XG5cbi8vIE1hcHMgZm9yIG51bWJlciA8LT4gaGV4IHN0cmluZyBjb252ZXJzaW9uXG52YXIgX2J5dGVUb0hleCA9IFtdO1xudmFyIF9oZXhUb0J5dGUgPSB7fTtcbmZvciAodmFyIGkgPSAwOyBpIDwgMjU2OyBpKyspIHtcbiAgX2J5dGVUb0hleFtpXSA9IChpICsgMHgxMDApLnRvU3RyaW5nKDE2KS5zdWJzdHIoMSk7XG4gIF9oZXhUb0J5dGVbX2J5dGVUb0hleFtpXV0gPSBpO1xufVxuXG4vLyAqKmBwYXJzZSgpYCAtIFBhcnNlIGEgVVVJRCBpbnRvIGl0J3MgY29tcG9uZW50IGJ5dGVzKipcbmZ1bmN0aW9uIHBhcnNlKHMsIGJ1Ziwgb2Zmc2V0KSB7XG4gIHZhciBpID0gKGJ1ZiAmJiBvZmZzZXQpIHx8IDAsIGlpID0gMDtcblxuICBidWYgPSBidWYgfHwgW107XG4gIHMudG9Mb3dlckNhc2UoKS5yZXBsYWNlKC9bMC05YS1mXXsyfS9nLCBmdW5jdGlvbihvY3QpIHtcbiAgICBpZiAoaWkgPCAxNikgeyAvLyBEb24ndCBvdmVyZmxvdyFcbiAgICAgIGJ1ZltpICsgaWkrK10gPSBfaGV4VG9CeXRlW29jdF07XG4gICAgfVxuICB9KTtcblxuICAvLyBaZXJvIG91dCByZW1haW5pbmcgYnl0ZXMgaWYgc3RyaW5nIHdhcyBzaG9ydFxuICB3aGlsZSAoaWkgPCAxNikge1xuICAgIGJ1ZltpICsgaWkrK10gPSAwO1xuICB9XG5cbiAgcmV0dXJuIGJ1Zjtcbn1cblxuLy8gKipgdW5wYXJzZSgpYCAtIENvbnZlcnQgVVVJRCBieXRlIGFycmF5IChhbGEgcGFyc2UoKSkgaW50byBhIHN0cmluZyoqXG5mdW5jdGlvbiB1bnBhcnNlKGJ1Ziwgb2Zmc2V0KSB7XG4gIHZhciBpID0gb2Zmc2V0IHx8IDAsIGJ0aCA9IF9ieXRlVG9IZXg7XG4gIHJldHVybiAgYnRoW2J1ZltpKytdXSArIGJ0aFtidWZbaSsrXV0gK1xuICAgICAgICAgIGJ0aFtidWZbaSsrXV0gKyBidGhbYnVmW2krK11dICsgJy0nICtcbiAgICAgICAgICBidGhbYnVmW2krK11dICsgYnRoW2J1ZltpKytdXSArICctJyArXG4gICAgICAgICAgYnRoW2J1ZltpKytdXSArIGJ0aFtidWZbaSsrXV0gKyAnLScgK1xuICAgICAgICAgIGJ0aFtidWZbaSsrXV0gKyBidGhbYnVmW2krK11dICsgJy0nICtcbiAgICAgICAgICBidGhbYnVmW2krK11dICsgYnRoW2J1ZltpKytdXSArXG4gICAgICAgICAgYnRoW2J1ZltpKytdXSArIGJ0aFtidWZbaSsrXV0gK1xuICAgICAgICAgIGJ0aFtidWZbaSsrXV0gKyBidGhbYnVmW2krK11dO1xufVxuXG4vLyAqKmB2MSgpYCAtIEdlbmVyYXRlIHRpbWUtYmFzZWQgVVVJRCoqXG4vL1xuLy8gSW5zcGlyZWQgYnkgaHR0cHM6Ly9naXRodWIuY29tL0xpb3NLL1VVSUQuanNcbi8vIGFuZCBodHRwOi8vZG9jcy5weXRob24ub3JnL2xpYnJhcnkvdXVpZC5odG1sXG5cbi8vIHJhbmRvbSAjJ3Mgd2UgbmVlZCB0byBpbml0IG5vZGUgYW5kIGNsb2Nrc2VxXG52YXIgX3NlZWRCeXRlcyA9IF9ybmcoKTtcblxuLy8gUGVyIDQuNSwgY3JlYXRlIGFuZCA0OC1iaXQgbm9kZSBpZCwgKDQ3IHJhbmRvbSBiaXRzICsgbXVsdGljYXN0IGJpdCA9IDEpXG52YXIgX25vZGVJZCA9IFtcbiAgX3NlZWRCeXRlc1swXSB8IDB4MDEsXG4gIF9zZWVkQnl0ZXNbMV0sIF9zZWVkQnl0ZXNbMl0sIF9zZWVkQnl0ZXNbM10sIF9zZWVkQnl0ZXNbNF0sIF9zZWVkQnl0ZXNbNV1cbl07XG5cbi8vIFBlciA0LjIuMiwgcmFuZG9taXplICgxNCBiaXQpIGNsb2Nrc2VxXG52YXIgX2Nsb2Nrc2VxID0gKF9zZWVkQnl0ZXNbNl0gPDwgOCB8IF9zZWVkQnl0ZXNbN10pICYgMHgzZmZmO1xuXG4vLyBQcmV2aW91cyB1dWlkIGNyZWF0aW9uIHRpbWVcbnZhciBfbGFzdE1TZWNzID0gMCwgX2xhc3ROU2VjcyA9IDA7XG5cbi8vIFNlZSBodHRwczovL2dpdGh1Yi5jb20vYnJvb2ZhL25vZGUtdXVpZCBmb3IgQVBJIGRldGFpbHNcbmZ1bmN0aW9uIHYxKG9wdGlvbnMsIGJ1Ziwgb2Zmc2V0KSB7XG4gIHZhciBpID0gYnVmICYmIG9mZnNldCB8fCAwO1xuICB2YXIgYiA9IGJ1ZiB8fCBbXTtcblxuICBvcHRpb25zID0gb3B0aW9ucyB8fCB7fTtcblxuICB2YXIgY2xvY2tzZXEgPSBvcHRpb25zLmNsb2Nrc2VxICE9PSB1bmRlZmluZWQgPyBvcHRpb25zLmNsb2Nrc2VxIDogX2Nsb2Nrc2VxO1xuXG4gIC8vIFVVSUQgdGltZXN0YW1wcyBhcmUgMTAwIG5hbm8tc2Vjb25kIHVuaXRzIHNpbmNlIHRoZSBHcmVnb3JpYW4gZXBvY2gsXG4gIC8vICgxNTgyLTEwLTE1IDAwOjAwKS4gIEpTTnVtYmVycyBhcmVuJ3QgcHJlY2lzZSBlbm91Z2ggZm9yIHRoaXMsIHNvXG4gIC8vIHRpbWUgaXMgaGFuZGxlZCBpbnRlcm5hbGx5IGFzICdtc2VjcycgKGludGVnZXIgbWlsbGlzZWNvbmRzKSBhbmQgJ25zZWNzJ1xuICAvLyAoMTAwLW5hbm9zZWNvbmRzIG9mZnNldCBmcm9tIG1zZWNzKSBzaW5jZSB1bml4IGVwb2NoLCAxOTcwLTAxLTAxIDAwOjAwLlxuICB2YXIgbXNlY3MgPSBvcHRpb25zLm1zZWNzICE9PSB1bmRlZmluZWQgPyBvcHRpb25zLm1zZWNzIDogbmV3IERhdGUoKS5nZXRUaW1lKCk7XG5cbiAgLy8gUGVyIDQuMi4xLjIsIHVzZSBjb3VudCBvZiB1dWlkJ3MgZ2VuZXJhdGVkIGR1cmluZyB0aGUgY3VycmVudCBjbG9ja1xuICAvLyBjeWNsZSB0byBzaW11bGF0ZSBoaWdoZXIgcmVzb2x1dGlvbiBjbG9ja1xuICB2YXIgbnNlY3MgPSBvcHRpb25zLm5zZWNzICE9PSB1bmRlZmluZWQgPyBvcHRpb25zLm5zZWNzIDogX2xhc3ROU2VjcyArIDE7XG5cbiAgLy8gVGltZSBzaW5jZSBsYXN0IHV1aWQgY3JlYXRpb24gKGluIG1zZWNzKVxuICB2YXIgZHQgPSAobXNlY3MgLSBfbGFzdE1TZWNzKSArIChuc2VjcyAtIF9sYXN0TlNlY3MpLzEwMDAwO1xuXG4gIC8vIFBlciA0LjIuMS4yLCBCdW1wIGNsb2Nrc2VxIG9uIGNsb2NrIHJlZ3Jlc3Npb25cbiAgaWYgKGR0IDwgMCAmJiBvcHRpb25zLmNsb2Nrc2VxID09PSB1bmRlZmluZWQpIHtcbiAgICBjbG9ja3NlcSA9IGNsb2Nrc2VxICsgMSAmIDB4M2ZmZjtcbiAgfVxuXG4gIC8vIFJlc2V0IG5zZWNzIGlmIGNsb2NrIHJlZ3Jlc3NlcyAobmV3IGNsb2Nrc2VxKSBvciB3ZSd2ZSBtb3ZlZCBvbnRvIGEgbmV3XG4gIC8vIHRpbWUgaW50ZXJ2YWxcbiAgaWYgKChkdCA8IDAgfHwgbXNlY3MgPiBfbGFzdE1TZWNzKSAmJiBvcHRpb25zLm5zZWNzID09PSB1bmRlZmluZWQpIHtcbiAgICBuc2VjcyA9IDA7XG4gIH1cblxuICAvLyBQZXIgNC4yLjEuMiBUaHJvdyBlcnJvciBpZiB0b28gbWFueSB1dWlkcyBhcmUgcmVxdWVzdGVkXG4gIGlmIChuc2VjcyA+PSAxMDAwMCkge1xuICAgIHRocm93IG5ldyBFcnJvcigndXVpZC52MSgpOiBDYW5cXCd0IGNyZWF0ZSBtb3JlIHRoYW4gMTBNIHV1aWRzL3NlYycpO1xuICB9XG5cbiAgX2xhc3RNU2VjcyA9IG1zZWNzO1xuICBfbGFzdE5TZWNzID0gbnNlY3M7XG4gIF9jbG9ja3NlcSA9IGNsb2Nrc2VxO1xuXG4gIC8vIFBlciA0LjEuNCAtIENvbnZlcnQgZnJvbSB1bml4IGVwb2NoIHRvIEdyZWdvcmlhbiBlcG9jaFxuICBtc2VjcyArPSAxMjIxOTI5MjgwMDAwMDtcblxuICAvLyBgdGltZV9sb3dgXG4gIHZhciB0bCA9ICgobXNlY3MgJiAweGZmZmZmZmYpICogMTAwMDAgKyBuc2VjcykgJSAweDEwMDAwMDAwMDtcbiAgYltpKytdID0gdGwgPj4+IDI0ICYgMHhmZjtcbiAgYltpKytdID0gdGwgPj4+IDE2ICYgMHhmZjtcbiAgYltpKytdID0gdGwgPj4+IDggJiAweGZmO1xuICBiW2krK10gPSB0bCAmIDB4ZmY7XG5cbiAgLy8gYHRpbWVfbWlkYFxuICB2YXIgdG1oID0gKG1zZWNzIC8gMHgxMDAwMDAwMDAgKiAxMDAwMCkgJiAweGZmZmZmZmY7XG4gIGJbaSsrXSA9IHRtaCA+Pj4gOCAmIDB4ZmY7XG4gIGJbaSsrXSA9IHRtaCAmIDB4ZmY7XG5cbiAgLy8gYHRpbWVfaGlnaF9hbmRfdmVyc2lvbmBcbiAgYltpKytdID0gdG1oID4+PiAyNCAmIDB4ZiB8IDB4MTA7IC8vIGluY2x1ZGUgdmVyc2lvblxuICBiW2krK10gPSB0bWggPj4+IDE2ICYgMHhmZjtcblxuICAvLyBgY2xvY2tfc2VxX2hpX2FuZF9yZXNlcnZlZGAgKFBlciA0LjIuMiAtIGluY2x1ZGUgdmFyaWFudClcbiAgYltpKytdID0gY2xvY2tzZXEgPj4+IDggfCAweDgwO1xuXG4gIC8vIGBjbG9ja19zZXFfbG93YFxuICBiW2krK10gPSBjbG9ja3NlcSAmIDB4ZmY7XG5cbiAgLy8gYG5vZGVgXG4gIHZhciBub2RlID0gb3B0aW9ucy5ub2RlIHx8IF9ub2RlSWQ7XG4gIGZvciAodmFyIG4gPSAwOyBuIDwgNjsgbisrKSB7XG4gICAgYltpICsgbl0gPSBub2RlW25dO1xuICB9XG5cbiAgcmV0dXJuIGJ1ZiA/IGJ1ZiA6IHVucGFyc2UoYik7XG59XG5cbi8vICoqYHY0KClgIC0gR2VuZXJhdGUgcmFuZG9tIFVVSUQqKlxuXG4vLyBTZWUgaHR0cHM6Ly9naXRodWIuY29tL2Jyb29mYS9ub2RlLXV1aWQgZm9yIEFQSSBkZXRhaWxzXG5mdW5jdGlvbiB2NChvcHRpb25zLCBidWYsIG9mZnNldCkge1xuICAvLyBEZXByZWNhdGVkIC0gJ2Zvcm1hdCcgYXJndW1lbnQsIGFzIHN1cHBvcnRlZCBpbiB2MS4yXG4gIHZhciBpID0gYnVmICYmIG9mZnNldCB8fCAwO1xuXG4gIGlmICh0eXBlb2Yob3B0aW9ucykgPT0gJ3N0cmluZycpIHtcbiAgICBidWYgPSBvcHRpb25zID09ICdiaW5hcnknID8gbmV3IEFycmF5KDE2KSA6IG51bGw7XG4gICAgb3B0aW9ucyA9IG51bGw7XG4gIH1cbiAgb3B0aW9ucyA9IG9wdGlvbnMgfHwge307XG5cbiAgdmFyIHJuZHMgPSBvcHRpb25zLnJhbmRvbSB8fCAob3B0aW9ucy5ybmcgfHwgX3JuZykoKTtcblxuICAvLyBQZXIgNC40LCBzZXQgYml0cyBmb3IgdmVyc2lvbiBhbmQgYGNsb2NrX3NlcV9oaV9hbmRfcmVzZXJ2ZWRgXG4gIHJuZHNbNl0gPSAocm5kc1s2XSAmIDB4MGYpIHwgMHg0MDtcbiAgcm5kc1s4XSA9IChybmRzWzhdICYgMHgzZikgfCAweDgwO1xuXG4gIC8vIENvcHkgYnl0ZXMgdG8gYnVmZmVyLCBpZiBwcm92aWRlZFxuICBpZiAoYnVmKSB7XG4gICAgZm9yICh2YXIgaWkgPSAwOyBpaSA8IDE2OyBpaSsrKSB7XG4gICAgICBidWZbaSArIGlpXSA9IHJuZHNbaWldO1xuICAgIH1cbiAgfVxuXG4gIHJldHVybiBidWYgfHwgdW5wYXJzZShybmRzKTtcbn1cblxuLy8gRXhwb3J0IHB1YmxpYyBBUElcbnZhciB1dWlkID0gdjQ7XG51dWlkLnYxID0gdjE7XG51dWlkLnY0ID0gdjQ7XG51dWlkLnBhcnNlID0gcGFyc2U7XG51dWlkLnVucGFyc2UgPSB1bnBhcnNlO1xuXG5tb2R1bGUuZXhwb3J0cyA9IHV1aWQ7XG4iXX0=

--- a/lib/config/loader.js
+++ b/lib/config/loader.js
@@ -270,7 +270,7 @@ module.exports = function (userCfgPath) {
 		config = defaults(schema);
 	}
 
-	config.listen = config.listen || config.port;
+	config.listen = `${config.host}:${config.port}`;
 	config.baseURL = config.baseURL || `${config.host}:${config.port}`;
 
 	const validate = validator(schema, {greedy: true});

--- a/lib/config/loader.js
+++ b/lib/config/loader.js
@@ -270,7 +270,6 @@ module.exports = function (userCfgPath) {
 		config = defaults(schema);
 	}
 
-	config.listen = `${config.host}:${config.port}`;
 	config.baseURL = config.baseURL || `${config.host}:${config.port}`;
 
 	const validate = validator(schema, {greedy: true});

--- a/lib/server/index.js
+++ b/lib/server/index.js
@@ -147,7 +147,7 @@ module.exports.start = function () {
 		server.listen(config.listen);
 
 		const protocol = config.ssl && config.ssl.enabled ? 'https' : 'http';
-		log.info('NodeCG running on %s://%s', protocol, config.baseURL);
+		log.info('NodeCG running on %s://%s', protocol, config.listen);
 		module.exports.emit('started');
 	});
 
@@ -269,12 +269,11 @@ module.exports.start = function () {
 		}
 	});
 
-	log.trace('Attempting to listen on %s', config.listen);
+	log.trace(`Attempting to listen on %s`, config.listen);
 	server.on('error', err => {
 		switch (err.code) {
 			case 'EADDRINUSE':
-				log.error('[server.js] Listen %s in use, is NodeCG already running? NodeCG will now exit.',
-					config.listen);
+				log.error('[server.js] Listen %s in use, is NodeCG already running? NodeCG will now exit.', config.listen);
 				break;
 			default:
 				log.error('Unhandled error!', err);

--- a/lib/server/index.js
+++ b/lib/server/index.js
@@ -144,7 +144,7 @@ module.exports.start = function () {
 		// This has two benefits:
 		// 1) Prevents the dashboard/views from being opened before everything has finished loading
 		// 2) Prevents dashboard/views from re-declaring replicants on reconnect before extensions have had a chance
-		server.listen(config.listen);
+		server.listen(config.port, config.host);
 
 		const protocol = config.ssl && config.ssl.enabled ? 'https' : 'http';
 		log.info('NodeCG running on %s://%s', protocol, config.listen);

--- a/lib/server/index.js
+++ b/lib/server/index.js
@@ -147,7 +147,7 @@ module.exports.start = function () {
 		server.listen(config.port, config.host);
 
 		const protocol = config.ssl && config.ssl.enabled ? 'https' : 'http';
-		log.info('NodeCG running on %s://%s', protocol, config.listen);
+		log.info('NodeCG running on %s://%s', protocol, config.baseURL);
 		module.exports.emit('started');
 	});
 
@@ -269,11 +269,11 @@ module.exports.start = function () {
 		}
 	});
 
-	log.trace(`Attempting to listen on %s`, config.listen);
+	log.trace(`Attempting to listen on ${config.host}:${config.port}`);
 	server.on('error', err => {
 		switch (err.code) {
 			case 'EADDRINUSE':
-				log.error('[server.js] Listen %s in use, is NodeCG already running? NodeCG will now exit.', config.listen);
+				log.error(`[server.js] Listen ${config.host}:${config.port} in use, is NodeCG already running? NodeCG will now exit.`);
 				break;
 			default:
 				log.error('Unhandled error!', err);

--- a/lib/util/authcheck.js
+++ b/lib/util/authcheck.js
@@ -3,6 +3,16 @@
 const tokens = require('../login/tokens');
 const config = require('../config').config;
 
+function getDomain(url) {
+	const index = url.indexOf(':');
+
+	if (url.substring === -1) {
+		return url;
+	}
+
+	return url.substring(0, index);
+}
+
 /**
  * Express middleware that checks if the user is authenticated.
  * @param req
@@ -16,7 +26,7 @@ module.exports = function (req, res, next) {
 	}
 
 	// To set a cookie on localhost, domain must be "null"
-	const domain = config.host === 'localhost' ? null : config.host;
+	const domain = getDomain(config.baseURL) === 'localhost' ? null : getDomain(config.baseURL);
 
 	const allowed = req.user === undefined ? false : req.user.allowed;
 	const provider = req.user === undefined ? 'none' : req.user.provider;

--- a/lib/util/authcheck.js
+++ b/lib/util/authcheck.js
@@ -3,16 +3,6 @@
 const tokens = require('../login/tokens');
 const config = require('../config').config;
 
-function getDomain(url) {
-	const index = url.indexOf(':');
-
-	if (url.substring === -1) {
-		return url;
-	}
-
-	return url.substring(0, index);
-}
-
 /**
  * Express middleware that checks if the user is authenticated.
  * @param req
@@ -26,8 +16,7 @@ module.exports = function (req, res, next) {
 	}
 
 	// To set a cookie on localhost, domain must be "null"
-	const domain = getDomain(config.baseURL) === 'localhost' ? null : getDomain(config.baseURL);
-
+	const domain = config.host === 'localhost' ? null : config.host;
 	const allowed = req.user === undefined ? false : req.user.allowed;
 	const provider = req.user === undefined ? 'none' : req.user.provider;
 	const providerAllowed = provider === 'none' ? false : config.login[provider].enabled;


### PR DESCRIPTION
The PR fixes some issues nodecg had behind a reverse proxy:
* `config.listen`, which nodecg was passing as the sole argument to `server.listen`, was set to `config.listen || config.port`. This meant that nodecg would always listen on `0.0.0.0` or `::`, despite what `config.host` was set to.

* In the express middleware defined in `authcheck.js`, the cookie domain was set to whatever `config.host` was. Behind a reverse proxy, the baseURL would be used as the URL to nodecg, which would make authentication impossible. I've added a `getDomain` function which extracts the domain from the baseURL (which is set to `config.host` by default). 