### PR TITLE
Uploaded files' non-ascii filename being broken solved

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -122,7 +122,7 @@
         "@types/lodash.template": "^4.4.6",
         "@types/make-fetch-happen": "^10.0.0",
         "@types/multer": "^1.4.2",
-        "@types/node": "^18.11.9",
+        "@types/node": "^18.16.16",
         "@types/object-path": "^0.11.0",
         "@types/passport": "^1.0.3",
         "@types/passport-local": "^1.0.33",
@@ -3595,9 +3595,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "18.11.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.9.tgz",
-      "integrity": "sha512-CRpX21/kGdzjOpFsZSkcrXMGIBWMGNIHXXBVFSH+ggkftxg+XYP20TESbh+zFvFj3EQOl5byk0HTRn1IL6hbqg=="
+      "version": "18.16.16",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.16.16.tgz",
+      "integrity": "sha512-NpaM49IGQQAUlBhHMF82QH80J08os4ZmyF9MkpCzWAGuOHqE4gTEbhzd7L3l5LmWuZ6E0OiC1FweQ4tsiW35+g=="
     },
     "node_modules/@types/node-fetch": {
       "version": "2.6.2",
@@ -25730,9 +25730,9 @@
       }
     },
     "@types/node": {
-      "version": "18.11.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.9.tgz",
-      "integrity": "sha512-CRpX21/kGdzjOpFsZSkcrXMGIBWMGNIHXXBVFSH+ggkftxg+XYP20TESbh+zFvFj3EQOl5byk0HTRn1IL6hbqg=="
+      "version": "18.16.16",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.16.16.tgz",
+      "integrity": "sha512-NpaM49IGQQAUlBhHMF82QH80J08os4ZmyF9MkpCzWAGuOHqE4gTEbhzd7L3l5LmWuZ6E0OiC1FweQ4tsiW35+g=="
     },
     "@types/node-fetch": {
       "version": "2.6.2",

--- a/package.json
+++ b/package.json
@@ -170,7 +170,7 @@
     "@types/lodash.template": "^4.4.6",
     "@types/make-fetch-happen": "^10.0.0",
     "@types/multer": "^1.4.2",
-    "@types/node": "^18.11.9",
+    "@types/node": "^18.16.16",
     "@types/object-path": "^0.11.0",
     "@types/passport": "^1.0.3",
     "@types/passport-local": "^1.0.33",

--- a/src/server/assets/index.ts
+++ b/src/server/assets/index.ts
@@ -213,8 +213,7 @@ export default class AssetManager {
 				destination: this.assetsRoot,
 				filename(req, file, cb) {
 					const p = req.params as Record<string, string>;
-					cb(null, `${p.namespace}/${p.category}/${file.originalname}`);
-				},
+					cb(null, `${p.namespace}/${p.category}/${Buffer.from(file.originalname, 'latin1').toString('utf8')
 			}),
 		});
 		const uploader = upload.array('file', 64);


### PR DESCRIPTION
With default multer, non-ascii file names get broken, so I changed multer options.
Now it seems work well.