### PR TITLE
Refactor fs.existsSync calls

### DIFF
--- a/lib/assets/index.js
+++ b/lib/assets/index.js
@@ -184,13 +184,13 @@ const upload = multer({
 app.get('/assets/:bundleName/:category/:filePath', (req, res) => {
 	const fullPath = path.join(ASSETS_ROOT, req.params.bundleName, req.params.category, req.params.filePath);
 	res.sendFile(fullPath, err => {
-		if (!err) return;
-
-		if (err.code === 'ENOENT') {
-			return res.sendStatus(404);
+		if (err) {
+			if (err.code === 'ENOENT') {
+				return res.sendStatus(404);
+			}
+			log.error(`Unexpected error sending file ${fullPath}`, err);
+			res.sendStatus(500);
 		}
-		log.error(`Unexpected error sending file ${fullPath}`, err);
-		res.sendStatus(500);
 	});
 });
 
@@ -221,14 +221,14 @@ app.delete('/assets/:bundleName/:category/:filename', authCheck, (req, res) => {
 	const fullPath = path.join(ASSETS_ROOT, bundleName, category, filename);
 
 	fs.unlink(fullPath, err => {
-		if (!err) return;
+		if (err) {
+			if (err.code === 'ENOENT') {
+				return res.status(410).send(`The file to delete does not exist: ${filename}`);
+			}
 
-		if (err.code === 'ENOENT') {
-			return res.status(410).send(`The file to delete does not exist: ${filename}`);
+			log.error(`Failed to delete file ${fullPath}`, err);
+			res.status(500).send(`Failed to delete file: ${filename}`);
 		}
-
-		log.error(`Failed to delete file ${fullPath}`, err);
-		res.status(500).send(`Failed to delete file: ${filename}`);
 	});
 });
 

--- a/lib/assets/index.js
+++ b/lib/assets/index.js
@@ -183,13 +183,14 @@ const upload = multer({
 // Retrieving existing files
 app.get('/assets/:bundleName/:category/:filePath', (req, res) => {
 	const fullPath = path.join(ASSETS_ROOT, req.params.bundleName, req.params.category, req.params.filePath);
-	fs.exists(fullPath, exists => {
-		if (!exists) {
-			res.status(404).send(`File not found: ${req.path}`);
-			return;
-		}
+	res.sendFile(fullPath, err => {
+		if (!err) return;
 
-		res.sendFile(fullPath);
+		if (err.code === 'ENOENT') {
+			return res.sendStatus(404);
+		}
+		log.error(`Unexpected error sending file ${fullPath}`, err);
+		res.sendStatus(500);
 	});
 });
 
@@ -217,23 +218,17 @@ app.delete('/assets/:bundleName/:category/:filename', authCheck, (req, res) => {
 	const bundleName = req.params.bundleName;
 	const category = req.params.category;
 	const filename = req.params.filename;
-	const fullpath = path.join(ASSETS_ROOT, bundleName, category, filename);
+	const fullPath = path.join(ASSETS_ROOT, bundleName, category, filename);
 
-	fs.exists(fullpath, exists => {
-		if (!exists) {
-			res.status(410).send(`The file to delete does not exist: ${filename}`);
-			return;
+	fs.unlink(fullPath, err => {
+		if (!err) return;
+
+		if (err.code === 'ENOENT') {
+			return res.status(410).send(`The file to delete does not exist: ${filename}`);
 		}
 
-		fs.unlink(fullpath, err => {
-			if (err) {
-				log.error(`Failed to delete file: ${err.message}`);
-				res.status(500).send(`Failed to delete file: ${filename}`);
-				return;
-			}
-
-			res.sendStatus(200);
-		});
+		log.error(`Failed to delete file ${fullPath}`, err);
+		res.status(500).send(`Failed to delete file: ${filename}`);
 	});
 });
 

--- a/lib/dashboard/index.js
+++ b/lib/dashboard/index.js
@@ -51,14 +51,6 @@ app.get('/bundles/:bundleName/dashboard/*', ncgUtils.authCheck, (req, res, next)
 	}
 
 	const resName = req.params[0];
-	const fileLocation = path.join(bundle.dashboard.dir, resName);
-
-	// Check if the file exists
-	if (!fs.existsSync(fileLocation)) {
-		next();
-		return;
-	}
-
 	// If the target file is a panel or dialog, inject the appropriate scripts.
 	// Else, serve the file as-is.
 	const panel = bundle.dashboardPanels.find(p => p.file === resName);
@@ -70,7 +62,16 @@ app.get('/bundles/:bundleName/dashboard/*', ncgUtils.authCheck, (req, res, next)
 			fullbleed: panel.fullbleed
 		}, html => res.send(html));
 	} else {
-		res.sendFile(fileLocation);
+		const fileLocation = path.join(bundle.dashboard.dir, resName);
+		res.sendFile(fileLocation, err => {
+			if (!err) return;
+
+			if (err.code === 'ENOENT') {
+				return res.sendStatus(404);
+			}
+
+			return next();
+		});
 	}
 });
 

--- a/lib/dashboard/index.js
+++ b/lib/dashboard/index.js
@@ -1,7 +1,6 @@
 'use strict';
 
 // Native
-const fs = require('fs');
 const path = require('path');
 const pug = require('pug');
 
@@ -64,13 +63,13 @@ app.get('/bundles/:bundleName/dashboard/*', ncgUtils.authCheck, (req, res, next)
 	} else {
 		const fileLocation = path.join(bundle.dashboard.dir, resName);
 		res.sendFile(fileLocation, err => {
-			if (!err) return;
+			if (err) {
+				if (err.code === 'ENOENT') {
+					return res.sendStatus(404);
+				}
 
-			if (err.code === 'ENOENT') {
-				return res.sendStatus(404);
+				return next();
 			}
-
-			return next();
 		});
 	}
 });

--- a/lib/graphics/index.js
+++ b/lib/graphics/index.js
@@ -37,14 +37,6 @@ app.get('/bundles/:bundleName/graphics*', ncgUtils.authCheck, (req, res, next) =
 		resName = req.params[0];
 	}
 
-	const fileLocation = path.join(bundle.dir, 'graphics', resName);
-
-	// Check if the file exists
-	if (!fs.existsSync(fileLocation)) {
-		next();
-		return;
-	}
-
 	// Set a flag if this graphic is one we should enforce singleInstance behavior on.
 	// This flag is passed to injectScripts, which then injects the client-side portion of the
 	// singleInstance enforcement.
@@ -60,6 +52,7 @@ app.get('/bundles/:bundleName/graphics*', ncgUtils.authCheck, (req, res, next) =
 		return false;
 	});
 
+	const fileLocation = path.join(bundle.dir, 'graphics', resName);
 	// If this file is a main HTML file for a graphic, inject the graphic setup scripts.
 	if (isGraphic) {
 		ncgUtils.injectScripts(fileLocation, 'graphic', {
@@ -68,7 +61,15 @@ app.get('/bundles/:bundleName/graphics*', ncgUtils.authCheck, (req, res, next) =
 			sound: bundle.soundCues && bundle.soundCues.length > 0
 		}, html => res.send(html));
 	} else {
-		res.sendFile(fileLocation);
+		res.sendFile(fileLocation, err => {
+			if (!err) return;
+
+			if (err.code === 'ENOENT') {
+				return res.sendStatus(404);
+			}
+
+			return next();
+		});
 	}
 });
 
@@ -84,13 +85,15 @@ app.get('/bundles/:bundleName/bower_components/*', (req, res, next) => {
 	const resName = req.params[0];
 	const fileLocation = path.join(bundle.dir, 'bower_components', resName);
 
-	// Check if the file exists
-	if (!fs.existsSync(fileLocation)) {
-		next();
-		return;
-	}
+	res.sendFile(fileLocation, err => {
+		if (!err) return;
 
-	res.sendFile(fileLocation);
+		if (err.code === 'ENOENT') {
+			return res.sendStatus(404);
+		}
+
+		return next();
+	});
 });
 
 module.exports = app;

--- a/lib/graphics/index.js
+++ b/lib/graphics/index.js
@@ -2,7 +2,6 @@
 
 const express = require('express');
 const app = express();
-const fs = require('fs');
 const path = require('path');
 const log = require('../logger')('nodecg/lib/graphics');
 const Bundles = require('../bundles');
@@ -62,13 +61,13 @@ app.get('/bundles/:bundleName/graphics*', ncgUtils.authCheck, (req, res, next) =
 		}, html => res.send(html));
 	} else {
 		res.sendFile(fileLocation, err => {
-			if (!err) return;
+			if (err) {
+				if (err.code === 'ENOENT') {
+					return res.sendStatus(404);
+				}
 
-			if (err.code === 'ENOENT') {
-				return res.sendStatus(404);
+				return next();
 			}
-
-			return next();
 		});
 	}
 });
@@ -86,13 +85,13 @@ app.get('/bundles/:bundleName/bower_components/*', (req, res, next) => {
 	const fileLocation = path.join(bundle.dir, 'bower_components', resName);
 
 	res.sendFile(fileLocation, err => {
-		if (!err) return;
+		if (err) {
+			if (err.code === 'ENOENT') {
+				return res.sendStatus(404);
+			}
 
-		if (err.code === 'ENOENT') {
-			return res.sendStatus(404);
+			return next();
 		}
-
-		return next();
 	});
 });
 

--- a/lib/graphics/single_instance/index.js
+++ b/lib/graphics/single_instance/index.js
@@ -67,18 +67,20 @@ app.get('/instance/*', (req, res, next) => {
 	const resName = req.path.split('/').slice(2).join('/');
 	const fileLocation = path.resolve(__dirname, 'public/', resName);
 
-	// Check if the file exists
-	if (!fs.existsSync(fileLocation)) {
-		next();
-		return;
-	}
-
 	// If it's a HTML file, inject the graphic setup script and serve that
 	// otherwise, send the file unmodified
 	if (resName.endsWith('.html')) {
 		injectScripts(fileLocation, 'graphic', {}, html => res.send(html));
 	} else {
-		res.sendFile(fileLocation);
+		res.sendFile(fileLocation, err => {
+			if (!err) return;
+
+			if (err.code === 'ENOENT') {
+				return res.sendStatus(404);
+			}
+
+			return next();
+		});
 	}
 });
 

--- a/lib/graphics/single_instance/index.js
+++ b/lib/graphics/single_instance/index.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const fs = require('fs');
 const path = require('path');
 const app = require('express')();
 const io = require('../../server').getIO();
@@ -73,13 +72,13 @@ app.get('/instance/*', (req, res, next) => {
 		injectScripts(fileLocation, 'graphic', {}, html => res.send(html));
 	} else {
 		res.sendFile(fileLocation, err => {
-			if (!err) return;
+			if (err) {
+				if (err.code === 'ENOENT') {
+					return res.sendStatus(404);
+				}
 
-			if (err.code === 'ENOENT') {
-				return res.sendStatus(404);
+				return next();
 			}
-
-			return next();
 		});
 	}
 });

--- a/lib/sounds.js
+++ b/lib/sounds.js
@@ -2,7 +2,6 @@
 'use strict';
 
 const clone = require('clone');
-const fs = require('fs');
 const path = require('path');
 const app = require('express')();
 const sha1File = require('sha1-file');
@@ -120,13 +119,13 @@ function _serveDefault(req, res) {
 
 	const fullPath = path.join(bundle.dir, cue.defaultFile);
 	res.sendFile(fullPath, err => {
-		if (!err) return;
-
-		if (err.code === 'ENOENT') {
-			return res.sendStatus(404);
+		if (err) {
+			if (err.code === 'ENOENT') {
+				return res.sendStatus(404);
+			}
+			log.error(`Unexpected error sending file ${fullPath}`, err);
+			res.sendStatus(500);
 		}
-		log.error(`Unexpected error sending file ${fullPath}`, err);
-		return res.sendStatus(500);
 	});
 }
 

--- a/lib/sounds.js
+++ b/lib/sounds.js
@@ -119,13 +119,14 @@ function _serveDefault(req, res) {
 	}
 
 	const fullPath = path.join(bundle.dir, cue.defaultFile);
-	fs.exists(fullPath, exists => {
-		if (!exists) {
-			res.status(404).send(`File not found: ${req.path}`);
-			return;
-		}
+	res.sendFile(fullPath, err => {
+		if (!err) return;
 
-		res.sendFile(fullPath);
+		if (err.code === 'ENOENT') {
+			return res.sendStatus(404);
+		}
+		log.error(`Unexpected error sending file ${fullPath}`, err);
+		return res.sendStatus(500);
 	});
 }
 


### PR DESCRIPTION
Fixes #262.

This does not replace _all_ fs.existsSync calls, the ones I have left are calls like
```
if (!fs.existsSync(REPLICANTS_ROOT)) {
	fs.mkdirSync(REPLICANTS_ROOT);
}
```
and similar calls that are run on startup. To me they are easier to read and if mkdir throws an exception, I want that to kill the server on startup.

Merge if it looks good.