### PR TITLE
Doc change - fails w/ nodejs <= v8.2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ without writing any code may be disappointed.
 
 ## Install
 
-Install [Node.js (version 8 or greater) & npm (version 2 or greater)](http://nodejs.org/).  
+Install [Node.js (version 8.3 or greater) & npm (version 2 or greater)](http://nodejs.org/).  
 
 Then, run the following commands from a terminal (command prompt):
 


### PR DESCRIPTION
Tiny documentation update because I discovered that the current version of NodeCG doesn't work in nodejs 8.2.1 or below.  It looks like they didn't land object spread properties until 8.3, which is used in /lib/graphics/registration.js (which is what threw the exception) and potentially elsewhere.  Everything seems ok with 8.3.