### PR TITLE
Target ES2015 in generated typings

### DIFF
--- a/generated-types/tsconfig.json
+++ b/generated-types/tsconfig.json
@@ -1,5 +1,7 @@
 {
   "compilerOptions": {
+    "target": "ES2015",
+    "moduleResolution": "node",
     "strict": true,
     "noEmit": true,
     "esModuleInterop": true


### PR DESCRIPTION
The current build error on `main` is caused by the generated typings. The used version of the `zod` dependency is using a private field which requires targeting ES2015 in the generated typings otherwise the typescript compiler will error causing the current build failure. 
Also the module resolution strategy needs to be specified when targeting ES2015 which does PR also does.