### PR TITLE
fix(zeit_pkg): fix pkg'd executables not working when compiled on a drive other than C:

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ process.title = 'NodeCG';
 global.exitOnUncaught = true;
 
 const cwd = process.cwd();
-global.isZeitPkg = __dirname.startsWith('/snapshot/') || __dirname.toLowerCase().startsWith('c:\\snapshot\\');
+global.isZeitPkg = __dirname.startsWith('/snapshot/') || /^(.:\\snapshot\\)/i.test(__dirname);
 if (global.isZeitPkg) {
 	console.info('[nodecg] Detected that NodeCG is running inside a ZEIT pkg (https://github.com/zeit/pkg)');
 } else if (cwd !== __dirname) {

--- a/index.js
+++ b/index.js
@@ -3,8 +3,23 @@
 process.title = 'NodeCG';
 global.exitOnUncaught = true;
 
+const path = require('path');
 const cwd = process.cwd();
-global.isZeitPkg = __dirname.startsWith('/snapshot/') || /^(.:\\snapshot\\)/i.test(__dirname);
+global.isZeitPkg = isZeitPkg();
+
+/**
+ * Lange: As of July 2019, the only way I know to programmatically
+ * determine if code is running inside a Zeit pkg is to check if
+ * the first directory in the __dirname is called `snapshot`.
+ *
+ * There's definitely a possibility for false positives here,
+ * but I have yet to find a better alternative.
+ */
+function isZeitPkg() {
+	const parts = __dirname.split(path.sep);
+	return parts[1].toLowerCase() === 'snapshot';
+}
+
 if (global.isZeitPkg) {
 	console.info('[nodecg] Detected that NodeCG is running inside a ZEIT pkg (https://github.com/zeit/pkg)');
 } else if (cwd !== __dirname) {


### PR DESCRIPTION
Turns out that the beginning drive letter in this path is inherited from the drive letter where the pkg was created. That is to say: if I invoke `pkg` from my `C:` drive, then the virtual filesystem snapshot will start with `c:`, if I invoke it from `D:`, then the virtual filesystem snapshot will start with `d:`, etc.

This was breaking my builds on Azure Pipelines, which often use a `D:` drive letter instead of `C:`.