### PR TITLE
feat(server): add server clients api

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "start": "node index.js",
     "dev": "del-cli dist out && run-p dev:*",
     "dev:client": "npm run build:client -- --watch",
-    "dev:build-server": "tsc -b src/server --watch --preserveWatchOutput",
+    "dev:build-server": "tsc -b src/server src/client --watch --preserveWatchOutput",
     "dev:run-server": "node --watch --watch-preserve-output index.js",
     "test": "ava --config ava.config.js",
     "test-coverage": "c8 ava --config ava.config.js",

--- a/src/client/api/api.client.ts
+++ b/src/client/api/api.client.ts
@@ -480,4 +480,6 @@ export class NodeCGAPIClient<C extends Record<string, any> = NodeCG.Bundle.Unkno
 	}
 }
 
-(window as any).NodeCG = NodeCGAPIClient;
+if (globalThis.window) {
+	(window as any).NodeCG = NodeCGAPIClient;
+}

--- a/src/client/api/logger/index.ts
+++ b/src/client/api/logger/index.ts
@@ -4,10 +4,10 @@ import loggerFactory from './logger.client';
 import type { LoggerInterface } from '../../../types/logger-interface';
 
 export let Logger: new (name: string) => LoggerInterface;
-if (filteredConfig.sentry.enabled) {
-	Logger = loggerFactory(filteredConfig.logging as any, Sentry);
+if (filteredConfig?.sentry?.enabled) {
+	Logger = loggerFactory(filteredConfig?.logging as any, Sentry);
 } else {
-	Logger = loggerFactory(filteredConfig.logging as any);
+	Logger = loggerFactory(filteredConfig?.logging as any);
 }
 
 export default function (name: string): LoggerInterface {

--- a/src/client/tsconfig.json
+++ b/src/client/tsconfig.json
@@ -1,8 +1,8 @@
 {
 	"extends": "../../tsconfig.json",
 	"compilerOptions": {
-		"target": "es2019",
-		"module": "ESNext",
+		"target": "es2016",
+		"module": "CommonJS",
 		"esModuleInterop": false,
 		"allowSyntheticDefaultImports": true,
 		"composite": true,

--- a/src/server/replicant/server-replicant.ts
+++ b/src/server/replicant/server-replicant.ts
@@ -39,6 +39,7 @@ export default class ServerReplicant<
 		 * fetched the current value from the server, which is an
 		 * async operation that takes time.
 		 */
+		this.type = 'server';
 		this.status = 'declared';
 		this.log = createLogger(`Replicant/${namespace}.${name}`);
 

--- a/src/server/tsconfig.json
+++ b/src/server/tsconfig.json
@@ -8,5 +8,5 @@
 		"composite": true
 	},
 	"include": ["./**/*.ts", "../types/stubs.d.ts"],
-	"references": [{ "path": "../shared" }, { "path": "../types" }]
+	"references": [{ "path": "../shared" }, { "path": "../types" }, { "path": "../client" }]
 }


### PR DESCRIPTION
Adds support for creating client connections from a NodeCG extension in order to connect to another instance.

Both Replicants and listenFor work when connecting to a remote NodeCG.