### PR TITLE
feat(server): use CSRF middleware

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -80,6 +80,7 @@
         "json-schema-to-typescript": "^15.0.3",
         "klona": "^2.0.6",
         "lodash": "^4.17.21",
+        "lusca": "^1.7.0",
         "multer": "^1.4.5-lts.1",
         "nano-spawn": "^0.2.0",
         "npm-package-arg": "^12.0.1",
@@ -8528,6 +8529,17 @@
         "yallist": "^2.1.2"
       }
     },
+    "node_modules/lusca": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/lusca/-/lusca-1.7.0.tgz",
+      "integrity": "sha512-msnrplCfY7zaqlZBDEloCIKld+RUeMZVeWzSPaGUKeRXFlruNSdKg2XxCyR+zj6BqzcXhXlRnvcvx6rAGgsvMA==",
+      "dependencies": {
+        "tsscmp": "^1.0.5"
+      },
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.17",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
@@ -11856,6 +11868,15 @@
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+    },
+    "node_modules/tsscmp": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/tsscmp/-/tsscmp-1.0.6.tgz",
+      "integrity": "sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.x"
+      }
     },
     "node_modules/tsx": {
       "version": "4.19.2",
@@ -20232,6 +20253,14 @@
         "yallist": "^2.1.2"
       }
     },
+    "lusca": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/lusca/-/lusca-1.7.0.tgz",
+      "integrity": "sha512-msnrplCfY7zaqlZBDEloCIKld+RUeMZVeWzSPaGUKeRXFlruNSdKg2XxCyR+zj6BqzcXhXlRnvcvx6rAGgsvMA==",
+      "requires": {
+        "tsscmp": "^1.0.5"
+      }
+    },
     "magic-string": {
       "version": "0.30.17",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
@@ -22557,6 +22586,11 @@
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+    },
+    "tsscmp": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/tsscmp/-/tsscmp-1.0.6.tgz",
+      "integrity": "sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA=="
     },
     "tsx": {
       "version": "4.19.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -124,6 +124,7 @@
         "@types/hosted-git-info": "^3.0.5",
         "@types/is-ci": "^3.0.4",
         "@types/lodash": "^4.17.13",
+        "@types/lusca": "^1.7.5",
         "@types/npm-package-arg": "^6.1.4",
         "@types/object-path": "^0.11.4",
         "@types/passport-discord": "^0.1.14",
@@ -3463,6 +3464,16 @@
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/@types/lru-cache/-/lru-cache-4.1.3.tgz",
       "integrity": "sha512-QjCOmf5kYwekcsfEKhcEHMK8/SvgnneuSDXFERBuC/DPca2KJIO/gpChTsVb35BoWLBpEAJWz1GFVEArSdtKtw=="
+    },
+    "node_modules/@types/lusca": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@types/lusca/-/lusca-1.7.5.tgz",
+      "integrity": "sha512-l49gAf8pu2iMzbKejLcz6Pqj+51H2na6BgORv1ElnE8ByPFcBdh/eZ0WNR1Va/6ZuNSZa01Hoy1DTZ3IZ+y+kA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/express": "*"
+      }
     },
     "node_modules/@types/mime": {
       "version": "1.3.5",
@@ -16616,6 +16627,15 @@
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/@types/lru-cache/-/lru-cache-4.1.3.tgz",
       "integrity": "sha512-QjCOmf5kYwekcsfEKhcEHMK8/SvgnneuSDXFERBuC/DPca2KJIO/gpChTsVb35BoWLBpEAJWz1GFVEArSdtKtw=="
+    },
+    "@types/lusca": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@types/lusca/-/lusca-1.7.5.tgz",
+      "integrity": "sha512-l49gAf8pu2iMzbKejLcz6Pqj+51H2na6BgORv1ElnE8ByPFcBdh/eZ0WNR1Va/6ZuNSZa01Hoy1DTZ3IZ+y+kA==",
+      "dev": true,
+      "requires": {
+        "@types/express": "*"
+      }
     },
     "@types/mime": {
       "version": "1.3.5",

--- a/package.json
+++ b/package.json
@@ -131,6 +131,7 @@
     "json-schema-to-typescript": "^15.0.3",
     "klona": "^2.0.6",
     "lodash": "^4.17.21",
+    "lusca": "^1.7.0",
     "multer": "^1.4.5-lts.1",
     "nano-spawn": "^0.2.0",
     "npm-package-arg": "^12.0.1",
@@ -156,8 +157,7 @@
     "uuid": "^9.0.1",
     "winston": "^3.11.0",
     "yargs": "^15.4.1",
-    "zod": "^3.22.4",
-    "lusca": "^1.7.0"
+    "zod": "^3.22.4"
   },
   "devDependencies": {
     "@eslint/js": "^9.17.0",
@@ -172,6 +172,7 @@
     "@types/hosted-git-info": "^3.0.5",
     "@types/is-ci": "^3.0.4",
     "@types/lodash": "^4.17.13",
+    "@types/lusca": "^1.7.5",
     "@types/npm-package-arg": "^6.1.4",
     "@types/object-path": "^0.11.4",
     "@types/passport-discord": "^0.1.14",

--- a/package.json
+++ b/package.json
@@ -156,7 +156,8 @@
     "uuid": "^9.0.1",
     "winston": "^3.11.0",
     "yargs": "^15.4.1",
-    "zod": "^3.22.4"
+    "zod": "^3.22.4",
+    "lusca": "^1.7.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.17.0",

--- a/src/server/login/index.ts
+++ b/src/server/login/index.ts
@@ -9,6 +9,7 @@ import { Strategy as DiscordStrategy } from "passport-discord";
 import { Strategy as LocalStrategy } from "passport-local";
 import SteamStrategy from "passport-steam";
 import { Strategy as TwitchStrategy } from "passport-twitch-helix";
+import lusca from "lusca";
 
 import { DatabaseAdapter } from "../../types/database-adapter";
 import type { Role, User } from "../../types/models";
@@ -414,6 +415,7 @@ export function createMiddleware(
 	});
 
 	app.use(sessionMiddleware);
+	app.use(lusca.csrf());
 
 	app.use(passport.initialize());
 	app.use(passport.session());


### PR DESCRIPTION
Potential fix for [https://github.com/nodecg/nodecg/security/code-scanning/24](https://github.com/nodecg/nodecg/security/code-scanning/24)

To fix the problem, we need to add CSRF protection middleware to the Express application. The `lusca` package provides a convenient way to add CSRF protection. We will install the `lusca` package and use its CSRF middleware in the Express application.

1. Install the `lusca` package.
2. Import the `lusca` package in the `src/server/login/index.ts` file.
3. Add the `lusca.csrf()` middleware to the Express application after the session middleware.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
