### PR TITLE
chore: unify Node.js version check

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,9 +18,11 @@ if (!process.env.NODECG_ROOT) {
 }
 
 const semver = require('semver');
+const {engines} = require('./package.json');
 const nodeVersion = process.versions.node;
-if (!semver.satisfies(nodeVersion, '>=8.3')) {
-	console.error('ERROR: NodeCG requires Node.js >=8.3 and npm >=2');
+
+if (!semver.satisfies(nodeVersion, engines.node)) {
+	console.error(`ERROR: NodeCG requires Node.js ${engines.node}`);
 	console.error(`       Your Node.js version: v${nodeVersion}`);
 	process.exit(1);
 }

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "all": true
   },
   "engines": {
-    "node": ">= 4.1.2"
+    "node": ">=8.3.0"
   },
   "files": [
     "AUTHORS",


### PR DESCRIPTION
A simple change in order to unify Node.js version check across npm and at launch by moving the semver pattern into the `package.json` file.