### PR TITLE
fix: correct full update read code

### DIFF
--- a/src/client/api/replicant.ts
+++ b/src/client/api/replicant.ts
@@ -328,7 +328,7 @@ export default class ClientReplicant<
 				expectedRevision,
 				data.revision,
 			);
-			this._fullUpdate();
+			this._fullUpdate(data.revision);
 			return;
 		}
 
@@ -352,10 +352,10 @@ export default class ClientReplicant<
 	 * Requests the latest value from the Replicator, discarding the local value.
 	 * @private
 	 */
-	private _fullUpdate(): void {
+	private _fullUpdate(revision: number): void {
 		(window as any).NodeCG.readReplicant(this.name, this.namespace, (data: any) => {
 			this.emit('fullUpdate', data);
-			this._assignValue(data.value, data.revision);
+			this._assignValue(data, revision);
 		});
 	}
 }


### PR DESCRIPTION
readReplicant returns just the value of the replicant, not an object containing the value and the revision number like this code expects, resulting in replicants always being briefly set to undefined whenever this code path is used.

Since this code path is only used in one instance where a revision number mismatch happens, and we were told what revision number the server actually has, it should be safe to use that for the assignment.