### PR TITLE
fix: unlisten overload missing

### DIFF
--- a/src/shared/api.base.ts
+++ b/src/shared/api.base.ts
@@ -194,6 +194,7 @@ export abstract class NodeCGAPIBase<
 	 * nodecg.unlisten('printMessage', 'another-bundle', someFunctionName);
 	 */
 	unlisten(messageName: string, handlerFunc: NodeCG.ListenHandler): boolean;
+	unlisten(messageName: string, bundleName: string, handlerFunc: NodeCG.ListenHandler): boolean;
 	unlisten(
 		messageName: string,
 		bundleNameOrHandler: string | NodeCG.ListenHandler,


### PR DESCRIPTION
I had misunderstood how overloads worked when writing this code originally, so what I thought was an overload actually wasn't being compiled as one. Now it is. This fixes the bug in the types package.