### PR TITLE
docs: fix typo

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -454,7 +454,7 @@ NodeCG.Replicant = function (name, namespace, opts) {
 };
 
 /**
- * Replicants are objcts which monitor changes to a variable's value.
+ * Replicants are objects which monitor changes to a variable's value.
  * The changes are replicated across all extensions, graphics, and dashboard panels.
  * When a Replicant changes in one of those places it is quickly updated in the rest,
  * and a `change` event is emitted allowing bundles to react to the changes in the data.


### PR DESCRIPTION
Just fixes a minor typo ("objcts" ->"objects").