### PR TITLE
feat: add multiple bundles paths support

### DIFF
--- a/lib/bundle-manager.js
+++ b/lib/bundle-manager.js
@@ -36,7 +36,6 @@ const emitter = new EventEmitter();
 const bundles = [];
 let log;
 let _cfgPath;
-let _bundlesPath;
 let backoffTimer = null;
 let hasChanged = {};
 let initialized = false;
@@ -76,124 +75,125 @@ module.exports = emitter;
  * @return {Object} - A bundle-manager instance.
  */
 // eslint-disable-next-line max-params
-module.exports.init = function (bundlesPath, cfgPath, nodecgVersion, nodecgConfig, Logger) {
+module.exports.init = function (bundlesPaths, cfgPath, nodecgVersion, nodecgConfig, Logger) {
 	if (initialized) {
 		throw new Error('Cannot initialize when already initialized');
 	}
 
 	initialized = true;
-	_bundlesPath = bundlesPath;
 	_cfgPath = cfgPath;
 	log = new Logger('nodecg/lib/bundles');
 	log.trace('Loading bundles');
 
-	// Create the "bundles" dir if it does not exist.
-	/* istanbul ignore if: We know this code works and testing it is tedious, so we don't bother to test it. */
-	if (!fs.existsSync(bundlesPath)) {
-		fs.mkdirpSync(bundlesPath);
-	}
-
-	/* istanbul ignore next */
-	watcher.on('add', filePath => {
-		const bundleName = extractBundleName(filePath);
-
-		// In theory, the bundle parser would have thrown an error long before this block would execute,
-		// because in order for us to be adding a panel HTML file, that means that the file would have been missing,
-		// which the parser does not allow and would throw an error for.
-		// Just in case though, its here.
-		if (isPanelHTMLFile(bundleName, filePath)) {
-			handleChange(bundleName);
-		} else if (isGitData(bundleName, filePath)) {
-			debouncedGitChangeHandler(bundleName);
-		}
-	});
-
-	watcher.on('change', filePath => {
-		const bundleName = extractBundleName(filePath);
-
-		if (isManifest(bundleName, filePath) || isPanelHTMLFile(bundleName, filePath)) {
-			handleChange(bundleName);
-		} else if (isGitData(bundleName, filePath)) {
-			debouncedGitChangeHandler(bundleName);
-		}
-	});
-
-	watcher.on('unlink', filePath => {
-		const bundleName = extractBundleName(filePath);
-
-		if (isPanelHTMLFile(bundleName, filePath)) {
-			// This will cause NodeCG to crash, because the parser will throw an error due to
-			// a panel's HTML file no longer being present.
-			handleChange(bundleName);
-		} else if (isManifest(bundleName, filePath)) {
-			debouncedManifestDeletionCheck(bundleName, filePath);
-		} else if (isGitData(bundleName, filePath)) {
-			debouncedGitChangeHandler(bundleName);
-		}
-	});
-
-	/* istanbul ignore next */
-	watcher.on('error', error => {
-		log.error(error.stack);
-	});
-
-	// Do an initial load of each bundle in the "bundles" folder.
-	// During runtime, any changes to a bundle's "dashboard" folder will trigger a re-load of that bundle,
-	// as will changes to its `package.json`.
-	fs.readdirSync(bundlesPath).forEach(bundleFolderName => {
-		const bundlePath = path.join(bundlesPath, bundleFolderName);
-		if (!fs.statSync(bundlePath).isDirectory()) {
-			return;
+	bundlesPaths.forEach(bundlesPath => {
+		// Create the "bundles" dir if it does not exist.
+		/* istanbul ignore if: We know this code works and testing it is tedious, so we don't bother to test it. */
+		if (!fs.existsSync(bundlesPath)) {
+			fs.mkdirpSync(bundlesPath);
 		}
 
-		// Prevent attempting to load unwanted directories. Those specified above and all dot-prefixed.
-		if (blacklistedBundleDirectories.includes(bundleFolderName) || bundleFolderName.startsWith('.')) {
-			return;
-		}
+		/* istanbul ignore next */
+		watcher.on('add', filePath => {
+			const bundleName = extractBundleName(bundlesPath, filePath);
 
-		if (nodecgConfig && nodecgConfig.bundles && nodecgConfig.bundles.disabled &&
-			nodecgConfig.bundles.disabled.includes(bundleFolderName)) {
-			log.debug('Not loading bundle ' + bundleFolderName + ' as it is disabled in config');
-			return;
-		}
+			// In theory, the bundle parser would have thrown an error long before this block would execute,
+			// because in order for us to be adding a panel HTML file, that means that the file would have been missing,
+			// which the parser does not allow and would throw an error for.
+			// Just in case though, its here.
+			if (isPanelHTMLFile(bundleName, filePath)) {
+				handleChange(bundleName);
+			} else if (isGitData(bundleName, filePath)) {
+				debouncedGitChangeHandler(bundleName);
+			}
+		});
 
-		if (nodecgConfig && nodecgConfig.bundles && nodecgConfig.bundles.enabled &&
-			!(nodecgConfig.bundles.enabled.includes(bundleFolderName))) {
-			log.debug('Not loading bundle ' + bundleFolderName + ' as it is not enabled in config');
-			return;
-		}
+		watcher.on('change', filePath => {
+			const bundleName = extractBundleName(bundlesPath, filePath);
 
-		// Parse each bundle and push the result onto the bundles array
-		let bundle;
-		const bundleCfgPath = path.join(cfgPath, `${bundleFolderName}.json`);
+			if (isManifest(bundleName, filePath) || isPanelHTMLFile(bundleName, filePath)) {
+				handleChange(bundleName);
+			} else if (isGitData(bundleName, filePath)) {
+				debouncedGitChangeHandler(bundleName);
+			}
+		});
 
-		if (fs.existsSync(bundleCfgPath)) {
-			bundle = parseBundle(bundlePath, bundleCfgPath);
-		} else {
-			bundle = parseBundle(bundlePath);
-		}
+		watcher.on('unlink', filePath => {
+			const bundleName = extractBundleName(bundlesPath, filePath);
 
-		// Check if the bundle is compatible with this version of NodeCG
-		if (!semver.satisfies(nodecgVersion, bundle.compatibleRange)) {
-			log.error(
-				'%s requires NodeCG version %s, current version is %s',
-				bundle.name, bundle.compatibleRange, nodecgVersion
-			);
-			return;
-		}
+			if (isPanelHTMLFile(bundleName, filePath)) {
+				// This will cause NodeCG to crash, because the parser will throw an error due to
+				// a panel's HTML file no longer being present.
+				handleChange(bundleName);
+			} else if (isManifest(bundleName, filePath)) {
+				debouncedManifestDeletionCheck(bundleName, filePath);
+			} else if (isGitData(bundleName, filePath)) {
+				debouncedGitChangeHandler(bundleName);
+			}
+		});
 
-		bundles.push(bundle);
+		/* istanbul ignore next */
+		watcher.on('error', error => {
+			log.error(error.stack);
+		});
 
-		// Use `chokidar` to watch for file changes within bundles.
-		// Workaround for https://github.com/paulmillr/chokidar/issues/419
-		// This workaround is necessary to fully support symlinks.
-		// This is applied after the bundle has been validated and loaded.
-		// Bundles that do not properly load upon startup are not recognized for updates.
-		watcher.add([
-			path.join(bundlePath, '.git'), // Watch `.git` directories.
-			path.join(bundlePath, 'dashboard'), // Watch `dashboard` directories.
-			path.join(bundlePath, 'package.json') // Watch each bundle's `package.json`.
-		]);
+		// Do an initial load of each bundle in the "bundles" folder.
+		// During runtime, any changes to a bundle's "dashboard" folder will trigger a re-load of that bundle,
+		// as will changes to its `package.json`.
+		fs.readdirSync(bundlesPath).forEach(bundleFolderName => {
+			const bundlePath = path.join(bundlesPath, bundleFolderName);
+			if (!fs.statSync(bundlePath).isDirectory()) {
+				return;
+			}
+
+			// Prevent attempting to load unwanted directories. Those specified above and all dot-prefixed.
+			if (blacklistedBundleDirectories.includes(bundleFolderName) || bundleFolderName.startsWith('.')) {
+				return;
+			}
+
+			if (nodecgConfig && nodecgConfig.bundles && nodecgConfig.bundles.disabled &&
+				nodecgConfig.bundles.disabled.includes(bundleFolderName)) {
+				log.debug('Not loading bundle ' + bundleFolderName + ' as it is disabled in config');
+				return;
+			}
+
+			if (nodecgConfig && nodecgConfig.bundles && nodecgConfig.bundles.enabled &&
+				!(nodecgConfig.bundles.enabled.includes(bundleFolderName))) {
+				log.debug('Not loading bundle ' + bundleFolderName + ' as it is not enabled in config');
+				return;
+			}
+
+			// Parse each bundle and push the result onto the bundles array
+			let bundle;
+			const bundleCfgPath = path.join(cfgPath, `${bundleFolderName}.json`);
+
+			if (fs.existsSync(bundleCfgPath)) {
+				bundle = parseBundle(bundlePath, bundleCfgPath);
+			} else {
+				bundle = parseBundle(bundlePath);
+			}
+
+			// Check if the bundle is compatible with this version of NodeCG
+			if (!semver.satisfies(nodecgVersion, bundle.compatibleRange)) {
+				log.error(
+					'%s requires NodeCG version %s, current version is %s',
+					bundle.name, bundle.compatibleRange, nodecgVersion
+				);
+				return;
+			}
+
+			bundles.push(bundle);
+
+			// Use `chokidar` to watch for file changes within bundles.
+			// Workaround for https://github.com/paulmillr/chokidar/issues/419
+			// This workaround is necessary to fully support symlinks.
+			// This is applied after the bundle has been validated and loaded.
+			// Bundles that do not properly load upon startup are not recognized for updates.
+			watcher.add([
+				path.join(bundlePath, '.git'), // Watch `.git` directories.
+				path.join(bundlePath, 'dashboard'), // Watch `dashboard` directories.
+				path.join(bundlePath, 'package.json') // Watch each bundle's `package.json`.
+			]);
+		});
 	});
 
 	emitter.emit('init', bundles);
@@ -331,9 +331,8 @@ function resetBackoffTimer() {
  * @returns {String} - The name of the bundle that owns this path.
  * @private
  */
-function extractBundleName(filePath) {
-	const parts = filePath.replace(_bundlesPath, '').split(path.sep);
-	return parts[1];
+function extractBundleName(bundlesPath, filePath) {
+	return filePath.replace(bundlesPath, '').split(path.sep)[1];
 }
 
 /**

--- a/lib/server/index.js
+++ b/lib/server/index.js
@@ -123,11 +123,14 @@ module.exports.start = function () {
 		});
 	}
 
-	const bundlesPath = global.isZeitPkg ?
-		path.resolve(__dirname, '../../bundles') :
-		path.join(process.env.NODECG_ROOT, 'bundles');
+	const bundlesPaths = [path.join(process.env.NODECG_ROOT, 'bundles')];
 	const cfgPath = path.join(process.env.NODECG_ROOT, 'cfg');
-	bundleManager.init(bundlesPath, cfgPath, require('../../package.json').version, config, Logger);
+
+	if (global.isZeitPkg) {
+		bundlesPaths.unshift(path.resolve(__dirname, '../../bundles'));
+	}
+
+	bundleManager.init(bundlesPaths, cfgPath, pjson.version, config, Logger);
 
 	bundleManager.all().forEach(bundle => {
 		if (bundle.transformBareModuleSpecifiers) {

--- a/test/bundle-manager.js
+++ b/test/bundle-manager.js
@@ -39,7 +39,7 @@ test.cb.before(t => {
 
 	bundleManager = require('../lib/bundle-manager');
 	bundleManager.init(
-		path.join(tempFolder, 'bundles'),
+		[path.join(tempFolder, 'bundles')],
 		path.join(tempFolder, 'cfg'),
 		'0.7.0',
 		nodecgConfig,


### PR DESCRIPTION
This feature allows more flexibility when NodeCG is a pkg executable, by removing the necessity of including bundles into the pkg package and makes it portable-friendly.

In my case, because I'm working on multiple bundles and have to separate them for more efficiency, I can simply use a single 80MB executable instead of the whole repository, making everything cleaner.