### PR TITLE
fix(json-schema): prevent ajv to throw on invalid JSON schema

### DIFF
--- a/src/server/assets.ts
+++ b/src/server/assets.ts
@@ -1,18 +1,16 @@
-import * as fs from 'fs';
-import * as path from 'path';
-
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 import express from 'express';
 import chokidar from 'chokidar';
 import multer from 'multer';
 import hasha from 'hasha';
 import { z } from 'zod';
-
 import { authCheck, debounceName, sendFile } from './util';
 import createLogger from './logger';
 import type Replicator from './replicant/replicator';
 import type ServerReplicant from './replicant/server-replicant';
 import type { NodeCG } from '../types/nodecg';
-import { stringifyError } from '../shared/utils';
+import { stringifyError } from '../shared/utils/errors';
 import { NODECG_ROOT } from './nodecg-root';
 
 type Collection = {

--- a/src/server/bundle-parser/config.ts
+++ b/src/server/bundle-parser/config.ts
@@ -1,15 +1,11 @@
-// Native
-import * as path from 'path';
-import * as fs from 'fs';
-
-// Packages
+import * as path from 'node:path';
+import * as fs from 'node:fs';
 import { klona as clone } from 'klona/json';
 import extend from 'extend';
 import type { NodeCG } from '../../types/nodecg';
 import type { ValidateFunction } from 'ajv';
-
-// Ours
-import { compileJsonSchema, formatJsonSchemaErrors, getSchemaDefault, stringifyError } from '../../shared/utils';
+import { stringifyError } from '../../shared/utils/errors';
+import { compileJsonSchema, getSchemaDefault, formatJsonSchemaErrors } from '../../shared/utils/compileJsonSchema';
 
 export function parse(
 	bundleName: string,

--- a/src/server/replicant/replicator.ts
+++ b/src/server/replicant/replicator.ts
@@ -7,7 +7,7 @@ import * as uuid from 'uuid';
 import * as db from '../database';
 import type { TypedServerSocket, ServerToClientEvents, RootNS } from '../../types/socket-protocol';
 import type { NodeCG } from '../../types/nodecg';
-import { stringifyError } from '../../shared/utils';
+import { stringifyError } from '../../shared/utils/errors';
 import type { EntityManager } from 'typeorm';
 
 const log = createLogger('replicator');

--- a/src/server/replicant/server-replicant.ts
+++ b/src/server/replicant/server-replicant.ts
@@ -1,13 +1,8 @@
-// Native
-import * as fs from 'fs';
-import * as path from 'path';
-
-// Packages
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 import $RefParser from 'json-schema-lib';
 import { klona as clone } from 'klona/json';
 import hasha from 'hasha';
-
-// Ours
 import {
 	proxyRecursive,
 	ignoreProxy,
@@ -18,7 +13,7 @@ import {
 import formatSchema from './schema-hacks';
 import createLogger from '../logger';
 import type { NodeCG } from '../../types/nodecg';
-import { getSchemaDefault } from '../../shared/utils';
+import { getSchemaDefault } from '../../shared/utils/compileJsonSchema';
 import { NODECG_ROOT } from '../nodecg-root';
 
 /**

--- a/src/server/server/extensions.ts
+++ b/src/server/server/extensions.ts
@@ -1,19 +1,14 @@
-// Native
-import { EventEmitter } from 'events';
-import path from 'path';
-
-// Packages
+import { EventEmitter } from 'node:events';
+import * as path from 'node:path';
 import semver from 'semver';
 import * as Sentry from '@sentry/node';
-
-// Ours
 import extensionApiClassFactory from '../api.server';
 import createLogger from '../logger';
 import type { Replicator } from '../replicant';
 import type { RootNS } from '../../types/socket-protocol';
 import type BundleManager from '../bundle-manager';
 import type { NodeCG } from '../../types/nodecg';
-import { stringifyError } from '../../shared/utils';
+import { stringifyError } from '../../shared/utils/errors';
 import { sentryEnabled } from '../config';
 
 const log = createLogger('extensions');

--- a/src/shared/replicants.shared.ts
+++ b/src/shared/replicants.shared.ts
@@ -5,7 +5,9 @@ import objectPath from 'object-path';
 import type { LoggerInterface } from '../types/logger-interface';
 import type { NodeCG } from '../types/nodecg';
 import { TypedEmitter } from '../shared/typed-emitter';
-import { compileJsonSchema, formatJsonSchemaErrors, isBrowser, stringifyError } from './utils';
+import { stringifyError } from './utils/errors';
+import { compileJsonSchema, formatJsonSchemaErrors } from './utils/compileJsonSchema';
+import { isBrowser } from './utils/isBrowser';
 
 export type ReplicantValue<P extends NodeCG.Platform, V, O, S extends boolean = false> = P extends 'server'
 	? S extends true

--- a/src/shared/utils/compileJsonSchema.ts
+++ b/src/shared/utils/compileJsonSchema.ts
@@ -1,21 +1,15 @@
-// Packages
 import AjvDraft07, { type ValidateFunction, type Options, type ErrorObject } from 'ajv';
 import AjvDraft04 from 'ajv-draft-04';
 import Ajv2019 from 'ajv/dist/2019';
 import Ajv2020 from 'ajv/dist/2020';
 import addFormats from 'ajv-formats';
 import defaults from '@nodecg/json-schema-defaults';
-import { stringifyError } from '.';
+import { stringifyError } from './errors';
 
 const options: Options = {
 	allErrors: true,
 	verbose: true,
-	strict: undefined,
-	strictSchema: true,
-	strictNumbers: true,
-	strictTypes: true,
-	strictTuples: true,
-	strictRequired: false,
+	strict: 'log',
 };
 
 const ajv = {

--- a/src/shared/utils/errors.ts
+++ b/src/shared/utils/errors.ts
@@ -1,5 +1,3 @@
-export * from './compileJsonSchema';
-
 /**
  * Make a string out of an error (or other equivalents),
  * including any additional data such as stack trace if available.
@@ -65,8 +63,4 @@ export function stringifyErrorInner(error: unknown): {
 		message,
 		stack,
 	};
-}
-
-export function isBrowser(): boolean {
-	return typeof globalThis.window !== 'undefined';
 }

--- a/src/shared/utils/isBrowser.ts
+++ b/src/shared/utils/isBrowser.ts
@@ -1,0 +1,3 @@
+export function isBrowser(): boolean {
+	return typeof globalThis.window !== 'undefined';
+}


### PR DESCRIPTION
This is preventing some bundles to migrate to v2 since NodeCG rejects invalid JSON schema now. Setting strict mode to `"log"` only outputs logs but accept JSON schema.