### PR TITLE
fix(dashboard): default style injection

### DIFF
--- a/lib/util/injectscripts.js
+++ b/lib/util/injectscripts.js
@@ -173,15 +173,14 @@ module.exports = function (pathOrHtml, resourceType, opts, cb) {
 			$('body').append(scripts);
 		}
 
-		// Inject the needed stylesheets, if any.
-		// If there are <script> tags in the head, inject before them.
-		// Otherwise, add at the end of the <head>.
+		// Prepend our styles before the first one.
+		// If there are no styles, put our styles at the end of <head>.
 		if (styles.length > 0) {
 			styles = styles.join('\n');
 
-			const headScripts = $('head').find('script');
-			if (headScripts.length > 0) {
-				headScripts.first().before(styles);
+			const headStyles = $('head').find('style, link[rel="stylesheet"]');
+			if (headStyles.length > 0) {
+				headStyles.first().before(styles);
 			} else {
 				$('head').append(styles);
 			}


### PR DESCRIPTION
Currently, default styles are injected at the end of `head` despite the presence of existing ones, overriding  the body style everytime.