### PR TITLE
chore(CI): use travis build stages for releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,26 +17,30 @@ install:
 - npm install
 - bower install
 after_success: npm run report-coverage
-before_deploy:
-- mv $(npm pack 2>/dev/null) nodecg-${TRAVIS_TAG}.tgz
-deploy:
-  - provider: releases
-    api_key:
-      secure: ph/2keCTbmoaCIFhBZE65Tj1DcRHf3U+Dk3KSVZOOR29NbI3tkwpoLjl0OQpeLtHqgu76L/W+B1ZFGQbegjHRCYOz6bvzLxe37c0p0FNmt+rWnyHAtri9O4iPObgsGX7t2+A2Qehq0NgM6KkjSQRRYpfF+Vx1S5+grTXY/lm/cI=
-    file: nodecg-${TRAVIS_TAG}.tgz
-    skip_cleanup: true
-    on:
-      tags: true
-      repo: nodecg/nodecg
-  - provider: npm
-    email:
-      secure: VAevo66XIzgA9mbhQhnouv101W7HVhHGvohxmJtGadGL/kwVuMZcYp5nG3IwuetYDpjCmRTY0My13HRBG7ciVg7CW+Wx/raLmST09QokEtvIcvLwGBmxBjR37UnU/SD65XjgAqM+sNPoCTe6vxaJVoInR8uNxdi6IsYiOE9wlmE=
-    api_key:
-      secure: MwR9W8ositdbBKRVg+oV7vUK43Gcs8eCZNSJejVAAk+rLZuwkpr9DPR6I5Crh6/8IblHD87xI90DPN5BGf0BJRzwVxeJWCuLaOwO5eUmqlXSrJt3VAoGDkxYzh2nm92CLnek6PxdeoZwqap2wDKUBoPh+Je7uZucgtRU27x7sUc=
-    skip_cleanup: true
-    tag: next
-    on:
-      branch: master
+jobs:
+  include:
+  - stage: "NPM Release @next"
+    if: type = push # add master later
+    script: skip
+    deploy:
+    - provider: npm
+      tag: next
+      email:
+        secure: VAevo66XIzgA9mbhQhnouv101W7HVhHGvohxmJtGadGL/kwVuMZcYp5nG3IwuetYDpjCmRTY0My13HRBG7ciVg7CW+Wx/raLmST09QokEtvIcvLwGBmxBjR37UnU/SD65XjgAqM+sNPoCTe6vxaJVoInR8uNxdi6IsYiOE9wlmE=
+      api_key:
+        secure: MwR9W8ositdbBKRVg+oV7vUK43Gcs8eCZNSJejVAAk+rLZuwkpr9DPR6I5Crh6/8IblHD87xI90DPN5BGf0BJRzwVxeJWCuLaOwO5eUmqlXSrJt3VAoGDkxYzh2nm92CLnek6PxdeoZwqap2wDKUBoPh+Je7uZucgtRU27x7sUc=
+      skip_cleanup: true
+  - stage: "GitHub Release"
+    if: type = push AND tag IS present
+    script: skip
+    before_deploy:
+    - mv $(npm pack 2>/dev/null) "nodecg-${TRAVIS_TAG}.tgz"
+    deploy:
+    - provider: releases
+      api_key:
+        secure: ph/2keCTbmoaCIFhBZE65Tj1DcRHf3U+Dk3KSVZOOR29NbI3tkwpoLjl0OQpeLtHqgu76L/W+B1ZFGQbegjHRCYOz6bvzLxe37c0p0FNmt+rWnyHAtri9O4iPObgsGX7t2+A2Qehq0NgM6KkjSQRRYpfF+Vx1S5+grTXY/lm/cI=
+      file: "nodecg-${TRAVIS_TAG}.tgz"
+      skip_cleanup: true
 notifications:
   webhooks:
     urls:

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,8 @@ jobs:
       api_key:
         secure: MwR9W8ositdbBKRVg+oV7vUK43Gcs8eCZNSJejVAAk+rLZuwkpr9DPR6I5Crh6/8IblHD87xI90DPN5BGf0BJRzwVxeJWCuLaOwO5eUmqlXSrJt3VAoGDkxYzh2nm92CLnek6PxdeoZwqap2wDKUBoPh+Je7uZucgtRU27x7sUc=
       skip_cleanup: true
+      on:
+        all_branches: true
   - stage: "GitHub Release"
     if: type = push AND tag IS present
     script: skip

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,8 @@ install:
 after_success: npm run report-coverage
 jobs:
   include:
-  - stage: "NPM Release @next"
-    if: type = push # add master later
+  - stage: "NPM Release next"
+    if: type = push AND branch = master
     script: skip
     before_deploy:
     - git reset --hard
@@ -34,7 +34,7 @@ jobs:
         secure: MwR9W8ositdbBKRVg+oV7vUK43Gcs8eCZNSJejVAAk+rLZuwkpr9DPR6I5Crh6/8IblHD87xI90DPN5BGf0BJRzwVxeJWCuLaOwO5eUmqlXSrJt3VAoGDkxYzh2nm92CLnek6PxdeoZwqap2wDKUBoPh+Je7uZucgtRU27x7sUc=
       skip_cleanup: true
       on:
-        all_branches: true
+        branch: master
   - stage: "GitHub Release"
     if: type = push AND tag IS present
     script: skip

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ jobs:
     if: type = push # add master later
     script: skip
     before_deploy:
+    - git reset --hard
     - npm version $(npm view nodecg version)-master.$(git rev-parse --short HEAD)
     deploy:
       provider: npm

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,9 +21,12 @@ jobs:
   include:
   - stage: "NPM Release @next"
     if: type = push # add master later
+    before_install: skip
+    install: skip
     script: skip
+    after_success: skip
     deploy:
-    - provider: npm
+      provider: npm
       tag: next
       email:
         secure: VAevo66XIzgA9mbhQhnouv101W7HVhHGvohxmJtGadGL/kwVuMZcYp5nG3IwuetYDpjCmRTY0My13HRBG7ciVg7CW+Wx/raLmST09QokEtvIcvLwGBmxBjR37UnU/SD65XjgAqM+sNPoCTe6vxaJVoInR8uNxdi6IsYiOE9wlmE=
@@ -34,11 +37,14 @@ jobs:
         all_branches: true
   - stage: "GitHub Release"
     if: type = push AND tag IS present
+    before_install: skip
+    install: skip
     script: skip
+    after_success: skip
     before_deploy:
     - mv $(npm pack 2>/dev/null) "nodecg-${TRAVIS_TAG}.tgz"
     deploy:
-    - provider: releases
+      provider: releases
       api_key:
         secure: ph/2keCTbmoaCIFhBZE65Tj1DcRHf3U+Dk3KSVZOOR29NbI3tkwpoLjl0OQpeLtHqgu76L/W+B1ZFGQbegjHRCYOz6bvzLxe37c0p0FNmt+rWnyHAtri9O4iPObgsGX7t2+A2Qehq0NgM6KkjSQRRYpfF+Vx1S5+grTXY/lm/cI=
       file: "nodecg-${TRAVIS_TAG}.tgz"

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,8 @@ jobs:
   - stage: "NPM Release @next"
     if: type = push # add master later
     script: skip
+    before_deploy:
+    - npm version $(npm view nodecg version)-master.$(git rev-parse --short HEAD)
     deploy:
       provider: npm
       tag: next
@@ -43,6 +45,8 @@ jobs:
         secure: ph/2keCTbmoaCIFhBZE65Tj1DcRHf3U+Dk3KSVZOOR29NbI3tkwpoLjl0OQpeLtHqgu76L/W+B1ZFGQbegjHRCYOz6bvzLxe37c0p0FNmt+rWnyHAtri9O4iPObgsGX7t2+A2Qehq0NgM6KkjSQRRYpfF+Vx1S5+grTXY/lm/cI=
       file: "nodecg-${TRAVIS_TAG}.tgz"
       skip_cleanup: true
+      on:
+        tags: true
 notifications:
   webhooks:
     urls:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,10 +21,7 @@ jobs:
   include:
   - stage: "NPM Release @next"
     if: type = push # add master later
-    before_install: skip
-    install: skip
     script: skip
-    after_success: skip
     deploy:
       provider: npm
       tag: next
@@ -37,10 +34,7 @@ jobs:
         all_branches: true
   - stage: "GitHub Release"
     if: type = push AND tag IS present
-    before_install: skip
-    install: skip
     script: skip
-    after_success: skip
     before_deploy:
     - mv $(npm pack 2>/dev/null) "nodecg-${TRAVIS_TAG}.tgz"
     deploy:


### PR DESCRIPTION
Modified travis config to use "build stages" for deploy jobs.

Also includes fix for npm `next` release trying to push current version~, I hope~ it required to bump the version, so it just uses `${latestVersion}-master.${lastCommitShortSha}`.
