### PR TITLE
fix(bundles): avoid throwing exception on Unicode BOM

### DIFF
--- a/lib/bundle-parser/panels.js
+++ b/lib/bundle-parser/panels.js
@@ -56,7 +56,11 @@ module.exports = function (dashboardDir, bundle) {
 			throw new Error(`Panel file "${panel.file}" in bundle "${bundle.name}" does not exist.`);
 		}
 
-		const $ = cheerio.load(fs.readFileSync(filePath));
+		// This fixes some harder to spot issues with Unicode Byte Order Markings in dashboard HTML.
+		const panelBuf = fs.readFileSync(filePath);
+		const cheerioBuf = Buffer.from(panelBuf.toString().trim());
+
+		const $ = cheerio.load(cheerioBuf);
 
 		// We used to need to check for a <head> tag, but modern versions of Cheerio add this for us automatically!
 

--- a/lib/bundle-parser/panels.js
+++ b/lib/bundle-parser/panels.js
@@ -57,10 +57,8 @@ module.exports = function (dashboardDir, bundle) {
 		}
 
 		// This fixes some harder to spot issues with Unicode Byte Order Markings in dashboard HTML.
-		const panelBuf = fs.readFileSync(filePath);
-		const cheerioBuf = Buffer.from(panelBuf.toString().trim());
-
-		const $ = cheerio.load(cheerioBuf);
+		const panelStr = fs.readFileSync(filePath, 'utf8');
+		const $ = cheerio.load(panelStr.trim());
 
 		// We used to need to check for a <head> tag, but modern versions of Cheerio add this for us automatically!
 

--- a/test/bundle-parser/panels.js
+++ b/test/bundle-parser/panels.js
@@ -37,6 +37,11 @@ test('when a panel\'s file has no <!DOCTYPE>, throw an error', t => {
 	t.true(error.message.includes('has no DOCTYPE'));
 });
 
+test('when a panel\'s file has a BOM before it\'s <!DOCTYPE>, continue to parse it', t => {
+	const parsedBundle = parseBundle('./test/fixtures/bundle-parser/bom-doctype');
+	t.true(Array.isArray(parsedBundle.dashboard.panels));
+});
+
 test('when a panel\'s file does not exist, throw an error', t => {
 	const error = t.throws(parseBundle.bind(parseBundle, './test/fixtures/bundle-parser/non-existant-panel'));
 	t.true(error.message.includes(' does not exist'));

--- a/test/bundle-parser/parser.js
+++ b/test/bundle-parser/parser.js
@@ -49,7 +49,7 @@ test('should return the expected data when "nodecg" property does exist', t => {
 			path: path.resolve(__dirname, '../fixtures/bundle-parser/good-bundle/dashboard/panel.html'),
 			file: 'panel.html',
 			html: '<!DOCTYPE html><html><head></head>\n<body>\n<p>This is a test panel!</p>\n<script>' +
-			'\n    window.parent.dashboardApi = window.nodecg;\n</script>\n\n</body></html>',
+			'\n    window.parent.dashboardApi = window.nodecg;\n</script>\n</body></html>',
 			dialog: false,
 			bundleName: 'good-bundle',
 			workspace: 'default',
@@ -63,7 +63,7 @@ test('should return the expected data when "nodecg" property does exist', t => {
 			path: path.resolve(__dirname, '../fixtures/bundle-parser/good-bundle/dashboard/workspace-panel.html'),
 			file: 'workspace-panel.html',
 			html: '<!DOCTYPE html><html><head></head>\n<body>\n<p>This is a test panel that goes into a test ' +
-			'workspace!</p>\n\n</body></html>',
+			'workspace!</p>\n</body></html>',
 			dialog: false,
 			bundleName: 'good-bundle',
 			workspace: 'foo',
@@ -76,7 +76,7 @@ test('should return the expected data when "nodecg" property does exist', t => {
 			headerColor: '#9f9bbd',
 			path: path.resolve(__dirname, '../fixtures/bundle-parser/good-bundle/dashboard/fullbleed-panel.html'),
 			file: 'fullbleed-panel.html',
-			html: '<!DOCTYPE html><html><head></head>\n<body>\n<p>This is a test fullbleed panel!</p>\n\n</body></html>',
+			html: '<!DOCTYPE html><html><head></head>\n<body>\n<p>This is a test fullbleed panel!</p>\n</body></html>',
 			dialog: false,
 			bundleName: 'good-bundle',
 			fullbleed: true,
@@ -89,7 +89,7 @@ test('should return the expected data when "nodecg" property does exist', t => {
 			headerColor: '#333222',
 			path: path.resolve(__dirname, '../fixtures/bundle-parser/good-bundle/dashboard/dialog.html'),
 			file: 'dialog.html',
-			html: '<!DOCTYPE html><html><head></head>\n<body>\n<p>This is a test dialog!</p>\n\n</body></html>',
+			html: '<!DOCTYPE html><html><head></head>\n<body>\n<p>This is a test dialog!</p>\n</body></html>',
 			dialog: true,
 			bundleName: 'good-bundle',
 			fullbleed: false

--- a/test/fixtures/bundle-parser/bom-doctype/dashboard/panel.html
+++ b/test/fixtures/bundle-parser/bom-doctype/dashboard/panel.html
@@ -1,0 +1,8 @@
+﻿<!DOCTYPE html>
+<head></head>
+<body>
+<p>This is a test panel!</p>
+<script>
+    window.parent.dashboardApi = window.nodecg;
+</script>
+</body>

--- a/test/fixtures/bundle-parser/bom-doctype/package.json
+++ b/test/fixtures/bundle-parser/bom-doctype/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "bom-doctype",
+  "version": "0.0.1",
+  "homepage": "http://github.com/nodecg",
+  "author": [
+    "Karen West <atribecalledkwest.97@gmail.com>"
+  ],
+  "description": "A test bundle",
+  "license": "MIT",
+  "nodecg": {
+    "compatibleRange": "~0.7.0",
+    "dashboardPanels": [
+      {
+        "name": "test",
+        "title": "Test Panel",
+        "width": 1,
+        "file": "panel.html"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Byte Order Marks are pretty rare, but sometimes they show up at the beginning of the dashboard panel HTML. This causes Cheerio to assume it to be an HTML entity and spit out some incorrect HTML, even if a Doctype is specified.