### PR TITLE
fix(config loader): handle when cfg is symlink

### DIFF
--- a/src/server/config/loader.ts
+++ b/src/server/config/loader.ts
@@ -223,7 +223,7 @@ function getConfigSchema(userConfig: Record<string, any>) {
 export default function (cfgDirOrFile: string) {
 	let isFile = false;
 	try {
-		isFile = fs.lstatSync(cfgDirOrFile).isFile()
+		isFile = fs.lstatSync(cfgDirOrFile).isFile();
 		// eslint-disable-next-line @typescript-eslint/no-implicit-any-catch
 	} catch (error: any) {
 		if (error.code !== 'ENOENT') {

--- a/src/server/config/loader.ts
+++ b/src/server/config/loader.ts
@@ -221,9 +221,9 @@ function getConfigSchema(userConfig: Record<string, any>) {
 
 // eslint-disable-next-line complexity
 export default function (cfgDirOrFile: string) {
-	let isDir = false;
+	let isFile = false;
 	try {
-		isDir = fs.lstatSync(cfgDirOrFile).isDirectory();
+		isFile = fs.lstatSync(cfgDirOrFile).isFile()
 		// eslint-disable-next-line @typescript-eslint/no-implicit-any-catch
 	} catch (error: any) {
 		if (error.code !== 'ENOENT') {
@@ -232,11 +232,11 @@ export default function (cfgDirOrFile: string) {
 		}
 	}
 
-	const cfgDir = isDir ? cfgDirOrFile : path.dirname(cfgDirOrFile);
+	const cfgDir = isFile ? path.dirname(cfgDirOrFile) : cfgDirOrFile;
 	const cc = cosmiconfig('nodecg', {
-		searchPlaces: isDir
-			? ['nodecg.json', 'nodecg.yaml', 'nodecg.yml', 'nodecg.js', 'nodecg.config.js']
-			: [path.basename(cfgDirOrFile)],
+		searchPlaces: isFile
+			? [path.basename(cfgDirOrFile)]
+			: ['nodecg.json', 'nodecg.yaml', 'nodecg.yml', 'nodecg.js', 'nodecg.config.js'],
 		stopDir: cfgDir,
 	});
 	const result = cc.search(cfgDir);

--- a/test/api/general.ts
+++ b/test/api/general.ts
@@ -78,7 +78,6 @@ test.serial('should not return a promise if the user provided a callback ', asyn
 	const res = await dashboard.evaluate(
 		async () =>
 			new Promise((resolve) => {
-				// eslint-disable-next-line @typescript-eslint/no-confusing-void-expression
 				const returnVal = window.dashboardApi.sendMessage('ackPromiseCallback', () => {
 					resolve(returnVal === undefined);
 				});


### PR DESCRIPTION
I happened to hit this specific bug where if the `cfg` directory is symlink directory, it fails to load nodecg.json