### PR TITLE
fix: Fix for JSON Schema URI Validation in Drafts 2019-09 and 2020-12

### DIFF
--- a/src/shared/utils/compileJsonSchema.ts
+++ b/src/shared/utils/compileJsonSchema.ts
@@ -35,11 +35,11 @@ export function compileJsonSchema(schema: Record<any, unknown>): ValidateFunctio
 		return ajv.draft07.compile(schema);
 	}
 
-	if (schemaVersion.includes('draft-2019-09')) {
+	if (schemaVersion.includes('draft/2019-09')) {
 		return ajv['draft2019-09'].compile(schema);
 	}
 
-	if (schemaVersion.includes('draft-2020-12')) {
+	if (schemaVersion.includes('draft/2020-12')) {
 		return ajv['draft2020-12'].compile(schema);
 	}
 
@@ -57,11 +57,11 @@ export function formatJsonSchemaErrors(schema: Record<any, unknown>, errors?: Er
 		return ajv.draft07.errorsText(errors).replace(/^data\//gm, '');
 	}
 
-	if (schemaVersion.includes('draft-2019-09')) {
+	if (schemaVersion.includes('draft/2019-09')) {
 		return ajv['draft2019-09'].errorsText(errors).replace(/^data\//gm, '');
 	}
 
-	if (schemaVersion.includes('draft-2020-12')) {
+	if (schemaVersion.includes('draft/2020-12')) {
 		return ajv['draft2020-12'].errorsText(errors).replace(/^data\//gm, '');
 	}
 


### PR DESCRIPTION
This PR addresses a discrepancy in our JSON schema validation. Previously, the URI set for the $schema keyword was expected in the format `https://json-schema.org/draft-xx/schema`. However, according to the JSON Schema `Draft 2019-09` and` Draft  2020-12`, the correct URI should be in the format `https://json-schema.org/draft/20xx-xx/schema`.

The validation was expected to handle `draft-20xx-xx`, hence I have made changes to ensure that the correct URI is accepted.

Reference:
https://json-schema.org/learn/getting-started-step-by-step.html#starting-the-schema