### PR TITLE
fix(dashboard): fullbleed workspace label

### DIFF
--- a/lib/dashboard.js
+++ b/lib/dashboard.js
@@ -151,7 +151,7 @@ function parseWorkspaces() {
 				const workspaceName = `__nodecg_fullbleed__${bundle.name}_${panel.name}`;
 				workspaces.push({
 					name: workspaceName,
-					label: panel.name,
+					label: panel.title,
 					route: `fullbleed/${panel.name}`,
 					fullbleed: true
 				});


### PR DESCRIPTION
Small change to display the title of the fullbleed panel instead of its name in the top bar of the dashboard.