### PR TITLE
Update README to note Java requirement for Selenium

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,8 @@ Please contribute! This is an open source project. If you would like to report a
 4. Push to the branch (`git push origin my-new-feature`)
 5. Create a new Pull Request
 
+Note: Make sure you run `npm install` in the root directory without the `--production` flag to ensure all `devDependencies` are installed.
+
 **Before creating your pull request:**
 
 1. Ensure your code matches our existing style using our provided [EditorConfig](http://editorconfig.org/) options.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,3 +22,5 @@ Check which branch you should PR to. NodeCG is still in an unstable state, so we
 1. Install selenium-standalone (`npm install --global selenium-standalone`), then run the installer (`selenium-standalone install`)
 2. Open one terminal and start Selenium: `selenium-standalone start`
 3. Open a second terminal, navigate to the NodeCG root and run `npm test`
+
+Note: Selenium requires [Java](https://www.java.com/en/download/help/download_options.xml).

--- a/README.md
+++ b/README.md
@@ -236,6 +236,8 @@ Once you've made your changes, follow the steps above in the [Contribute](#contr
 2.  Open one terminal and start Selenium: `selenium-standalone start`
 3.  Open a second terminal, navigate to the NodeCG root and run `npm test`
 
+Note: Selenium requires [Java](https://www.java.com/en/download/help/download_options.xml).
+
 ### Code of Conduct
 
 Note that all contributions and discussions around NodeCG take place under our [Code of Conduct](CODE_OF_CONDUCT.md).

--- a/README.md
+++ b/README.md
@@ -203,6 +203,8 @@ Please contribute! This is an open source project. If you would like to report a
 4.  Push to the branch (`git push origin my-new-feature`)
 5.  Create a new Pull Request
 
+Note: Make sure you run `npm install` in the root directory without the `--production` flag to ensure all `devDependencies` are installed.
+
 **Before creating your pull request:**
 
 1.  Ensure your code matches our existing style using our provided [EditorConfig](http://editorconfig.org/) options.


### PR DESCRIPTION
I was setting up nodecg on my Windows machine and noticed that selenium won't run without Java (something I knew but never thought about since I was using a Mac with Java previously). Since the console error message doesn't explicitly call this out (and even [Selenium's website](http://www.seleniumhq.org/) doesn't make it obvious), I figured it might be nice to include a note in the README and CONTRIBUTE files with a link to Oracle's Java download page.

On a semi-related note, I noticed you encourage people to install nodecg using `npm install --production`. I know it's pretty obvious to anyone who works with npm often that the `--production` flag doesn't install `devDependencies`, but for newcomers I thought it might be nice to either:
1. Just recommend people install using `npm install` on line 68 -- the added footprint isn't all that substantial.
2. In the Contribute section of the README, remind developers to run `npm install` before beginning development -- otherwise they won't be able to run the test suite, for example.

If you like either of those ideas, let me know and I'll update this branch again before it's merged.