### PR TITLE
Feature: Docker Image Impovment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,3 +6,4 @@
 !bower.json
 !index.js
 !package.json
+!Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,48 @@
 FROM node:8
 
-WORKDIR /usr/src/app
+# User and group arguments
+ARG user=nodecg
+ARG group=nodecg
+ARG gid=1001
+ARG uid=1001
 
-# Copy NodeCG (just the files we need)
+# Create a non-root user
+RUN groupadd -r -g ${gid} ${group}  &&\
+    useradd --no-log-init -r -u ${uid} -g ${group} ${user} &&\
+    mkdir /home/${user} && chown -R ${user}:${group} /home/${user}
+
+# Install bower cli
+RUN yarn global add bower
+
+# Set workdir
+WORKDIR /opt/nodecg/
+
+# Copy nodecg into the workdir
+COPY . /opt/nodecg/
+
+# Set permissions
+RUN chown -R ${user}:${group} . &&\
+    chmod 744 .
+
+# Login as nodecg
+USER ${user}
+
+# Setup mountable volumes
 RUN mkdir cfg && mkdir bundles && mkdir logs && mkdir db
-COPY . /usr/src/app/
 
 # Install dependencies
-RUN npm install -g bower
-RUN npm install --production
-RUN bower install --allow-root
+RUN yarn install --prod
+RUN bower install
+
+# Expose volumes
+# Volumes that are mounted need to have read and write permission for user nodecg with uid=1001 or group nodecg gid=1001
+# You can set the dir ownership with ´chown -R 1001:1001 [directory]´ or you can give everyone read and write
+# permissions with ´chmod -R 666 [directory]´
+# (you may need root permissions to change read and write permissions or directory ownership)
+VOLUME ["/opt/nodecg/cfg/", "/opt/nodecg/bundles/", "/opt/nodecg/db/"]
+
+# Expose standard port
+EXPOSE 9090
 
 # The command to run
-EXPOSE 9090
 CMD ["node", "index.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN groupadd -r -g ${gid} ${group}  &&\
     mkdir /home/${user} && chown -R ${user}:${group} /home/${user}
 
 # Install bower cli
-RUN yarn global add bower
+RUN npm install -g bower
 
 # Set workdir
 WORKDIR /opt/nodecg/
@@ -31,7 +31,7 @@ USER ${user}
 RUN mkdir cfg && mkdir bundles && mkdir logs && mkdir db
 
 # Install dependencies
-RUN yarn install --prod
+RUN npm install --production
 RUN bower install
 
 # Expose volumes


### PR DESCRIPTION
Improve Docker support by using a non-root user to execute nodecg.(https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/#user)
Also changed the workdir to "/opt/nodecg" as "/opt" it's supposed to be used to install programs.
Also Adding Volumes. (https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/#volume) 
Also Using yarn instead of npm, because of it's advantages. (nodejs/docker-node#243)



