### PR TITLE
Fix 'can't set headers after they are sent' error spam

### DIFF
--- a/lib/dashboard.js
+++ b/lib/dashboard.js
@@ -108,8 +108,9 @@ app.get('/bundles/:bundleName/dashboard/*', ncgUtils.authCheck, (req, res, next)
 					return res.sendStatus(404);
 				}
                 
-                if (!res.headersSent)
+                if (!res.headersSent) {
 				    return next();
+				}
 			}
 		});
 	}

--- a/lib/dashboard.js
+++ b/lib/dashboard.js
@@ -108,8 +108,8 @@ app.get('/bundles/:bundleName/dashboard/*', ncgUtils.authCheck, (req, res, next)
 					return res.sendStatus(404);
 				}
                 
-                if (!res.headersSent) {
-				    return next();
+				if (!res.headersSent) {
+					return next();
 				}
 			}
 		});

--- a/lib/dashboard.js
+++ b/lib/dashboard.js
@@ -64,7 +64,7 @@ if (process.env.NODECG_TEST || configHelper.config.developer) {
 			const fp = path.join(INSTRUMENTED_PATH, resName);
 			if (fs.existsSync(fp)) {
 				return res.sendFile(fp, err => {
-					if (err) {
+					if (err && !res.headersSent) {
 						return next();
 					}
 				});
@@ -107,8 +107,9 @@ app.get('/bundles/:bundleName/dashboard/*', ncgUtils.authCheck, (req, res, next)
 				if (err.code === 'ENOENT') {
 					return res.sendStatus(404);
 				}
-
-				return next();
+                
+                if (!res.headersSent)
+				    return next();
 			}
 		});
 	}

--- a/lib/graphics/index.js
+++ b/lib/graphics/index.js
@@ -66,7 +66,8 @@ app.get('/bundles/:bundleName/graphics*', ncgUtils.authCheck, (req, res, next) =
 					return res.sendStatus(404);
 				}
 
-				return next();
+                if (!res.headersSent)
+				    return next();
 			}
 		});
 	}
@@ -90,7 +91,8 @@ app.get('/bundles/:bundleName/:target(bower_components|node_modules)/*', (req, r
 				return res.sendStatus(404);
 			}
 
-			return next();
+            if (!res.headersSent)
+			    return next();
 		}
 	});
 });

--- a/lib/graphics/index.js
+++ b/lib/graphics/index.js
@@ -66,8 +66,9 @@ app.get('/bundles/:bundleName/graphics*', ncgUtils.authCheck, (req, res, next) =
 					return res.sendStatus(404);
 				}
 
-                if (!res.headersSent)
-				    return next();
+				if (!res.headersSent) {
+					return next();
+				}
 			}
 		});
 	}
@@ -91,8 +92,9 @@ app.get('/bundles/:bundleName/:target(bower_components|node_modules)/*', (req, r
 				return res.sendStatus(404);
 			}
 
-            if (!res.headersSent)
-			    return next();
+			if (!res.headersSent) {
+				return next();
+			}
 		}
 	});
 });

--- a/lib/graphics/single_instance/index.js
+++ b/lib/graphics/single_instance/index.js
@@ -77,8 +77,8 @@ app.get('/instance/*', (req, res, next) => {
 					return res.sendStatus(404);
 				}
 
-                if (!res.headersSent) {
-				    return next();
+				if (!res.headersSent) {
+					return next();
 				}
 			}
 		});

--- a/lib/graphics/single_instance/index.js
+++ b/lib/graphics/single_instance/index.js
@@ -77,7 +77,8 @@ app.get('/instance/*', (req, res, next) => {
 					return res.sendStatus(404);
 				}
 
-				return next();
+                if (!res.headersSent)
+				    return next();
 			}
 		});
 	}

--- a/lib/graphics/single_instance/index.js
+++ b/lib/graphics/single_instance/index.js
@@ -77,8 +77,9 @@ app.get('/instance/*', (req, res, next) => {
 					return res.sendStatus(404);
 				}
 
-                if (!res.headersSent)
+                if (!res.headersSent) {
 				    return next();
+				}
 			}
 		});
 	}

--- a/lib/mounts.js
+++ b/lib/mounts.js
@@ -22,8 +22,9 @@ all.forEach(bundle => {
 						return res.sendStatus(404);
 					}
 
-                    if (!res.headersSent)
+                    if (!res.headersSent) {
 					    return next();
+					}
 				}
 			});
 		});

--- a/lib/mounts.js
+++ b/lib/mounts.js
@@ -22,7 +22,8 @@ all.forEach(bundle => {
 						return res.sendStatus(404);
 					}
 
-					return next();
+                    if (!res.headersSent)
+					    return next();
 				}
 			});
 		});

--- a/lib/mounts.js
+++ b/lib/mounts.js
@@ -22,8 +22,8 @@ all.forEach(bundle => {
 						return res.sendStatus(404);
 					}
 
-                    if (!res.headersSent) {
-					    return next();
+					if (!res.headersSent) {
+						return next();
 					}
 				}
 			});

--- a/lib/shared-sources.js
+++ b/lib/shared-sources.js
@@ -32,8 +32,8 @@ app.get('/bundles/:bundleName/shared/*', ncgUtils.authCheck, (req, res, next) =>
 				return res.sendStatus(404);
 			}
 
-            if (!res.headersSent) {
-			    return next();
+			if (!res.headersSent) {
+				return next();
 			}
 		}
 	});

--- a/lib/shared-sources.js
+++ b/lib/shared-sources.js
@@ -32,7 +32,8 @@ app.get('/bundles/:bundleName/shared/*', ncgUtils.authCheck, (req, res, next) =>
 				return res.sendStatus(404);
 			}
 
-			return next();
+            if (!res.headersSent)
+			    return next();
 		}
 	});
 });

--- a/lib/shared-sources.js
+++ b/lib/shared-sources.js
@@ -32,8 +32,9 @@ app.get('/bundles/:bundleName/shared/*', ncgUtils.authCheck, (req, res, next) =>
 				return res.sendStatus(404);
 			}
 
-            if (!res.headersSent)
+            if (!res.headersSent) {
 			    return next();
+			}
 		}
 	});
 });


### PR DESCRIPTION
The 'can't set headers after they are sent' error is not only annoying, it also got many sources of how it can happen. This just fixes one of them across the entire codebase, there might be more.

In our NodeCG production use (ZeldaSpeedRuns) this error frequently occurred when large files were being served over express, in this case music files. As it turns out with very large files the browser quickly cancels the request after receiving note about the filesize, then repeats the same request with streaming flags set so the file is being streamed instead. Cancellation of res.sendFile on the browser side triggers an error code on the express side of things and in this case it's obviously not a "404: File not found" error.

Currently this means NodeCG calls the next() function which allows express to try other routes and possibly does another response as a result. In the case of the client abort error, the headers have already been set, thus calling the next() function for the same request is 'illegal' since later on it will attempt to set the headers again for the new response if there is one.

This fix is simple: In every instance res.sendFile is used, we check if the headers have already been set before calling the next() function if an error occured. If they have, calling next() serves no purpose and would only generate said error, so we avoid it. If they have not been set, then the error occurred before headers could be set so it's still safe to call next().

After deploying this fix the spam stopped for us completely and I could not notice any regressions.