### PR TITLE
feat(replicant): update serializer

### DIFF
--- a/lib/replicant/replicant.js
+++ b/lib/replicant/replicant.js
@@ -119,7 +119,7 @@ class Replicant extends EventEmitter {
 		// Get the existing value, if any, and JSON parse if its an object
 		let existingValue = replicator.stores[namespace].getItem(`${name}.rep`);
 		try {
-			existingValue = JSON.parse(existingValue);
+			existingValue = existingValue === '' ? undefined : JSON.parse(existingValue);
 		} catch (e) {}
 
 		// Set the default value, if a schema is present and no default value was provided.

--- a/lib/replicator.js
+++ b/lib/replicator.js
@@ -220,10 +220,9 @@ function saveReplicant(replicant) {
 			return;
 		}
 
-		let {value} = replicant;
-		if (typeof value === 'object') {
-			value = JSON.stringify(value);
-		} else if (typeof value === 'undefined') {
+		let value = JSON.stringify(replicant.value);
+
+		if (typeof value === 'undefined') {
 			value = '';
 		}
 

--- a/test/replicants/server.js
+++ b/test/replicants/server.js
@@ -248,14 +248,14 @@ test.serial('dates - should not throw an error', t => {
 });
 
 test.serial('persistent - should load persisted values when they exist', t => {
-	const rep = t.context.apis.extension.Replicant('extensionPersistence');
+	const rep = t.context.apis.extension.Replicant('extensionPersistence', {persistenceInterval: 0});
 	t.is(rep.value, 'it work good!');
 });
 
 test.serial.cb('persistent - should persist assignment to disk', t => {
 	t.plan(1);
 
-	const rep = t.context.apis.extension.Replicant('extensionPersistence');
+	const rep = t.context.apis.extension.Replicant('extensionPersistence', {persistenceInterval: 0});
 	rep.value = {nested: 'hey we assigned!'};
 	setTimeout(() => {
 		const replicantPath = path.join(C.replicantsRoot(), 'test-bundle/extensionPersistence.rep');
@@ -273,7 +273,7 @@ test.serial.cb('persistent - should persist assignment to disk', t => {
 test.serial.cb('persistent - should persist changes to disk', t => {
 	t.plan(1);
 
-	const rep = t.context.apis.extension.Replicant('extensionPersistence');
+	const rep = t.context.apis.extension.Replicant('extensionPersistence', {persistenceInterval: 0});
 	rep.value.nested = 'hey we changed!';
 	setTimeout(() => {
 		const replicantPath = path.join(C.replicantsRoot(), 'test-bundle/extensionPersistence.rep');
@@ -291,7 +291,7 @@ test.serial.cb('persistent - should persist changes to disk', t => {
 test.serial.cb('persistent - should persist top-level string', t => {
 	t.plan(1);
 
-	const rep = t.context.apis.extension.Replicant('extensionPersistence');
+	const rep = t.context.apis.extension.Replicant('extensionPersistence', {persistenceInterval: 0});
 	rep.value = 'lorem';
 
 	setTimeout(() => {
@@ -311,7 +311,7 @@ test.serial.cb('persistent - should persist top-level string', t => {
 test.serial.cb('persistent - should persist top-level undefined', t => {
 	t.plan(1);
 
-	const rep = t.context.apis.extension.Replicant('extensionPersistence');
+	const rep = t.context.apis.extension.Replicant('extensionPersistence', {persistenceInterval: 0});
 	rep.value = undefined;
 
 	setTimeout(() => {
@@ -331,7 +331,7 @@ test.serial.cb('persistent - should persist top-level undefined', t => {
 test.serial.cb('persistent - should persist falsey values to disk', t => {
 	t.plan(1);
 
-	const rep = t.context.apis.extension.Replicant('extensionFalseyWrite');
+	const rep = t.context.apis.extension.Replicant('extensionFalseyWrite', {persistenceInterval: 0});
 	rep.value = 0;
 	setTimeout(() => {
 		const replicantPath = path.join(C.replicantsRoot(), 'test-bundle/extensionFalseyWrite.rep');
@@ -347,7 +347,7 @@ test.serial.cb('persistent - should persist falsey values to disk', t => {
 });
 
 test.serial('persistent - should read falsey values from disk', t => {
-	const rep = t.context.apis.extension.Replicant('extensionFalseyRead');
+	const rep = t.context.apis.extension.Replicant('extensionFalseyRead', {persistenceInterval: 0});
 	t.is(rep.value, 0);
 });
 

--- a/test/replicants/server.js
+++ b/test/replicants/server.js
@@ -288,6 +288,46 @@ test.serial.cb('persistent - should persist changes to disk', t => {
 	}, 250); // Delay needs to be longer than the persistence interval.
 });
 
+test.serial.cb('persistent - should persist top-level string', t => {
+	t.plan(1);
+
+	const rep = t.context.apis.extension.Replicant('extensionPersistence');
+	rep.value = 'lorem';
+
+	setTimeout(() => {
+		const replicantPath = path.join(C.replicantsRoot(), 'test-bundle/extensionPersistence.rep');
+
+		fs.readFile(replicantPath, 'utf-8', (err, data) => {
+			if (err) {
+				throw err;
+			}
+
+			t.is(data, '"lorem"');
+			t.end();
+		});
+	}, 10);
+});
+
+test.serial.cb('persistent - should persist top-level undefined', t => {
+	t.plan(1);
+
+	const rep = t.context.apis.extension.Replicant('extensionPersistence');
+	rep.value = undefined;
+
+	setTimeout(() => {
+		const replicantPath = path.join(C.replicantsRoot(), 'test-bundle/extensionPersistence.rep');
+
+		fs.readFile(replicantPath, 'utf-8', (err, data) => {
+			if (err) {
+				throw err;
+			}
+
+			t.is(data, '');
+			t.end();
+		});
+	}, 10);
+});
+
 test.serial.cb('persistent - should persist falsey values to disk', t => {
 	t.plan(1);
 


### PR DESCRIPTION
Closes #509.

This change also adds a proper parsing of `undefined` values.