### PR TITLE
Fix (login session): Redirect to /login after destroying session

### DIFF
--- a/lib/login/index.js
+++ b/lib/login/index.js
@@ -120,7 +120,7 @@ app.get('/logout', (req, res) => {
 	req.session.destroy(() => {
 		res.clearCookie('connect.sid', {path: '/'});
 		res.clearCookie('socketToken', {path: '/'});
-		res.redirect('/');
+		res.redirect('/login');
 	});
 });
 


### PR DESCRIPTION
You cannot go to login screen if you use nginx or nginx reverse proxy or some specific proxy settings. 

I could not find the exact reason why the session doesn't die, but at least this solution works since `/login` does not take session into account.