### PR TITLE
 feat(extension): add Babel/TypeScript `export default` support and conditional calling

### DIFF
--- a/lib/server/extensions.js
+++ b/lib/server/extensions.js
@@ -99,7 +99,18 @@ module.exports.getExtensions = function () {
 function _loadExtension(bundle) {
 	const extPath = path.join(bundle.dir, 'extension');
 	try {
-		const extension = require(extPath)(new ExtensionApi(bundle));
+		let extension = require(extPath);
+
+		// If the extension is an ECMAScript module with a `default` export.
+		if (extension.__esModule && extension.default) {
+			extension = extension.default;
+		}
+
+		// Only call the extension if it's a function.
+		if (typeof extension === 'function') {
+			extension = extension(new ExtensionApi(bundle));
+		}
+
 		log.info('Mounted %s extension', bundle.name);
 		extensions[bundle.name] = extension;
 	} catch (err) {

--- a/test/fixtures/bundle-parser/es-extension/extension.js
+++ b/test/fixtures/bundle-parser/es-extension/extension.js
@@ -1,0 +1,12 @@
+/* istanbul ignore next */
+'use strict';
+
+Object.defineProperty(module, '__esModule', {
+	value: true
+});
+
+module.exports.default = function () {
+	return {
+		lorem: 'ipsum'
+	};
+};

--- a/test/fixtures/bundle-parser/es-extension/package.json
+++ b/test/fixtures/bundle-parser/es-extension/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "es-extension",
+  "version": "0.0.1",
+  "homepage": "http://github.com/nodecg",
+  "author": [
+    "Alex Van Camp <email@alexvan.camp>",
+    "Matt McNamara"
+  ],
+  "description": "A test bundle",
+  "license": "MIT",
+  "nodecg": {
+    "compatibleRange": "~0.7.0"
+  }
+}

--- a/test/fixtures/bundle-parser/non-function-extension/extension.js
+++ b/test/fixtures/bundle-parser/non-function-extension/extension.js
@@ -1,0 +1,6 @@
+/* istanbul ignore next */
+'use strict';
+
+module.exports = {
+	lorem: 'ipsum'
+};

--- a/test/fixtures/bundle-parser/non-function-extension/package.json
+++ b/test/fixtures/bundle-parser/non-function-extension/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "non-function-extension",
+  "version": "0.0.1",
+  "homepage": "http://github.com/nodecg",
+  "author": [
+    "Alex Van Camp <email@alexvan.camp>",
+    "Matt McNamara"
+  ],
+  "description": "A test bundle",
+  "license": "MIT",
+  "nodecg": {
+    "compatibleRange": "~0.7.0"
+  }
+}


### PR DESCRIPTION
The pull request adds two features:

- ECMAScript module support, useful when using a bundler and removes the need of including compatibility plugins/code
- Conditional function calling, which can be handy when the module is an utility bundle for example