### PR TITLE
fix(auth): fix case where token auth via cookies would fail when `host` was set to `0.0.0.0`

### DIFF
--- a/lib/server/index.js
+++ b/lib/server/index.js
@@ -144,7 +144,7 @@ module.exports.start = function () {
 		// This has two benefits:
 		// 1) Prevents the dashboard/views from being opened before everything has finished loading
 		// 2) Prevents dashboard/views from re-declaring replicants on reconnect before extensions have had a chance
-		server.listen(config.port, config.host);
+		server.listen(config.port);
 
 		const protocol = config.ssl && config.ssl.enabled ? 'https' : 'http';
 		log.info('NodeCG running on %s://%s', protocol, config.baseURL);

--- a/lib/sounds.js
+++ b/lib/sounds.js
@@ -57,7 +57,8 @@ bundles.all().forEach(bundle => {
 
 	if (bundle.enableCustomCues) {
 		const customCuesRep = new Replicant('customSoundCues', bundle.name, {
-			schemaPath: 'schemas/customSoundCues.json'
+			schemaPath: 'schemas/customSoundCues.json',
+			defaultValue: []
 		});
 		customCueRepsByBundle.set(bundle.name, customCuesRep);
 	}


### PR DESCRIPTION
This specifically impacts docker deployments of NodeCG which use things like [jwilder/nginx-proxy](https://github.com/jwilder/nginx-proxy) and therefore must bind to `0.0.0.0`, as their internal Docker IP isn't known.