### PR TITLE
feat(bundles): Avoid crash when a bundle becomes invalid after a change.

### DIFF
--- a/lib/bundle-manager.js
+++ b/lib/bundle-manager.js
@@ -298,6 +298,7 @@ function _handleChange(bundleName) {
 			emitter.emit('bundleChanged', reparsedBundle);
 		} catch (error) {
 			log.warn('Unable to handle the bundle "%s" change: %s', bundleName, error.message, {error});
+			emitter.emit('invalidBundle', bundle);
 		}
 	}
 }

--- a/lib/bundle-manager.js
+++ b/lib/bundle-manager.js
@@ -284,16 +284,21 @@ function _handleChange(bundleName) {
 		log.debug('Processing change event for', bundleName);
 		resetBackoffTimer();
 
-		let reparsedBundle;
-		const bundleCfgPath = path.join(_cfgPath, `${bundleName}.json`);
-		if (fs.existsSync(bundleCfgPath)) {
-			reparsedBundle = parseBundle(bundle.dir, bundleCfgPath);
-		} else {
-			reparsedBundle = parseBundle(bundle.dir);
-		}
+		try {
+			let reparsedBundle;
+			const bundleCfgPath = path.join(_cfgPath, `${bundleName}.json`);
 
-		module.exports.add(reparsedBundle);
-		emitter.emit('bundleChanged', reparsedBundle);
+			if (fs.existsSync(bundleCfgPath)) {
+				reparsedBundle = parseBundle(bundle.dir, bundleCfgPath);
+			} else {
+				reparsedBundle = parseBundle(bundle.dir);
+			}
+
+			module.exports.add(reparsedBundle);
+			emitter.emit('bundleChanged', reparsedBundle);
+		} catch (error) {
+			log.warn('Unable to handle the bundle "%s" change: %s', bundleName, error.message, {error});
+		}
 	}
 }
 

--- a/test/bundle-manager.js
+++ b/test/bundle-manager.js
@@ -173,3 +173,12 @@ test.cb.serial('watcher - should produce an unhandled exception when a panel HTM
 
 	fs.unlinkSync(`${tempFolder}/bundles/remove-panel/dashboard/panel.html`);
 });
+
+test.cb.serial('watcher - should not throw en error when the bundle becomes invalid', t => {
+	bundleManager.once('invalidBundle', bundle => {
+		t.is(bundle.name, 'invalid-manifest');
+		t.end();
+	});
+
+	fs.writeFileSync(`${tempFolder}/bundles/invalid-manifest/package.json`, 'invalid-manifest');
+});

--- a/test/fixtures/bundle-manager/bundles/invalid-manifest/package.json
+++ b/test/fixtures/bundle-manager/bundles/invalid-manifest/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "invalid-manifest",
+  "version": "1.0.0",
+  "homepage": "http://github.com/nodecg",
+  "author": "Seldszar <contact@seldszar.fr>",
+  "description": "A test bundle that shouldn't throw en error when the bundle becomes invalid",
+  "license": "MIT",
+  "nodecg": {
+    "compatibleRange": "~0.7.0"
+  }
+}


### PR DESCRIPTION
Currently, when a bundle becomes invalid during the execution, the whole application crashes.

By wrapping the change process with a try/catch to contain bundle parsing errors, a warning message will be shown instead of crashing. However, the application will still crash during the first bundle parsing.

Closes #373.