### PR TITLE
fix(dashboard): iframe lazy loading

### DIFF
--- a/src/client/dashboard/elements/ncg-dashboard.ts
+++ b/src/client/dashboard/elements/ncg-dashboard.ts
@@ -345,7 +345,7 @@ class NcgDashboard extends Polymer.PolymerElement {
 					<h2 hidden="[[_falsey(dialog.title)]]">[[dialog.title]]</h2>
 
 					<paper-dialog-scrollable>
-						<iframe src="/bundles/[[dialog.bundleName]]/dashboard/[[dialog.file]]" frameborder="0" scrolling="no" id="[[dialog.bundleName]]_[[dialog.name]]_iframe">
+						<iframe src="/bundles/[[dialog.bundleName]]/dashboard/[[dialog.file]]" frameborder="0" scrolling="no" id="[[dialog.bundleName]]_[[dialog.name]]_iframe" loading="lazy">
 						</iframe>
 					</paper-dialog-scrollable>
 

--- a/src/client/dashboard/elements/ncg-workspace.ts
+++ b/src/client/dashboard/elements/ncg-workspace.ts
@@ -68,7 +68,7 @@ class NcgWorkspace extends Polymer.PolymerElement {
 		<div id="panels">
 			<template is="dom-repeat" items="[[panels]]" as="panel">
 				<ncg-dashboard-panel id="[[panel.bundleName]]_[[panel.name]]" display-title="[[panel.title]]" bundle="[[panel.bundleName]]" panel="[[panel.name]]" header-color="[[panel.headerColor]]" width="[[panel.width]]" on-transitioning-changed="_handlePanelCollapseTransition" fullbleed="[[panel.fullbleed]]">
-					<iframe src="/bundles/[[panel.bundleName]]/dashboard/[[panel.file]]" frameborder="0" scrolling\$="[[_calcIframeScrolling(panel.fullbleed)]]" id="[[panel.bundleName]]_[[panel.name]]_iframe" on-iframe-resized="shiftPackery" fullbleed\$="[[panel.fullbleed]]">
+					<iframe src="/bundles/[[panel.bundleName]]/dashboard/[[panel.file]]" frameborder="0" scrolling\$="[[_calcIframeScrolling(panel.fullbleed)]]" id="[[panel.bundleName]]_[[panel.name]]_iframe" on-iframe-resized="shiftPackery" fullbleed\$="[[panel.fullbleed]]" loading="lazy">
 					</iframe>
 				</ncg-dashboard-panel>
 			</template>


### PR DESCRIPTION
Currently, all dashboard panels are being loaded as soon as possible, stressing the browser even more when there is a lot of panels available. Telling frames to be lazily loaded should reduce this stress, making the whole dashboard's initial loading faster.