### PR TITLE
Make nodecg-dialog attribute work inside of a shadow DOM

### DIFF
--- a/src/dashboard/js/dialog_opener.js
+++ b/src/dashboard/js/dialog_opener.js
@@ -2,7 +2,7 @@
 document.addEventListener('click', e => {
 	'use strict';
 
-	const elWithDialogAttr = e.target.closest('[nodecg-dialog]');
+	const elWithDialogAttr = e.composedPath()[0].closest('[nodecg-dialog]');
 	if (elWithDialogAttr) {
 		const dialogName = elWithDialogAttr.getAttribute('nodecg-dialog');
 		const dialogIg = nodecg.bundleName + '_' + dialogName;


### PR DESCRIPTION
If the source of the click was located inside a shadow DOM, `e.target` returns the outside element, so the `nodecg-dialog` attribute cannot be found.
According to https://www.polymer-project.org/2.0/docs/devguide/events#retargeting, we can get the original target for the event.