### PR TITLE
fix: don't list package-lock in files

### DIFF
--- a/package.json
+++ b/package.json
@@ -140,8 +140,7 @@
     "bundles/.empty_directory",
     "db/.empty_directory",
     "schemas",
-    "AUTHORS",
-    "package-lock.json"
+    "AUTHORS"
   ],
   "devDependencies": {
     "@babel/core": "^7.20.2",


### PR DESCRIPTION
The file is never included in the package even if it's listed