### PR TITLE
fix: fix error when running NodeCG after local installation

### DIFF
--- a/src/server/bootstrap.ts
+++ b/src/server/bootstrap.ts
@@ -10,15 +10,17 @@
  */
 
 // Packages
-import appRootPath from 'app-root-path';
 import semver from 'semver';
 import fetch from 'node-fetch-commonjs';
 
+// Ours
+import rootPath from '../shared/utils/rootPath';
+
 const cwd = process.cwd();
-if (cwd !== appRootPath.path) {
-	console.warn('[nodecg] process.cwd is %s, expected %s', cwd, appRootPath.path);
-	process.chdir(appRootPath.path);
-	console.info('[nodecg] Changed process.cwd to %s', appRootPath.path);
+if (cwd !== rootPath.path) {
+	console.warn('[nodecg] process.cwd is %s, expected %s', cwd, rootPath.path);
+	process.chdir(rootPath.path);
+	console.info('[nodecg] Changed process.cwd to %s', rootPath.path);
 }
 
 if (!process.env.NODECG_ROOT) {

--- a/src/server/dashboard/index.ts
+++ b/src/server/dashboard/index.ts
@@ -4,13 +4,13 @@ import path from 'path';
 // Packages
 import clone from 'clone';
 import express from 'express';
-import appRootPath from 'app-root-path';
 
 // Ours
 import { config, filteredConfig } from '../config';
 import * as ncgUtils from '../util';
 import type BundleManager from '../bundle-manager';
 import type { NodeCG } from '../../types/nodecg';
+import rootPath from '../../shared/utils/rootPath';
 
 type Workspace = NodeCG.Workspace;
 
@@ -22,8 +22,8 @@ type DashboardContext = {
 	sentryEnabled: boolean;
 };
 
-const BUILD_PATH = path.join(appRootPath.path, 'build/client');
-const VIEWS_PATH = path.join(appRootPath.path, 'build/server/templates');
+const BUILD_PATH = path.join(rootPath.path, 'build/client');
+const VIEWS_PATH = path.join(rootPath.path, 'build/server/templates');
 
 export default class DashboardLib {
 	app = express();
@@ -37,7 +37,7 @@ export default class DashboardLib {
 
 		app.use(express.static(BUILD_PATH));
 
-		app.use('/node_modules', express.static(path.join(appRootPath.path, 'node_modules')));
+		app.use('/node_modules', express.static(path.join(rootPath.path, 'node_modules')));
 
 		app.get('/', (_, res) => {
 			res.redirect('/dashboard/');

--- a/src/server/database/datasource.ts
+++ b/src/server/database/datasource.ts
@@ -4,7 +4,6 @@ import path from 'path';
 // Packages
 import 'reflect-metadata';
 import { DataSource } from 'typeorm';
-import appRootPath from 'app-root-path';
 export * from './entity';
 
 // Ours
@@ -15,8 +14,9 @@ import { Replicant } from './entity/Replicant';
 import { Permission } from './entity/Permission';
 import { Identity } from './entity/Identity';
 import { ApiKey } from './entity/ApiKey';
+import rootPath from '../../shared/utils/rootPath';
 
-const dbPath = path.join(appRootPath.path, 'db/nodecg.sqlite3');
+const dbPath = path.join(rootPath.path, 'db/nodecg.sqlite3');
 export const testing = process.env.NODECG_TEST?.toLowerCase() === 'true';
 
 const dataSource = new DataSource({
@@ -36,8 +36,8 @@ const dataSource = new DataSource({
 	database: testing ? ':memory:' : dbPath,
 	logging: false,
 	entities: [ApiKey, Identity, Permission, Replicant, Role, Session, User],
-	migrations: [path.join(appRootPath.path, 'build/typeorm/migration/**/*.js')],
-	subscribers: [path.join(appRootPath.path, 'build/typeorm/subscriber/**/*.js')],
+	migrations: [path.join(rootPath.path, 'build/typeorm/migration/**/*.js')],
+	subscribers: [path.join(rootPath.path, 'build/typeorm/subscriber/**/*.js')],
 	migrationsRun: true,
 	synchronize: false,
 });

--- a/src/server/graphics/registration.ts
+++ b/src/server/graphics/registration.ts
@@ -4,7 +4,6 @@ import fs from 'fs';
 
 // Packages
 import express from 'express';
-import appRootPath from 'app-root-path';
 
 // Ours
 import { injectScripts } from '../util';
@@ -14,10 +13,11 @@ import type { RootNS, GraphicRegRequest } from '../../types/socket-protocol';
 import type BundleManager from '../bundle-manager';
 import type { NodeCG } from '../../types/nodecg';
 import isChildOf from '../util/isChildOf';
+import rootPath from '../../shared/utils/rootPath';
 
 type GraphicsInstance = NodeCG.GraphicsInstance;
 
-const BUILD_PATH = path.join(appRootPath.path, 'build/client/instance');
+const BUILD_PATH = path.join(rootPath.path, 'build/client/instance');
 
 export default class RegistrationCoordinator {
 	app = express();
@@ -34,7 +34,7 @@ export default class RegistrationCoordinator {
 		const { app } = this;
 
 		this._instancesRep = replicator.declare('graphics:instances', 'nodecg', {
-			schemaPath: path.resolve(appRootPath.path, 'schemas/graphics%3Ainstances.json'),
+			schemaPath: path.resolve(rootPath.path, 'schemas/graphics%3Ainstances.json'),
 			persistent: false,
 			defaultValue: [],
 		});

--- a/src/server/login/index.ts
+++ b/src/server/login/index.ts
@@ -10,7 +10,6 @@ import steamStrategy from 'passport-steam';
 import { Strategy as LocalStrategy } from 'passport-local';
 import { TypeormStore } from 'connect-typeorm';
 import cookieParser from 'cookie-parser';
-import appRootPath from 'app-root-path';
 import fetch from 'node-fetch-commonjs';
 
 // Ours
@@ -19,6 +18,7 @@ import createLogger from '../logger';
 import type { User, Role } from '../database';
 import { Session, getConnection } from '../database';
 import { findUser, upsertUser, getSuperUserRole, isSuperUser } from '../database/utils';
+import rootPath from '../../shared/utils/rootPath';
 
 type StrategyDoneCb = (error: NodeJS.ErrnoException | undefined, profile?: User) => void;
 
@@ -380,9 +380,9 @@ export async function createMiddleware(callbacks: {
 	app.use(passport.initialize());
 	app.use(passport.session());
 
-	const VIEWS_DIR = path.join(appRootPath.path, 'build/server/templates');
+	const VIEWS_DIR = path.join(rootPath.path, 'build/server/templates');
 
-	app.use('/login', express.static(path.join(appRootPath.path, 'build/client/login')));
+	app.use('/login', express.static(path.join(rootPath.path, 'build/client/login')));
 	app.set('views', VIEWS_DIR);
 
 	app.get('/login', (req, res) => {

--- a/src/server/server/index.ts
+++ b/src/server/server/index.ts
@@ -44,7 +44,6 @@ import transformMiddleware from 'express-transform-bare-module-specifiers';
 import compression from 'compression';
 import type { Server } from 'http';
 import SocketIO from 'socket.io';
-import appRootPath from 'app-root-path';
 import passport from 'passport';
 
 // Ours
@@ -65,6 +64,7 @@ import ExtensionManager from './extensions';
 import SentryConfig from '../util/sentry-config';
 import type { NodeCG } from '../../types/nodecg';
 import { TypedEmitter } from '../../shared/typed-emitter';
+import rootPath from '../../shared/utils/rootPath';
 
 const renderTemplate = memoize((content, options) => template(content)(options));
 
@@ -312,7 +312,7 @@ export default class NodeCGServer extends TypedEmitter<EventMap> {
 
 		// Set up "bundles" Replicant.
 		const bundlesReplicant = replicator.declare('bundles', 'nodecg', {
-			schemaPath: path.resolve(appRootPath.path, 'schemas/bundles.json'),
+			schemaPath: path.resolve(rootPath.path, 'schemas/bundles.json'),
 			persistent: false,
 		});
 		const updateBundlesReplicant = debounce(() => {

--- a/src/server/sounds.ts
+++ b/src/server/sounds.ts
@@ -5,13 +5,13 @@ import path from 'path';
 import clone from 'clone';
 import express from 'express';
 import sha1File from 'sha1-file';
-import appRootPath from 'app-root-path';
 
 // Ours
 import type { Replicator } from './replicant';
 import type ServerReplicant from './replicant/server-replicant';
 import { sendFile } from './util';
 import type { NodeCG } from '../types/nodecg';
+import rootPath from '../shared/utils/rootPath';
 
 export default class SoundsLib {
 	app = express();
@@ -33,7 +33,7 @@ export default class SoundsLib {
 				const defaultCuesRepValue = this._makeCuesRepDefaultValue(bundle);
 
 				const cuesRep = replicator.declare<NodeCG.SoundCue[]>('soundCues', bundle.name, {
-					schemaPath: path.resolve(appRootPath.path, 'schemas/soundCues.json'),
+					schemaPath: path.resolve(rootPath.path, 'schemas/soundCues.json'),
 					defaultValue: [],
 				});
 

--- a/src/server/util/pjson.ts
+++ b/src/server/util/pjson.ts
@@ -2,10 +2,10 @@
 import path from 'path';
 import fs from 'fs';
 
-// Packages
-import appRootPath from 'app-root-path';
+// Ours
+import rootPath from '../../shared/utils/rootPath';
 
-const pjsonPath = path.join(appRootPath.path, 'package.json');
+const pjsonPath = path.join(rootPath.path, 'package.json');
 const rawContents = fs.readFileSync(pjsonPath, 'utf8');
 const pjson = JSON.parse(rawContents);
 export default pjson;

--- a/src/server/util/sentry-config.ts
+++ b/src/server/util/sentry-config.ts
@@ -5,15 +5,15 @@ import os from 'os';
 // Packages
 import * as Sentry from '@sentry/node';
 import express from 'express';
-import appRootPath from 'app-root-path';
 
 // Ours
 import { config } from '../config';
 import type BundleManager from '../bundle-manager';
 import { authCheck, pjson } from '../util';
 import type { NodeCG } from '../../types/nodecg';
+import rootPath from '../../shared/utils/rootPath';
 
-const VIEWS_PATH = path.join(appRootPath.path, 'build/server/templates');
+const VIEWS_PATH = path.join(rootPath.path, 'build/server/templates');
 const baseSentryConfig = {
 	dsn: config.sentry?.dsn,
 	serverName: os.hostname(),

--- a/src/shared/utils/rootPath.ts
+++ b/src/shared/utils/rootPath.ts
@@ -1,7 +1,22 @@
-import * as path from 'path';
+import path from 'path';
+import fs from 'fs';
 
 const rootPath = {
-	path: path.resolve(__dirname, '../..'),
+	path: findRootPath(__dirname),
 };
+
+function findRootPath(dir: string): string {
+	const filePath = path.join(dir, 'package.json');
+	if (fs.existsSync(filePath)) {
+		return path.dirname(filePath);
+	}
+
+	const parentDir = path.dirname(dir);
+	if (dir === parentDir) {
+		return '';
+	}
+
+	return findRootPath(parentDir);
+}
 
 export default rootPath;

--- a/src/shared/utils/rootPath.ts
+++ b/src/shared/utils/rootPath.ts
@@ -1,7 +1,7 @@
 import * as path from 'path';
 
 const rootPath = {
-  path: path.resolve(__dirname, '../..')
+	path: path.resolve(__dirname, '../..'),
 };
 
 export default rootPath;

--- a/src/shared/utils/rootPath.ts
+++ b/src/shared/utils/rootPath.ts
@@ -1,0 +1,7 @@
+import * as path from 'path';
+
+const rootPath = {
+  path: path.resolve(__dirname, '../..')
+};
+
+export default rootPath;


### PR DESCRIPTION
This pull request addresses an issue encountered when installing NodeCG locally using npm and running index.js from the node_modules directory.

Problem:
After installing NodeCG locally using npm, executing index.js from the node_modules folder resulted in an error. The cause of the issue was app-root-path referring to the project's root. Since app-root-path was designed to find the root directory of a project, it was referencing incorrect Package.json and other related files when used in the context of a locally installed NodeCG package.

Solution:
I have replaced the app-root-path with alternative code to ensure the correct Package.json and related files are being referenced, resolving the issue.



Root Package.json
```
{
  "name": "nodecgtest",
  "version": "9.9.9",
  "description": "",
  "main": "index.js",
  "scripts": {
    "test": "echo \"Error: no test specified\" && exit 1"
  },
  "author": "",
  "license": "ISC",

  "dependencies": {
    "nodecg": "^2.1.3"
  }
}
```

Log

Brefore
```
WARNING: Unsupported Node.js version v19.5.0. NodeCG may not function as expected!
info: [server] Starting NodeCG 9.9.9 (Running on Node.js v19.5.0)
Error: Bundle at path /home/main/nodecgtest/bundles/nodecgtest does not contain a package.json!
```

After
```
[nodecg] process.cwd is /home/main/nodecgtest, expected /home/main/nodecgtest/node_modules/nodecg
[nodecg] Changed process.cwd to /home/main/nodecgtest/node_modules/nodecg
WARNING: Unsupported Node.js version v19.5.0. NodeCG may not function as expected!
2023-05-15 10:02:54 - info: [server] Starting NodeCG 2.1.3 (Running on Node.js v19.5.0)
2023-05-15 10:02:55 - info: [server] NodeCG running on http://localhost:9090
```

Please review and let me know if you have any suggestions or concerns. Thank you!



