### PR TITLE
Export more types in browser.d.ts

### DIFF
--- a/types/browser.d.ts
+++ b/types/browser.d.ts
@@ -4,8 +4,10 @@ import {NodeCGBrowser} from './lib/nodecg-instance';
 declare global {
 	export const nodecg: NodeCGBrowser;
 	export const NodeCG: NodeCGStaticBrowser;
+	export interface Window { nodecg: NodeCGBrowser, NodeCG: NodeCGStaticBrowser }
 }
 
+export {NodeCGStaticBrowser, NodeCGBrowser};
 export * from './lib/config';
 export * from './lib/logger';
 export * from './lib/replicant';


### PR DESCRIPTION
Export `NodeCGStaticBrowser` and `NodeCGBrowser` directly, as well as providing global constants for the two named `NodeCG` and `nodecg` respectively.