### PR TITLE
feat: support nodejs v22

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -148,7 +148,7 @@
         "typescript": "~5.3.3"
       },
       "engines": {
-        "node": "^18.12.0 || ^20.9.0"
+        "node": "^18.12.0 || ^20.9.0 || ^22.11.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
         "ajv-draft-04": "^1.0.0",
         "ajv-formats": "^2.1.1",
         "app-root-path": "^3.1.0",
-        "better-sqlite3": "9.6.0",
+        "better-sqlite3": "^11.7.0",
         "body-parser": "^1.20.2",
         "cheerio": "1.0.0-rc.12",
         "chokidar": "^3.5.3",
@@ -3316,9 +3316,9 @@
       }
     },
     "node_modules/better-sqlite3": {
-      "version": "9.6.0",
-      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-9.6.0.tgz",
-      "integrity": "sha512-yR5HATnqeYNVnkaUTf4bOP2dJSnyhP4puJN/QPRyx4YkBEEUxib422n2XzPqDEHjQQqazoYoADdAm5vE15+dAQ==",
+      "version": "11.7.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-11.7.0.tgz",
+      "integrity": "sha512-mXpa5jnIKKHeoGzBrUJrc65cXFKcILGZpU3FXR0pradUEm9MA7UZz02qfEejaMcm9iXrSOCenwwYMJ/tZ1y5Ig==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -15093,9 +15093,9 @@
       "dev": true
     },
     "better-sqlite3": {
-      "version": "9.6.0",
-      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-9.6.0.tgz",
-      "integrity": "sha512-yR5HATnqeYNVnkaUTf4bOP2dJSnyhP4puJN/QPRyx4YkBEEUxib422n2XzPqDEHjQQqazoYoADdAm5vE15+dAQ==",
+      "version": "11.7.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-11.7.0.tgz",
+      "integrity": "sha512-mXpa5jnIKKHeoGzBrUJrc65cXFKcILGZpU3FXR0pradUEm9MA7UZz02qfEejaMcm9iXrSOCenwwYMJ/tZ1y5Ig==",
       "requires": {
         "bindings": "^1.5.0",
         "prebuild-install": "^7.1.1"

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "ajv-draft-04": "^1.0.0",
     "ajv-formats": "^2.1.1",
     "app-root-path": "^3.1.0",
-    "better-sqlite3": "9.6.0",
+    "better-sqlite3": "^11.7.0",
     "body-parser": "^1.20.2",
     "cheerio": "1.0.0-rc.12",
     "chokidar": "^3.5.3",
@@ -188,7 +188,10 @@
     "ts-node": "^10.9.2",
     "typescript": "~5.3.3"
   },
+  "overrides": {
+    "better-sqlite3": "$better-sqlite3"
+  },
   "engines": {
-    "node": "^18.12.0 || ^20.9.0"
+    "node": "^18.12.0 || ^20.9.0 || ^22.11.0"
   }
 }


### PR DESCRIPTION
This uses the [overrides](https://docs.npmjs.com/cli/v11/configuring-npm/package-json#overrides) key of `package.json` to effectively override the closed peer dependency window provided by typeorm and take the latest v11 of `better-sqlite3`. This is only safe to do because the only breaking changes are in the versions of which Node they support.

Build and tests all ran and passed for me locally on both node v18 and node v22

Fixes #758 