### PR TITLE
Update Dockerfile and add documentation about docker deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,4 +6,5 @@
 !bower.json
 !index.js
 !package.json
+!package-lock.json
 !types

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,27 @@
 FROM node:10
 
-WORKDIR /usr/src/app
+WORKDIR /opt/nodecg
 
-# Copy NodeCG (just the files we need)
-RUN mkdir cfg && mkdir bundles && mkdir logs && mkdir db
-COPY . /usr/src/app/
+RUN addgroup --system nodecg && adduser --system nodecg --ingroup nodecg && \
+    npm install -g nodecg-cli && \
+    mkdir cfg && mkdir bundles && mkdir logs && mkdir db && \
+    chown -R nodecg:nodecg /opt/nodecg
+
+USER nodecg
+
+# Copy package.json and package-lock.json
+COPY --chown=nodecg:nodecg package*.json /opt/nodecg/
 
 # Install dependencies
-RUN npm install --production
+RUN npm ci --production
 
-# The command to run
-EXPOSE 9090
-CMD ["node", "index.js"]
+# Copy NodeCG (just the files we need)
+COPY --chown=nodecg:nodecg . /opt/nodecg/
+
+# Define directories that should be persisted in a volume
+VOLUME /opt/nodecg/cfg /opt/nodecg/bundles /opt/nodecg/logs /opt/nodecg/db
+# Define ports that should be used to communicate
+EXPOSE 9090/tcp
+
+# Define command to run NodeCg
+CMD ["nodecg", "start"]


### PR DESCRIPTION
Moin,

This is my take on #422. 

I've updated the Docker file to:
- include bower and nodecg-cli to install bundles (mentioned in tutorials/deployment-with-docker.md#48)
- run the process as a non-root user [Best practices for Dockerfiles](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#user) (Also needed to run bower)
- change `npm install` to `npm ci` to improve build times and make it more safe (Added package-lock.json in the process)
- add basic information like volumes and exposed ports

The tutorial describes how to setup NodeCG with docker either by mounting volumes (recommended for bundle development) or building a new image with the parent `nodecg/nodecg` (recommended for production).
