### PR TITLE
chore(releases): tag release for github; master build release npm nodecg@next

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,34 +1,46 @@
 sudo: false
 dist: trusty
-
 language: node_js
-
 node_js:
-  - '8'
-  - '10'
-
+- '8'
+- '10'
 os:
-  - linux
-
+- linux
 cache:
-   directories:
-     - bower_components
-     - '$HOME/.npm'
-     - $(npm config get prefix)
-
+  directories:
+  - bower_components
+  - "$HOME/.npm"
+  - "$(npm config get prefix)"
 before_install:
-  - npm install -g codecov bower
-
+- npm install -g codecov bower
 install:
-  - npm install
-  - bower install
-
+- npm install
+- bower install
 after_success: npm run report-coverage
-
+before_deploy:
+- mv $(npm pack 2>/dev/null) nodecg-${TRAVIS_TAG}.tgz
+deploy:
+  - provider: releases
+    api_key:
+      secure: ph/2keCTbmoaCIFhBZE65Tj1DcRHf3U+Dk3KSVZOOR29NbI3tkwpoLjl0OQpeLtHqgu76L/W+B1ZFGQbegjHRCYOz6bvzLxe37c0p0FNmt+rWnyHAtri9O4iPObgsGX7t2+A2Qehq0NgM6KkjSQRRYpfF+Vx1S5+grTXY/lm/cI=
+    file: nodecg-${TRAVIS_TAG}.tgz
+    skip_cleanup: true
+    on:
+      tags: true
+      repo: nodecg/nodecg
+  - provider: npm
+    email:
+      secure: VAevo66XIzgA9mbhQhnouv101W7HVhHGvohxmJtGadGL/kwVuMZcYp5nG3IwuetYDpjCmRTY0My13HRBG7ciVg7CW+Wx/raLmST09QokEtvIcvLwGBmxBjR37UnU/SD65XjgAqM+sNPoCTe6vxaJVoInR8uNxdi6IsYiOE9wlmE=
+    api_key:
+      secure: MwR9W8ositdbBKRVg+oV7vUK43Gcs8eCZNSJejVAAk+rLZuwkpr9DPR6I5Crh6/8IblHD87xI90DPN5BGf0BJRzwVxeJWCuLaOwO5eUmqlXSrJt3VAoGDkxYzh2nm92CLnek6PxdeoZwqap2wDKUBoPh+Je7uZucgtRU27x7sUc=
+    skip_cleanup: true
+    tag: next
+    on:
+      branch: master
 notifications:
   webhooks:
     urls:
-      - https://webhooks.gitter.im/e/8c1769bff63cbd033bf7
+    - https://webhooks.gitter.im/e/8c1769bff63cbd033bf7
     on_success: always
     on_failure: always
     on_start: never

--- a/package.json
+++ b/package.json
@@ -102,12 +102,16 @@
     "node": ">=8.3.0"
   },
   "files": [
+    "build",
+    "bundles",
+    "db",
+    "lib",
+    "schemas",
+    "src",
+    "types",
     "AUTHORS",
-    "LICENSE",
-    "README.md",
     "bower.json",
-    "index.js",
-    "lib/"
+    "package-lock.json"
   ],
   "pkg": {
     "assets": [


### PR DESCRIPTION
This PR enables 2 CD jobs
- When a tag is pushed, pack the NodeCG into a tarball and create GitHub release.
- When a commit is pushed, publish to npm with `next` tag.