### PR TITLE
fix: Set cheerio version to avoid getting breaking changes in 1.0 release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
         "app-root-path": "^3.1.0",
         "better-sqlite3": "^8.7.0",
         "body-parser": "^1.20.2",
-        "cheerio": "^1.0.0-rc.2",
+        "cheerio": "1.0.0-rc.12",
         "chokidar": "^3.5.3",
         "clipboard": "^2.0.11",
         "compression": "^1.7.4",
@@ -97,7 +97,6 @@
       },
       "devDependencies": {
         "@types/app-root-path": "^1.2.8",
-        "@types/cheerio": "^0.22.35",
         "@types/clone": "^2.1.4",
         "@types/compression": "^1.7.5",
         "@types/cookie-parser": "^1.4.6",
@@ -2044,15 +2043,6 @@
       "integrity": "sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==",
       "dependencies": {
         "@types/connect": "*",
-        "@types/node": "*"
-      }
-    },
-    "node_modules/@types/cheerio": {
-      "version": "0.22.35",
-      "resolved": "https://registry.npmjs.org/@types/cheerio/-/cheerio-0.22.35.tgz",
-      "integrity": "sha512-yD57BchKRvTV+JD53UZ6PD8KWY5g5rvvMLRnZR3EQBCZXiDT/HR+pKpMzFGlWNhFrXlo7VPZXtKvIEwZkAWOIA==",
-      "dev": true,
-      "dependencies": {
         "@types/node": "*"
       }
     },
@@ -14094,15 +14084,6 @@
       "integrity": "sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==",
       "requires": {
         "@types/connect": "*",
-        "@types/node": "*"
-      }
-    },
-    "@types/cheerio": {
-      "version": "0.22.35",
-      "resolved": "https://registry.npmjs.org/@types/cheerio/-/cheerio-0.22.35.tgz",
-      "integrity": "sha512-yD57BchKRvTV+JD53UZ6PD8KWY5g5rvvMLRnZR3EQBCZXiDT/HR+pKpMzFGlWNhFrXlo7VPZXtKvIEwZkAWOIA==",
-      "dev": true,
-      "requires": {
         "@types/node": "*"
       }
     },

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "app-root-path": "^3.1.0",
     "better-sqlite3": "^8.7.0",
     "body-parser": "^1.20.2",
-    "cheerio": "^1.0.0-rc.2",
+    "cheerio": "1.0.0-rc.12",
     "chokidar": "^3.5.3",
     "clipboard": "^2.0.11",
     "compression": "^1.7.4",
@@ -138,7 +138,6 @@
   ],
   "devDependencies": {
     "@types/app-root-path": "^1.2.8",
-    "@types/cheerio": "^0.22.35",
     "@types/clone": "^2.1.4",
     "@types/compression": "^1.7.5",
     "@types/cookie-parser": "^1.4.6",


### PR DESCRIPTION
Fixes #746 

I was going to just upgrade the project to the final 1.0 release, but I saw that the latest cheerio drops support for node v16 which I see is still supported by nodecg according to the `package.json` engines field, so I just narrowed the semver range down to what exists in the lockfile today.

Also, I removed the `@types/cheerio` package as the `rc.12` version ships with its own types now.