### PR TITLE
fix(replicants): remove custom schema properties

### DIFF
--- a/src/server/replicant/schema-hacks.ts
+++ b/src/server/replicant/schema-hacks.ts
@@ -25,7 +25,7 @@ type PointerReference = { $ref: string } & UnknownObject;
 /**
  * Mutates an object in place, replacing all its JSON Refs with their dereferenced values.
  */
-export default function replaceRefs(inputObj: unknown, currentFile: File, allFiles: File[]): UnknownObject | undefined {
+function replaceRefs(inputObj: unknown, currentFile: File, allFiles: File[]): UnknownObject | undefined {
 	const type = jsonSchemaLibTypeOf(inputObj);
 	if (!type.isPOJO && !type.isArray) {
 		return;
@@ -130,4 +130,19 @@ function resolveFileReference(url: string, file: File): string {
 
 function resolvePointerReference(obj: Record<string, unknown>, ref: string): UnknownObject {
 	return JsonPointer.get(obj, ref) as UnknownObject;
+}
+
+export default function formatSchema(
+	inputObj: unknown,
+	currentFile: File,
+	allFiles: File[],
+): UnknownObject | undefined {
+	const schema = replaceRefs(inputObj, currentFile, allFiles);
+
+	if (schema) {
+		delete schema.tsType;
+		delete schema.tsEnumNames;
+	}
+
+	return schema;
 }

--- a/src/server/replicant/schema-hacks.ts
+++ b/src/server/replicant/schema-hacks.ts
@@ -139,6 +139,11 @@ export default function formatSchema(
 ): UnknownObject | undefined {
 	const schema = replaceRefs(inputObj, currentFile, allFiles);
 
+	/**
+	 * NodeCG's CLI uses `json-schema-to-typescript` to convert JSON schemas into TypeScript types with the ability to override the generated type (https://github.com/bcherny/json-schema-to-typescript#custom-schema-properties), which can be handy in certain situations.
+		The problem is that these custom properties are not standard, and AJV will throw an error due to their presence.
+		This ensures that the schema will be compliant by removing these custom properties and allowing the schema converter to customize the generated type if needed.
+	 */
 	if (schema) {
 		delete schema.tsType;
 		delete schema.tsEnumNames;

--- a/src/server/replicant/server-replicant.ts
+++ b/src/server/replicant/server-replicant.ts
@@ -15,7 +15,7 @@ import {
 	AbstractReplicant,
 	type ReplicantValue,
 } from '../../shared/replicants.shared';
-import replaceRefs from './schema-hacks';
+import formatSchema from './schema-hacks';
 import createLogger from '../logger';
 import type { NodeCG } from '../../types/nodecg';
 import { getSchemaDefault } from '../../shared/utils';
@@ -54,7 +54,7 @@ export default class ServerReplicant<
 			if (fs.existsSync(absoluteSchemaPath)) {
 				try {
 					const rawSchema = $RefParser.readSync(absoluteSchemaPath);
-					const parsedSchema = replaceRefs(rawSchema.root, rawSchema.rootFile, rawSchema.files);
+					const parsedSchema = formatSchema(rawSchema.root, rawSchema.rootFile, rawSchema.files);
 					if (!parsedSchema) {
 						throw new Error('parsed schema was unexpectedly undefined');
 					}


### PR DESCRIPTION
NodeCG's CLI uses `json-schema-to-typescript` to convert JSON schemas into TypeScript types with the ability to override the generated type (https://github.com/bcherny/json-schema-to-typescript#custom-schema-properties), which can be handy in certain situations.

The problem is that these custom properties are not standard, and AJV will throw an error due to their presence.

This pull request ensures that the schema will be compliant by removing these custom properties and allowing the schema converter to customize the generated type if needed.