### PR TITLE
feat(extension): flexible mount

### DIFF
--- a/lib/server/index.js
+++ b/lib/server/index.js
@@ -365,6 +365,6 @@ module.exports.getIO = function () {
 	return io;
 };
 
-module.exports.mount = function (middleware) {
-	app.use(middleware);
+module.exports.mount = function (...args) {
+	app.use(...args);
 };

--- a/test/api/general.js
+++ b/test/api/general.js
@@ -75,6 +75,18 @@ test('should mount custom routes via nodecg.mount', async t => {
 	t.is(response.data, 'custom route confirmed');
 });
 
+test('should mount prefixed custom routes via nodecg.mount', async t => {
+	const app = express();
+	app.get('/test-route', (req, res) => {
+		res.send('custom route confirmed');
+	});
+	t.context.apis.extension.mount('/test-bundle', app);
+
+	const response = await axios.get(`${C.rootUrl()}test-bundle/test-route`);
+	t.is(response.status, 200);
+	t.is(response.data, 'custom route confirmed');
+});
+
 test.serial.cb('should support multiple listenFor handlers', t => {
 	t.plan(2);
 	let callbacksInvoked = 0;

--- a/tutorials/custom-routes.md
+++ b/tutorials/custom-routes.md
@@ -14,3 +14,19 @@ module.exports = function (nodecg) {
     nodecg.mount(app); // The route '/my-bundle/customroute` is now available
 };
 ```
+
+You can also define a prefix path so that the routes will be relative to it:
+
+```javascript
+// bundles/my-bundle/extension.js
+const express = require('express');
+const app = express();
+
+module.exports = function (nodecg) {
+    app.get('/customroute', (req, res) => {
+        res.send('OK!');
+    });
+
+    nodecg.mount('/my-bundle', app); // The route '/my-bundle/customroute` is now available
+};
+```


### PR DESCRIPTION
This change allows more flexibility concerning sub-application mounting. Meaning, we can set a prefix path, like express provides.