### PR TITLE
ts-refactor: fix client socket.io reconnection events

### DIFF
--- a/src/client/api/replicant.ts
+++ b/src/client/api/replicant.ts
@@ -95,7 +95,7 @@ export default class ClientReplicant<T> extends AbstractReplicant<T> {
 		socket.on('disconnect', () => {
 			this._handleDisconnect();
 		});
-		socket.on('reconnect', () => {
+		socket.io.on('reconnect', () => {
 			this._declare();
 		});
 

--- a/src/client/dashboard/elements/ncg-dashboard.ts
+++ b/src/client/dashboard/elements/ncg-dashboard.ts
@@ -493,7 +493,7 @@ class NcgDashboard extends Polymer.PolymerElement {
 			}
 		});
 
-		window.socket.on('reconnect', (attempts) => {
+		window.socket.io.on('reconnect', (attempts) => {
 			this.$.mainToast.show('Reconnected to NodeCG server!');
 			this.$.reconnectToast.hide();
 			this.disconnected = false;
@@ -507,7 +507,7 @@ class NcgDashboard extends Polymer.PolymerElement {
 			}
 		});
 
-		window.socket.on('reconnect_failed', () => {
+		window.socket.io.on('reconnect_failed', () => {
 			this.$.mainToast.show('Failed to reconnect to NodeCG server!');
 
 			notify('Reconnection Failed', {

--- a/src/client/instance/client_registration.ts
+++ b/src/client/instance/client_registration.ts
@@ -62,7 +62,7 @@
 	// In single-instance graphics, this registration will be rejected if the graphic is already open elsewhere.
 	register();
 	/* istanbul ignore next: hard to test reconnection stuff right now */
-	window.socket.on('reconnect', () => {
+	window.socket.io.on('reconnect', () => {
 		register();
 	});
 

--- a/src/server/replicant/replicator.ts
+++ b/src/server/replicant/replicator.ts
@@ -37,7 +37,7 @@ export default class Replicator {
 		}
 
 		this.io = io;
-		io.on('connection', (socket) => {
+		io.on('connection', (socket: TypedServerSocket) => {
 			this._attachToSocket(socket);
 		});
 

--- a/src/types/socket-protocol.ts
+++ b/src/types/socket-protocol.ts
@@ -1,3 +1,6 @@
+// Native
+import type { EventEmitter } from 'events';
+
 // Packages
 import type {
 	ServerDefinition,
@@ -173,7 +176,7 @@ export type ProtocolDefinition = {
 	};
 } & ServerDefinition;
 
-type MissingBits = { id: string };
+type MissingBits = { id: string; io: EventEmitter };
 export type TypedServer = RootServer<ProtocolDefinition>;
 export type RootNS = ServerNamespace<ProtocolDefinition, '/'>;
 export type TypedClientSocket = ClientSideSocket<ProtocolDefinition, '/'> & MissingBits;


### PR DESCRIPTION
NodeCG used socket.io v2 before the TypeScript rewrite which upgraded it to v4.
Since socket.io v3 reconnection events aren't emitted directly anymore and the socket manager instance needs to be accessed directly for these events: https://socket.io/docs/v3/client-socket-instance/#events

This caused the reconnection toast in the dashboard to not show up but more importantly, Replicants wouldn't work anymore after a reconnect.