### PR TITLE
fix(types): add/tweak types for replicant/readReplicant

### DIFF
--- a/types/lib/nodecg-instance.d.ts
+++ b/types/lib/nodecg-instance.d.ts
@@ -55,6 +55,8 @@ export interface NodeCGServer extends NodeCGCommon<'server'> {
 	};
 	listenFor(messageName: string, handlerFunc: (message: any, cb?: ListenForCb) => void): void;
 	listenFor(messageName: string, bundleName: string, handlerFunc: (message: any, cb?: ListenForCb) => void): void;
+	readReplicant<V>(name: string): V;
+	readReplicant<V>(name: string, namespace: string): V;
 }
 
 /**

--- a/types/lib/nodecg-instance.d.ts
+++ b/types/lib/nodecg-instance.d.ts
@@ -36,6 +36,8 @@ interface NodeCGCommon<P extends Platform, M = SendMessageReturnType<P>> {
 	unlisten(messageName: string, bundleName: string, handlerFunc: (message: any) => void): void;
 	Replicant<V>(name: string, opts?: ReplicantOptions<V>): Replicant<V, P>;
 	Replicant<V>(name: string, namespace: string, opts?: ReplicantOptions<V>): Replicant<V, P>;
+	readReplicant<V>(name: string, cb: (value: V) => void): void;
+	readReplicant<V>(name: string, namespace: string, cb: (value: V) => void): void;
 }
 
 /**
@@ -67,8 +69,6 @@ export interface NodeCGBrowser extends NodeCGCommon<'browser'> {
 	playSound(cueName: string, opts?: { updateVolume?: boolean }): createjs.AbstractSoundInstance;
 	stopSound(cueName: string): void;
 	stopAllSounds(): void;
-	readReplicant<V>(name: string, cb: (value: V) => void): void;
-	readReplicant<V>(name: string, namespace: string, cb: (value: V) => void): void;
 }
 
 /**

--- a/types/lib/replicant.d.ts
+++ b/types/lib/replicant.d.ts
@@ -62,4 +62,5 @@ export interface ReplicantOptions<V> {
 	defaultValue?: V;
 	persistent?: boolean;
 	schemaPath?: string;
+	persistenceInterval?: number;
 }


### PR DESCRIPTION
the `replicant` typing needed the `persistenceInterval` option adding and `readReplicant` wasn't properly defined for extension usage. If I did anything wrong, tell me!