### PR TITLE
Update our passport-twitch strategy to use the New Twitch API

### DIFF
--- a/lib/login/index.js
+++ b/lib/login/index.js
@@ -35,12 +35,12 @@ if (config.login.steam && config.login.steam.enabled) {
 }
 
 if (config.login.twitch && config.login.twitch.enabled) {
-	const TwitchStrategy = require('passport-twitch').Strategy;
+	const TwitchStrategy = require('passport-twitch-helix').Strategy;
 
-	// The "user_read" scope is required. Add it if not present.
+	// The "user:read:email" scope is required. Add it if not present.
 	let scope = config.login.twitch.scope.split(' ');
-	if (scope.indexOf('user_read') < 0) {
-		scope.push('user_read');
+	if (scope.indexOf('user:read:email') < 0) {
+		scope.push('user:read:email');
 	}
 	scope = scope.join(' ');
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -16624,9 +16624,9 @@
 			"integrity": "sha1-tVOaqPwiWj0a0XlHbd8ja0QPUuQ="
 		},
 		"passport-twitch-helix": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/passport-twitch-helix/-/passport-twitch-helix-1.0.4.tgz",
-			"integrity": "sha512-wiDoc5/60/KtvN/YId8fu5IyzjQ8VvwXRlyypm4Kxlg6WYG57hHBZ5yFUjvWpUdDSTaKOKVcaTsV9Hu6zEy2aA==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/passport-twitch-helix/-/passport-twitch-helix-1.1.0.tgz",
+			"integrity": "sha512-8tItfW3w73ADcdwTcf3UdMfHu0VgtBj6xqvyP2SX8GrTDVJzGqpYUfI7XgFp/GwTT9DH1l1msVmhxr3442VIEw==",
 			"requires": {
 				"passport-oauth2": "^1.1.2",
 				"pkginfo": "0.2.x"
@@ -21941,9 +21941,9 @@
 			}
 		},
 		"utils-merge": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
-			"integrity": "sha1-ApT7kiu5N1FTVBxPcJYjHyh8ivg="
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+			"integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
 		},
 		"uuid": {
 			"version": "3.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16623,10 +16623,10 @@
 			"resolved": "https://registry.npmjs.org/passport-strategy/-/passport-strategy-1.0.0.tgz",
 			"integrity": "sha1-tVOaqPwiWj0a0XlHbd8ja0QPUuQ="
 		},
-		"passport-twitch": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/passport-twitch/-/passport-twitch-1.0.3.tgz",
-			"integrity": "sha1-gqSh++GTaNROYvBX6TxBSp1P58w=",
+		"passport-twitch-helix": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/passport-twitch-helix/-/passport-twitch-helix-1.0.4.tgz",
+			"integrity": "sha512-wiDoc5/60/KtvN/YId8fu5IyzjQ8VvwXRlyypm4Kxlg6WYG57hHBZ5yFUjvWpUdDSTaKOKVcaTsV9Hu6zEy2aA==",
 			"requires": {
 				"passport-oauth2": "^1.1.2",
 				"pkginfo": "0.2.x"

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "passport": "^0.4.0",
     "passport-local": "^1.0.0",
     "passport-steam": "^1.0.10",
-    "passport-twitch-helix": "^1.0.4",
+    "passport-twitch-helix": "^1.1",
     "pug": "^2.0.0-rc.4",
     "raven": "^2.2.1",
     "semver": "^5.4.1",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "passport": "^0.4.0",
     "passport-local": "^1.0.0",
     "passport-steam": "^1.0.10",
-    "passport-twitch": "^1.0.3",
+    "passport-twitch-helix": "^1.0.4",
     "pug": "^2.0.0-rc.4",
     "raven": "^2.2.1",
     "semver": "^5.4.1",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "passport": "^0.4.0",
     "passport-local": "^1.0.0",
     "passport-steam": "^1.0.10",
-    "passport-twitch-helix": "^1.1",
+    "passport-twitch-helix": "^1.1.0",
     "pug": "^2.0.0-rc.4",
     "raven": "^2.2.1",
     "semver": "^5.4.1",

--- a/tutorials/nodecg-configuration.md
+++ b/tutorials/nodecg-configuration.md
@@ -34,7 +34,7 @@ NodeCG is configured via a `cfg/nodecg.json` file with the following schema:
     - `clientID` _String_ A Twitch application ClientID [http://twitch.tv/kraken/oauth2/clients/new](http://twitch.tv/kraken/oauth2/clients/new)
     - `clientSecret` _String_ A Twitch application ClientSecret [http://twitch.tv/kraken/oauth2/clients/new](http://twitch.tv/kraken/oauth2/clients/new)
     - _Note:_ Configure your Twitch OAuth credentials with a Redirect URI to `{baseURL}/login/auth/twitch`
-    - `scope` _String_ A space-separated string of Twitch application [permissions](https://dev.twitch.tv/docs/v5/guides/authentication/#scopes).
+    - `scope` _String_ A space-separated string of Twitch application [permissions](https://dev.twitch.tv/docs/authentication/#scopes).
     - `allowedUsernames` _Array of strings_ Which Twitch usernames to allow.
 - `ssl` _Object_ Contains HTTPS/SSL configuration properties.
     - `enabled` _Boolean_ Whether to enable SSL/HTTPS encryption.


### PR DESCRIPTION
Twitch now has it's new "New Twitch API", and the Kraken endpoints are going to be taken offline at some point in 2019 (originally slated for the end of 2018). We might as well update these login methods as soon as possible.

I published the renamed module on npm, but perhaps it would be more sane to do as before with the json schema module and simply fork it on github and reference the specific commit (I could transfer the repo over to the NodeCG organization if that's preferred).

Also, I don't know if this is considered a breaking change, considering how the new API requires a different scope (`user:read:email` vs `user_read`), so input on that would be useful as I don't know the ins and outs of the SemVer spec.