### PR TITLE
fix: load extensions before internal libs

### DIFF
--- a/lib/server/index.js
+++ b/lib/server/index.js
@@ -217,6 +217,25 @@ module.exports.start = function () {
 		module.exports.emit('error', err);
 	});
 
+	// Set up "bundles" Replicant.
+	const Replicant = require('../replicant');
+	const bundlesReplicant = new Replicant('bundles', 'nodecg', {
+		schemaPath: path.resolve(__dirname, '../../schemas/bundles.json'),
+		persistent: false
+	});
+	const updateBundlesReplicant = debounce(() => {
+		bundlesReplicant.value = clone(bundleManager.all());
+	}, 100);
+	bundleManager.on('init', updateBundlesReplicant);
+	bundleManager.on('bundleChanged', updateBundlesReplicant);
+	bundleManager.on('gitChanged', updateBundlesReplicant);
+	bundleManager.on('bundleRemoved', updateBundlesReplicant);
+	updateBundlesReplicant();
+
+	extensionManager = require('./extensions.js');
+	extensionManager.init();
+	module.exports.emit('extensionsLoaded');
+
 	log.trace('Starting graphics lib');
 	const graphics = require('../graphics');
 	app.use(graphics);
@@ -240,25 +259,6 @@ module.exports.start = function () {
 	log.trace('Starting bundle shared sources lib');
 	const sharedSources = require('../shared-sources');
 	app.use(sharedSources);
-
-	// Set up "bundles" Replicant.
-	const Replicant = require('../replicant');
-	const bundlesReplicant = new Replicant('bundles', 'nodecg', {
-		schemaPath: path.resolve(__dirname, '../../schemas/bundles.json'),
-		persistent: false
-	});
-	const updateBundlesReplicant = debounce(() => {
-		bundlesReplicant.value = clone(bundleManager.all());
-	}, 100);
-	bundleManager.on('init', updateBundlesReplicant);
-	bundleManager.on('bundleChanged', updateBundlesReplicant);
-	bundleManager.on('gitChanged', updateBundlesReplicant);
-	bundleManager.on('bundleRemoved', updateBundlesReplicant);
-	updateBundlesReplicant();
-
-	extensionManager = require('./extensions.js');
-	extensionManager.init();
-	module.exports.emit('extensionsLoaded');
 
 	// We intentionally wait until all bundles and extensions are loaded before starting the server.
 	// This has two benefits:


### PR DESCRIPTION
Allows extensions to override our Express routes.

Upgrading some bundles from 0.8 to 1.1 and my webpack dev setup has broken since our libs return a 404 when a file isn't found on disk.
My dev setup runs webpack-dev-server in an extension and overrides the dashboard/graphics routes (now much easier with everything under `/bundles/{bundle.name}` !) to serve it's own in-memory build results.