### PR TITLE
fix: ensure assignable sounds are set correctly

### DIFF
--- a/schemas/soundCues.json
+++ b/schemas/soundCues.json
@@ -23,6 +23,12 @@
 				},
 				"default": {
 					"type": "boolean"
+				},
+				"namespace": {
+					"type": "string"
+				},
+				"category": {
+					"type": "string"
 				}
 			}
 		}


### PR DESCRIPTION
Asset uploading includes additional properties that aren't relevant to sound cues, but cause schema validation to fail. This means assignable sounds that do not have a default file appear to never work, and can never be changed. This corrects that.