### PR TITLE
fix: `iframe-resizer` content window injection

### DIFF
--- a/src/server/util/injectscripts.ts
+++ b/src/server/util/injectscripts.ts
@@ -73,8 +73,7 @@ export default function (
 			// We put this at the start and make it async so it loads ASAP.
 			if (!fullbleed) {
 				scripts.unshift(
-					'<script async src="/node_modules/iframe-resizer/js/iframeResizer.contentWindow.min.js">' +
-						'</script>',
+					'<script async src="/node_modules/iframe-resizer/js/iframeResizer.contentWindow.js"></script>',
 				);
 			}
 


### PR DESCRIPTION
Following a recent update of `iframe-resizer`, it seems that they no longer provide the minified version of the package (https://github.com/davidjbradshaw/iframe-resizer/commit/b3d5eba851dd20e93d70708ff197851b6c4aa82e), which breaks the auto-resizing of dashboard panels.