### PR TITLE
revert: support Node.js 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ sudo: false
 dist: trusty
 language: node_js
 node_js:
-- '10'
 - '8'
+- '10'
 os:
 - linux
 git:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10
+FROM node:8
 
 WORKDIR /usr/src/app
 

--- a/package.json
+++ b/package.json
@@ -137,7 +137,7 @@
     "all": true
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=8.3.0"
   },
   "files": [
     "build",


### PR DESCRIPTION
This PR reverts #513 #517 which dropped support for Node.js 8, which will hit EoL in Dec 2019.

I reverted base Docker image too since it would break the newer NodeCG image.