### PR TITLE
Always send 'dialog-dismissed' when clicking outside the dialog

### DIFF
--- a/src/dashboard/elements/ncg-dialog.js
+++ b/src/dashboard/elements/ncg-dialog.js
@@ -109,7 +109,7 @@ class NcgDialog extends Polymer.mixinBehaviors([
 
 	_onIronOverlayClosed(e) {
 		const iframeDocument = this.querySelector('iframe').contentDocument;
-		if (e.detail.confirmed) {
+		if (e.detail.confirmed && !e.detail.canceled) {
 			iframeDocument.dispatchEvent(new CustomEvent('dialog-confirmed'));
 		} else {
 			iframeDocument.dispatchEvent(new CustomEvent('dialog-dismissed'));


### PR DESCRIPTION
Open a dialog and then click the confirm button.
Then reopen that dialog, but this time cancel it by clicking outside.
Then the `dialog-confirmed` message is send.

In my case I want to do a destructive operation on confirmation, so clicking outside should imho always result in dismissing the dialog.

This is due to setting the 
When clicking the dialog-confirm button `closingReasonConfirmed` of the dialog is set to `true` (https://github.com/nodecg/nodecg/blob/master/src/dashboard/js/dialog_helper.js#L17)  but not reset once the dialog is opened again.

My proposed fix is to test that the dialog is not canceled before send the `dialog-confirmed` event.