### PR TITLE
fix(auth): send Client-ID header on all Twitch API requests

### DIFF
--- a/lib/login/index.js
+++ b/lib/login/index.js
@@ -49,7 +49,8 @@ if (config.login.twitch && config.login.twitch.enabled) {
 		clientID: config.login.twitch.clientID,
 		clientSecret: config.login.twitch.clientSecret,
 		callbackURL: `${protocol}://${config.baseURL}/login/auth/twitch`,
-		scope
+		scope,
+		customHeaders: {"Client-ID": config.login.twitch.clientID }
 	}, (accessToken, refreshToken, profile, done) => {
 		profile.allowed = (config.login.twitch.allowedUsernames.indexOf(profile.username) > -1);
 


### PR DESCRIPTION
As of now, Twitch requires this header on all Helix endpoints.