### PR TITLE
fix(dashboard): correct URL for obs drag when login is enabled

### DIFF
--- a/src/dashboard/elements/graphics/ncg-graphic.js
+++ b/src/dashboard/elements/graphics/ncg-graphic.js
@@ -361,9 +361,18 @@ class NcgGraphic extends MutableData(Polymer.PolymerElement) {
 
 	_onDrag(event) {
 		const dragged = event.target;
-		const obsURL = `${dragged.href}?layer-name=${this.graphic.file.replace('.html', '')}&layer-height=${
+
+		let obsURL;
+		if (window.ncgConfig.login.enabled && window.token) {
+			obsURL = `${dragged.href}&`;
+		} else {
+			obsURL = `${dragged.href}?`;
+		}
+
+		obsURL += `layer-name=${this.graphic.file.replace('.html', '')}&layer-height=${
 			this.graphic.height
 		}&layer-width=${this.graphic.width}`;
+
 		event.dataTransfer.setData('text/uri-list', obsURL);
 	}
 }


### PR DESCRIPTION
If login is enabled in the NodeCG config, dragging URLs from the graphics page in the dashboard will not work correctly, since the query string with the key will be overwritten by the query string for OBS' drag n drop parameters. This fix makes it so that when login is enabled, the parameters will get appended to the existing query string rather than adding on a new query string.