### PR TITLE
Added a logger rewriter for correctly serialize metadata objects.

### DIFF
--- a/lib/logger/server.js
+++ b/lib/logger/server.js
@@ -2,6 +2,7 @@
 
 const path = require('path');
 const {format, inspect} = require('util');
+const pick = require('lodash.pick');
 const fs = require('fs.extra');
 const winston = require('winston');
 
@@ -77,6 +78,26 @@ module.exports = function (initialOpts, Raven) {
 			warn: 1,
 			error: 0
 		}
+	});
+
+	mainLogger.rewriters.push((level, msg, meta) => {
+		const replacer = (key, value) => {
+			if (typeof value === 'object' && typeof value.toJSON === 'undefined') {
+				let propertyNames = [];
+				let target = value;
+
+				do {
+					propertyNames = propertyNames.concat(Object.getOwnPropertyNames(target));
+					target = Object.getPrototypeOf(target);
+				} while (target);
+
+				return pick(value, propertyNames);
+			}
+
+			return value;
+		};
+
+		return JSON.stringify(meta, replacer, 2);
 	});
 
 	/**

--- a/lib/logger/server.js
+++ b/lib/logger/server.js
@@ -2,9 +2,9 @@
 
 const path = require('path');
 const {format, inspect} = require('util');
-const pick = require('lodash.pick');
 const fs = require('fs.extra');
 const winston = require('winston');
+const {serializeObject} = require('../util');
 
 /**
  * Enum logging level values.
@@ -81,23 +81,11 @@ module.exports = function (initialOpts, Raven) {
 	});
 
 	mainLogger.rewriters.push((level, msg, meta) => {
-		const replacer = (key, value) => {
-			if (typeof value === 'object' && typeof value.toJSON === 'undefined') {
-				let propertyNames = [];
-				let target = value;
+		if (Object.keys(meta).length === 0 && meta.constructor === Object) {
+			return null;
+		}
 
-				do {
-					propertyNames = propertyNames.concat(Object.getOwnPropertyNames(target));
-					target = Object.getPrototypeOf(target);
-				} while (target);
-
-				return pick(value, propertyNames);
-			}
-
-			return value;
-		};
-
-		return JSON.stringify(meta, replacer, 2);
+		return JSON.stringify(meta, (key, value) => (typeof value === 'object' ? serializeObject(value) : value), 2);
 	});
 
 	/**

--- a/lib/util/index.js
+++ b/lib/util/index.js
@@ -3,5 +3,6 @@
 module.exports = {
 	authCheck: require('./authcheck'),
 	injectScripts: require('./injectscripts'),
-	debounceName: require('./debounce-name')
+	debounceName: require('./debounce-name'),
+	serializeObject: require('./serialize-object')
 };

--- a/lib/util/serialize-object.js
+++ b/lib/util/serialize-object.js
@@ -1,0 +1,25 @@
+'use strict';
+
+const pick = require('lodash.pick');
+
+/**
+ * Return the object properties, including the inherited ones.
+ *
+ * @param {object} object The object.
+ * @return {Array<string>}
+ */
+module.exports = function (object) {
+	if (typeof object.toJSON === 'undefined') {
+		let propertyNames = [];
+		let target = object;
+
+		do {
+			propertyNames = propertyNames.concat(Object.getOwnPropertyNames(target));
+			target = Object.getPrototypeOf(target);
+		} while (target);
+
+		return pick(object, propertyNames);
+	}
+
+	return object;
+};

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "json-schema-defaults": "^0.3.0",
     "json-schema-lib": "github:Lange/json-schema-lib#ac59fe29fad5c54647e4c483c7255a923cc430dd",
     "lodash.debounce": "^4.0.8",
+    "lodash.pick": "^4.4.0",
     "make-fetch-happen": "^2.6.0",
     "minimist": "^1.2.0",
     "multer": "^1.3.0",


### PR DESCRIPTION
The following change allows objects without a `toJSON` method being correctly serialized. For example, an `Error` object will return `{}` instead of showing the various properties (name, message, stack, etc), making the logging entry unhelpful.

The algorithm will walk through prototypes to collect all the inherited properties and build a plain object with them.