### PR TITLE
fix(replicants): clone default value

### DIFF
--- a/lib/replicant/replicant.js
+++ b/lib/replicant/replicant.js
@@ -140,7 +140,7 @@ class Replicant extends EventEmitter {
 				}
 			}
 
-			this.value = shared._proxyRecursive(this, opts.defaultValue, '/');
+			this.value = shared._proxyRecursive(this, clone(opts.defaultValue), '/');
 			this.log.replicants('Declared "%s" in namespace "%s" with defaultValue:\n', name, namespace, opts.defaultValue);
 			replicator.saveReplicant(this);
 		}

--- a/test/replicants/server.js
+++ b/test/replicants/server.js
@@ -323,3 +323,11 @@ test.serial('test that one else path that\'s hard to hit', t => {
 	rep.value[0] = true;
 	t.pass();
 });
+
+test.serial('should leave the default value intact', t => {
+	const defaultValue = {lorem: 'ipsum'};
+	const rep = t.context.apis.extension.Replicant('defaultValueIntact', {defaultValue});
+
+	t.is(rep.opts.defaultValue, defaultValue);
+	t.not(rep.value, defaultValue);
+});


### PR DESCRIPTION
This change avoid default replicant's value from being modified by cloning it before doing anything else.

Fixes #486.