### PR TITLE
Remove extra margin around :slotted elements (#339)

### DIFF
--- a/src/dashboard/elements/ncg-dialog.html
+++ b/src/dashboard/elements/ncg-dialog.html
@@ -71,6 +71,10 @@ Lange - 1/28/2016
 			:host > ::slotted(*:last-child) {
 				margin-bottom: 0;
 			}
+
+			:host > ::slotted(*:not(:first-child)) {
+				margin-top: 0;
+			}
 		</style>
 
 		<slot id="slot"></slot>


### PR DESCRIPTION
Added a small css rule to target the offending elements.

Before/After:

![image](https://user-images.githubusercontent.com/708588/30236603-c91306fa-94ea-11e7-8339-ad00294c13b0.png)
