### PR TITLE
Only exit with code 0 on server stop if there isn't already an exit code set

### DIFF
--- a/index.js
+++ b/index.js
@@ -68,7 +68,11 @@ process.on('unhandledRejection', err => {
 
 const server = require('./lib/server')
 	.on('error', () => process.exit(1))
-	.on('stopped', () => process.exit(0));
+	.on('stopped', () => {
+		if (!process.exitCode) {
+			process.exit(0);
+		}
+	});
 
 exitHook(() => {
 	server.stop();


### PR DESCRIPTION
We shall not exit with code 0 when the server stops if there is already a different exit code set, such as from an uncaught exception.