### PR TITLE
fix(dockerfile): CMD to absolute path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,4 +56,4 @@ EXPOSE 9090/tcp
 
 # Define command to run NodeCG
 # Using `node` directly is slightly faster than using `nodecg start`.
-CMD ["node", "index.js"]
+CMD ["node", "/opt/nodecg/index.js"]


### PR DESCRIPTION
When building optimized Docker image for bundles, `WORKDIR` is used to copy bundle files to the image. With the current `CMD` with a relative path, another `WORKDIR` at the end of Dockerfile is required to correctly run the index.js.