### PR TITLE
Fix "can't set headers..." error/crash when serving certain assets

### DIFF
--- a/lib/assets/index.js
+++ b/lib/assets/index.js
@@ -176,7 +176,6 @@ app.get(
 				if (err.code === 'ENOENT') {
 					return res.sendStatus(404);
 				}
-				
 				log.error(`Unexpected error sending file ${fullPath}`, err);
 				res.sendStatus(500);
 			}

--- a/lib/assets/index.js
+++ b/lib/assets/index.js
@@ -176,10 +176,6 @@ app.get(
 				if (err.code === 'ENOENT') {
 					return res.sendStatus(404);
 				}
-
-				if (!res.headersSent) {
-					return next();
-				}
 				
 				log.error(`Unexpected error sending file ${fullPath}`, err);
 				res.sendStatus(500);

--- a/lib/assets/index.js
+++ b/lib/assets/index.js
@@ -172,7 +172,7 @@ app.get(
 	(req, res) => {
 		const fullPath = path.join(ASSETS_ROOT, req.params.namespace, req.params.category, req.params.filePath);
 		res.sendFile(fullPath, err => {
-			if (err) {
+			if (err && !res.headersSent) {
 				if (err.code === 'ENOENT') {
 					return res.sendStatus(404);
 				}

--- a/lib/assets/index.js
+++ b/lib/assets/index.js
@@ -176,6 +176,11 @@ app.get(
 				if (err.code === 'ENOENT') {
 					return res.sendStatus(404);
 				}
+
+				if (!res.headersSent) {
+					return next();
+				}
+				
 				log.error(`Unexpected error sending file ${fullPath}`, err);
 				res.sendStatus(500);
 			}


### PR DESCRIPTION
Similar to #387 but it seems as if they left out the part where the assets are served from. Without this, I was getting errors when I was streaming videos when the video ended or was paused, or I closed the page.

This seemed to be a combination error where you would get `ECANCELED` or `ECONNABORTED` when the video ended/closed, but the headers were already sent, so when it tried to do `res.sendStatus(500)`, it would crash with the `can't set headers after they are sent` error.

I'm not sure if the `return next()` part is needed, but this was used in the other PR so might help here in some circumstances?