### PR TITLE
[FIX] assets: Solves assets not working when using include-nodecg

### DIFF
--- a/lib/assets/index.js
+++ b/lib/assets/index.js
@@ -90,7 +90,7 @@ collections.forEach(({name, categories}) => {
 // Therefore, we must replace them with Unix-style ones.
 // See https://github.com/paulmillr/chokidar/issues/777 for more details.
 const fixedPaths = watchPatterns.map(pattern => pattern.replace(/\\/g, '/'));
-const watcher = chokidar.watch(fixedPaths, {ignored: /[/\\]\./});
+const watcher = chokidar.watch(fixedPaths, { ignored: "**/.*" });
 
 /* When the Chokidar watcher first starts up, it will fire an 'add' event for each file found.
  * After that, it will emit the 'ready' event.


### PR DESCRIPTION
## Description

This solves issue #606 

## Testing

This only was tested when using `include-nodecg` in macOS environment and needs testing by being used as standard installation.