### PR TITLE
feat(bundle-manager): blacklisted bundle directory names

### DIFF
--- a/lib/bundle-manager.js
+++ b/lib/bundle-manager.js
@@ -147,7 +147,7 @@ module.exports.init = function (bundlesPath, cfgPath, nodecgVersion, nodecgConfi
 		}
 
 		// Prevent attempting to load unwanted directories. Those specified above and all dot-prefixed.
-		if (blacklistedBundleDirectories.indexOf(bundleFolderName) > -1 || /(?:^|[\\/])(\.(?!\.)[^\\/]+)$/.test(bundleFolderName)) {
+		if (blacklistedBundleDirectories.indexOf(bundleFolderName) > -1 || bundleFolderName.startsWith('.')) {
 			return;
 		}
 

--- a/lib/bundle-manager.js
+++ b/lib/bundle-manager.js
@@ -183,20 +183,18 @@ module.exports.init = function (bundlesPath, cfgPath, nodecgVersion, nodecgConfi
 		}
 
 		bundles.push(bundle);
-	});
 
-	// Workaround for https://github.com/paulmillr/chokidar/issues/419
-	// This workaround is necessary to fully support symlinks.
-	fs.readdirSync(bundlesPath)
-		.map(name => path.join(bundlesPath, name))
-		.filter(source => fs.statSync(source).isDirectory())
-		.forEach(bundlePath => {
-			watcher.add([
-				path.join(bundlePath, '.git'), // Watch .git folders
-				path.join(bundlePath, 'dashboard'), // Watch dashboard folders
-				path.join(bundlePath, 'package.json') // Watch bundle package.json files
-			]);
-		});
+		// Use `chokidar` to watch for file changes within bundles.
+		// Workaround for https://github.com/paulmillr/chokidar/issues/419
+		// This workaround is necessary to fully support symlinks.
+		// This is applied after the bundle has been validated and loaded.
+		// Bundles that do not properly load upon startup are not recognized for updates.
+		watcher.add([
+			path.join(bundlePath, '.git'), // Watch `.git` directories.
+			path.join(bundlePath, 'dashboard'), // Watch `dashboard` directories.
+			path.join(bundlePath, 'package.json') // Watch each bundle's `package.json`.
+		]);
+	});
 
 	emitter.emit('init', bundles);
 };

--- a/lib/bundle-manager.js
+++ b/lib/bundle-manager.js
@@ -155,10 +155,18 @@ module.exports.init = function (bundlesPath, cfgPath, nodecgVersion, nodecgConfi
 		// Parse each bundle and push the result onto the bundles array
 		let bundle;
 		const bundleCfgPath = path.join(cfgPath, `${bundleFolderName}.json`);
-		if (fs.existsSync(bundleCfgPath)) {
-			bundle = parseBundle(bundlePath, bundleCfgPath);
-		} else {
-			bundle = parseBundle(bundlePath);
+		try {
+			if (fs.existsSync(bundleCfgPath)) {
+				bundle = parseBundle(bundlePath, bundleCfgPath);
+			} else {
+				bundle = parseBundle(bundlePath);
+			}
+		} catch (e) {
+			log.error(
+				'An exception was thrown attempting to load bundle %s\n',
+				bundleFolderName, e
+			);
+			return;
 		}
 
 		// Check if the bundle is compatible with this version of NodeCG
@@ -167,14 +175,6 @@ module.exports.init = function (bundlesPath, cfgPath, nodecgVersion, nodecgConfi
 				'%s requires NodeCG version %s, current version is %s',
 				bundle.name, bundle.compatibleRange, nodecgVersion
 			);
-			return;
-		}
-
-		// This block can probably be removed in 0.8, but let's leave it for 0.7 just in case.
-		/* istanbul ignore next: Given how strict nodecg-bundle-parser is,
-		 it should not be possible for "bundle" to be undefined. */
-		if (typeof bundle === 'undefined') {
-			log.error('Could not load bundle in directory', bundleFolderName);
 			return;
 		}
 

--- a/lib/bundle-manager.js
+++ b/lib/bundle-manager.js
@@ -27,6 +27,11 @@ const watcher = chokidar.watch([
 	followSymlinks: true
 });
 
+const blacklistedBundleDirectories = [
+	'node_modules',
+	'bower_components'
+];
+
 const emitter = new EventEmitter();
 const bundles = [];
 let log;
@@ -70,6 +75,7 @@ module.exports = emitter;
  * @param Logger {Function} - A preconfigured @nodecg/logger constructor.
  * @return {Object} - A bundle-manager instance.
  */
+// eslint-disable-next-line max-params
 module.exports.init = function (bundlesPath, cfgPath, nodecgVersion, nodecgConfig, Logger) {
 	if (initialized) {
 		throw new Error('Cannot initialize when already initialized');
@@ -140,6 +146,11 @@ module.exports.init = function (bundlesPath, cfgPath, nodecgVersion, nodecgConfi
 			return;
 		}
 
+		// Prevent attempting to load unwanted directories. Those specified above and all dot-prefixed.
+		if (blacklistedBundleDirectories.indexOf(bundleFolderName) > -1 || /(?:^|[\\/])(\.(?!\.)[^\\/]+)$/.test(bundleFolderName)) {
+			return;
+		}
+
 		if (nodecgConfig && nodecgConfig.bundles && nodecgConfig.bundles.disabled &&
 			nodecgConfig.bundles.disabled.indexOf(bundleFolderName) > -1) {
 			log.debug('Not loading bundle ' + bundleFolderName + ' as it is disabled in config');
@@ -155,18 +166,11 @@ module.exports.init = function (bundlesPath, cfgPath, nodecgVersion, nodecgConfi
 		// Parse each bundle and push the result onto the bundles array
 		let bundle;
 		const bundleCfgPath = path.join(cfgPath, `${bundleFolderName}.json`);
-		try {
-			if (fs.existsSync(bundleCfgPath)) {
-				bundle = parseBundle(bundlePath, bundleCfgPath);
-			} else {
-				bundle = parseBundle(bundlePath);
-			}
-		} catch (e) {
-			log.error(
-				'An exception was thrown attempting to load bundle %s\n',
-				bundleFolderName, e
-			);
-			return;
+
+		if (fs.existsSync(bundleCfgPath)) {
+			bundle = parseBundle(bundlePath, bundleCfgPath);
+		} else {
+			bundle = parseBundle(bundlePath);
 		}
 
 		// Check if the bundle is compatible with this version of NodeCG

--- a/lib/bundle-manager.js
+++ b/lib/bundle-manager.js
@@ -147,18 +147,18 @@ module.exports.init = function (bundlesPath, cfgPath, nodecgVersion, nodecgConfi
 		}
 
 		// Prevent attempting to load unwanted directories. Those specified above and all dot-prefixed.
-		if (blacklistedBundleDirectories.indexOf(bundleFolderName) > -1 || bundleFolderName.startsWith('.')) {
+		if (blacklistedBundleDirectories.includes(bundleFolderName) || bundleFolderName.startsWith('.')) {
 			return;
 		}
 
 		if (nodecgConfig && nodecgConfig.bundles && nodecgConfig.bundles.disabled &&
-			nodecgConfig.bundles.disabled.indexOf(bundleFolderName) > -1) {
+			nodecgConfig.bundles.disabled.includes(bundleFolderName)) {
 			log.debug('Not loading bundle ' + bundleFolderName + ' as it is disabled in config');
 			return;
 		}
 
 		if (nodecgConfig && nodecgConfig.bundles && nodecgConfig.bundles.enabled &&
-			nodecgConfig.bundles.enabled.indexOf(bundleFolderName) < 0) {
+			!(nodecgConfig.bundles.enabled.includes(bundleFolderName))) {
 			log.debug('Not loading bundle ' + bundleFolderName + ' as it is not enabled in config');
 			return;
 		}

--- a/test/bundle-manager.js
+++ b/test/bundle-manager.js
@@ -73,7 +73,7 @@ test.serial('loader - should not load a bundle that has been disabled', t => {
 });
 
 test.serial('loader - should not crash or load an invalid bundle', t => {
-	const bundle = bundleManager.find('invalid-bundle');
+	const bundle = bundleManager.find('node_modules');
 	t.is(bundle, undefined);
 });
 

--- a/test/bundle-manager.js
+++ b/test/bundle-manager.js
@@ -72,6 +72,11 @@ test.serial('loader - should not load a bundle that has been disabled', t => {
 	t.is(bundle, undefined);
 });
 
+test.serial('loader - should not crash or load an invalid bundle', t => {
+	const bundle = bundleManager.find('invalid-bundle');
+	t.is(bundle, undefined);
+});
+
 test.cb.serial('watcher - hould emit a change event when the manifest file changes', t => {
 	const manifest = JSON.parse(fs.readFileSync(`${tempFolder}/bundles/change-manifest/package.json`));
 	bundleManager.once('bundleChanged', bundle => {

--- a/test/fixtures/bundle-manager/bundles/node_modules/.empty_directory
+++ b/test/fixtures/bundle-manager/bundles/node_modules/.empty_directory
@@ -1,0 +1,1 @@
+This directory intentionally empty.


### PR DESCRIPTION
Allows irrelevant folders (like `.git`) and invalid bundles to exist in the bundles directory without crashing.
It's likely that the bundle-parser should be logging these errors and returning an undefined bundle instead to avoid using this blind try/catch. That'd mean passing in and constructing a new logger instance each time with the current implementation, though.