### PR TITLE
fix(CLI): prevent setup command recursive node lookup

### DIFF
--- a/workspaces/cli/src/import.test.ts
+++ b/workspaces/cli/src/import.test.ts
@@ -2,53 +2,45 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
-import { expect, test } from "vitest";
+import { afterEach, beforeEach, expect, test } from "vitest";
+
+let tempDir: string;
+let originalCwd: string;
+
+beforeEach(() => {
+	// Save original working directory
+	originalCwd = process.cwd();
+
+	// Create a temporary directory without package.json
+	tempDir = mkdtempSync(path.join(tmpdir(), "nodecg-cli-import-test-"));
+
+	// Change to the temp directory before importing
+	process.chdir(tempDir);
+});
+
+afterEach(() => {
+	// Restore original working directory
+	process.chdir(originalCwd);
+
+	// Clean up temp directory
+	rmSync(tempDir, { recursive: true, force: true });
+});
 
 test("CLI modules can be imported from directories without package.json", async () => {
-	// Create a temporary directory without package.json
-	const tempDir = mkdtempSync(path.join(tmpdir(), "nodecg-cli-import-test-"));
-	const originalCwd = process.cwd();
+	// This import should NOT throw "Could not find Node.js project" error
+	// because the module should use lazy evaluation, not module-level side effects
+	const { setupCLI } = await import("./index.js");
 
-	try {
-		// Change to the temp directory before importing
-		process.chdir(tempDir);
-
-		// This import should NOT throw "Could not find Node.js project" error
-		// because the module should use lazy evaluation, not module-level side effects
-		const { setupCLI } = await import("./index.js");
-
-		// Verify the import succeeded
-		expect(setupCLI).toBeDefined();
-		expect(typeof setupCLI).toBe("function");
-	} finally {
-		// Restore original working directory
-		process.chdir(originalCwd);
-
-		// Clean up temp directory
-		rmSync(tempDir, { recursive: true, force: true });
-	}
+	// Verify the import succeeded
+	expect(setupCLI).toBeDefined();
+	expect(typeof setupCLI).toBe("function");
 });
 
 test("CLI commands can be imported from directories without package.json", async () => {
-	// Create a temporary directory without package.json
-	const tempDir = mkdtempSync(path.join(tmpdir(), "nodecg-cli-commands-test-"));
-	const originalCwd = process.cwd();
+	// Import all command modules - none should trigger recursion at import time
+	const { setupCommands } = await import("./commands/index.js");
 
-	try {
-		// Change to the temp directory before importing
-		process.chdir(tempDir);
-
-		// Import all command modules - none should trigger recursion at import time
-		const { setupCommands } = await import("./commands/index.js");
-
-		// Verify the import succeeded
-		expect(setupCommands).toBeDefined();
-		expect(typeof setupCommands).toBe("function");
-	} finally {
-		// Restore original working directory
-		process.chdir(originalCwd);
-
-		// Clean up temp directory
-		rmSync(tempDir, { recursive: true, force: true });
-	}
+	// Verify the import succeeded
+	expect(setupCommands).toBeDefined();
+	expect(typeof setupCommands).toBe("function");
 });

--- a/workspaces/cli/src/import.test.ts
+++ b/workspaces/cli/src/import.test.ts
@@ -1,0 +1,54 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { expect, test } from "vitest";
+
+test("CLI modules can be imported from directories without package.json", async () => {
+	// Create a temporary directory without package.json
+	const tempDir = mkdtempSync(path.join(tmpdir(), "nodecg-cli-import-test-"));
+	const originalCwd = process.cwd();
+
+	try {
+		// Change to the temp directory before importing
+		process.chdir(tempDir);
+
+		// This import should NOT throw "Could not find Node.js project" error
+		// because the module should use lazy evaluation, not module-level side effects
+		const { setupCLI } = await import("./index.js");
+
+		// Verify the import succeeded
+		expect(setupCLI).toBeDefined();
+		expect(typeof setupCLI).toBe("function");
+	} finally {
+		// Restore original working directory
+		process.chdir(originalCwd);
+
+		// Clean up temp directory
+		rmSync(tempDir, { recursive: true, force: true });
+	}
+});
+
+test("CLI commands can be imported from directories without package.json", async () => {
+	// Create a temporary directory without package.json
+	const tempDir = mkdtempSync(path.join(tmpdir(), "nodecg-cli-commands-test-"));
+	const originalCwd = process.cwd();
+
+	try {
+		// Change to the temp directory before importing
+		process.chdir(tempDir);
+
+		// Import all command modules - none should trigger recursion at import time
+		const { setupCommands } = await import("./commands/index.js");
+
+		// Verify the import succeeded
+		expect(setupCommands).toBeDefined();
+		expect(typeof setupCommands).toBe("function");
+	} finally {
+		// Restore original working directory
+		process.chdir(originalCwd);
+
+		// Clean up temp directory
+		rmSync(tempDir, { recursive: true, force: true });
+	}
+});

--- a/workspaces/cli/src/import.test.ts
+++ b/workspaces/cli/src/import.test.ts
@@ -8,39 +8,26 @@ let tempDir: string;
 let originalCwd: string;
 
 beforeEach(() => {
-	// Save original working directory
 	originalCwd = process.cwd();
-
-	// Create a temporary directory without package.json
 	tempDir = mkdtempSync(path.join(tmpdir(), "nodecg-cli-import-test-"));
-
-	// Change to the temp directory before importing
 	process.chdir(tempDir);
 });
 
 afterEach(() => {
-	// Restore original working directory
 	process.chdir(originalCwd);
-
-	// Clean up temp directory
 	rmSync(tempDir, { recursive: true, force: true });
 });
 
 test("CLI modules can be imported from directories without package.json", async () => {
-	// This import should NOT throw "Could not find Node.js project" error
-	// because the module should use lazy evaluation, not module-level side effects
 	const { setupCLI } = await import("./index.js");
 
-	// Verify the import succeeded
 	expect(setupCLI).toBeDefined();
 	expect(typeof setupCLI).toBe("function");
 });
 
 test("CLI commands can be imported from directories without package.json", async () => {
-	// Import all command modules - none should trigger recursion at import time
 	const { setupCommands } = await import("./commands/index.js");
 
-	// Verify the import succeeded
 	expect(setupCommands).toBeDefined();
 	expect(typeof setupCommands).toBe("function");
 });

--- a/workspaces/internal-util/src/find-nodejs-project.ts
+++ b/workspaces/internal-util/src/find-nodejs-project.ts
@@ -16,6 +16,11 @@ export function recursivelyFindNodeJSProject(dir: string) {
 	return recursivelyFindNodeJSProject(parentDir);
 }
 
-export const nearestProjectDirFromCwd = recursivelyFindNodeJSProject(
-	process.cwd(),
-);
+let _cachedNearestProjectDir: string | undefined;
+
+export function getNearestProjectDirFromCwd(): string {
+	if (_cachedNearestProjectDir === undefined) {
+		_cachedNearestProjectDir = recursivelyFindNodeJSProject(process.cwd());
+	}
+	return _cachedNearestProjectDir;
+}

--- a/workspaces/internal-util/src/import.test.ts
+++ b/workspaces/internal-util/src/import.test.ts
@@ -9,56 +9,36 @@ let originalCwd: string;
 
 describe("import from directories without package.json", () => {
 	beforeEach(() => {
-		// Save original working directory
 		originalCwd = process.cwd();
-
-		// Create a temporary directory without package.json
 		tempDir = mkdtempSync(path.join(tmpdir(), "nodecg-internal-util-test-"));
-
-		// Change to the temp directory before importing
 		process.chdir(tempDir);
 	});
 
 	afterEach(() => {
-		// Restore original working directory
 		process.chdir(originalCwd);
-
-		// Clean up temp directory
 		rmSync(tempDir, { recursive: true, force: true });
 	});
 
 	test("internal-util can be imported without throwing errors", async () => {
-		// This import should NOT throw "Could not find Node.js project" error
-		// The module should use lazy evaluation and only execute filesystem
-		// operations when functions are actually called, not on import
 		const importPromise = import("./main.js");
-
-		// The import itself should succeed without errors
 		await expect(importPromise).resolves.toBeDefined();
 
 		const module = await importPromise;
-
-		// Verify exports are available
 		expect(module.rootPaths).toBeDefined();
 		expect(module.isLegacyProject).toBeDefined();
 
-		// These are functions that should only execute when called
 		expect(typeof module.isLegacyProject).toBe("function");
 	});
 
 	test("isLegacyProject throws error only when called, not on import", async () => {
-		// Import should succeed
 		const { isLegacyProject } = await import("./main.js");
 
-		// Calling the function should throw because there's no package.json
 		expect(() => isLegacyProject()).toThrow("Could not find Node.js project");
 	});
 
 	test("rootPaths getters throw error only when accessed, not on import", async () => {
-		// Import should succeed
 		const { rootPaths } = await import("./main.js");
 
-		// Accessing the getters should throw because there's no package.json
 		expect(() => rootPaths.runtimeRootPath).toThrow(
 			"Could not find Node.js project",
 		);
@@ -70,15 +50,11 @@ describe("import from directories without package.json", () => {
 
 describe("import from directories with package.json", () => {
 	beforeEach(() => {
-		// Save original working directory
 		originalCwd = process.cwd();
-
-		// Create a temporary directory WITH package.json
 		tempDir = mkdtempSync(
 			path.join(tmpdir(), "nodecg-internal-util-valid-test-"),
 		);
 
-		// Create a valid package.json
 		writeFileSync(
 			path.join(tempDir, "package.json"),
 			JSON.stringify({
@@ -89,23 +65,17 @@ describe("import from directories with package.json", () => {
 			"utf-8",
 		);
 
-		// Change to the temp directory
 		process.chdir(tempDir);
 	});
 
 	afterEach(() => {
-		// Restore original working directory
 		process.chdir(originalCwd);
-
-		// Clean up temp directory
 		rmSync(tempDir, { recursive: true, force: true });
 	});
 
 	test("internal-util works correctly when package.json exists", async () => {
-		// Import should succeed
 		const { isLegacyProject, rootPaths } = await import("./main.js");
 
-		// Should work correctly
 		expect(isLegacyProject()).toBe(true);
 		expect(rootPaths.runtimeRootPath).toBe(tempDir);
 	});

--- a/workspaces/internal-util/src/project-type.ts
+++ b/workspaces/internal-util/src/project-type.ts
@@ -1,16 +1,26 @@
 import fs from "node:fs";
 import path from "node:path";
 
-import { nearestProjectDirFromCwd } from "./find-nodejs-project.ts";
+import { getNearestProjectDirFromCwd } from "./find-nodejs-project.ts";
 
-const rootPackageJson = JSON.parse(
-	fs.readFileSync(path.join(nearestProjectDirFromCwd, "package.json"), "utf-8"),
-);
+let _cachedIsLegacyProject: boolean | undefined;
 
-export const isLegacyProject = rootPackageJson.nodecgRoot === true;
+export function isLegacyProject(): boolean {
+	if (_cachedIsLegacyProject === undefined) {
+		const rootPackageJson = JSON.parse(
+			fs.readFileSync(
+				path.join(getNearestProjectDirFromCwd(), "package.json"),
+				"utf-8",
+			),
+		);
 
-if (!isLegacyProject) {
-	console.warn(
-		"NodeCG is installed as a dependency. This is an experimental feature. Please report any issues you encounter.",
-	);
+		_cachedIsLegacyProject = rootPackageJson.nodecgRoot === true;
+
+		if (!_cachedIsLegacyProject) {
+			console.warn(
+				"NodeCG is installed as a dependency. This is an experimental feature. Please report any issues you encounter.",
+			);
+		}
+	}
+	return _cachedIsLegacyProject;
 }

--- a/workspaces/internal-util/src/root-paths.ts
+++ b/workspaces/internal-util/src/root-paths.ts
@@ -4,7 +4,6 @@ import { getNearestProjectDirFromCwd } from "./find-nodejs-project.ts";
 import { isLegacyProject } from "./project-type.ts";
 
 let _cachedRuntimeRootPath: string | undefined;
-let _cachedNodecgInstalledPath: string | undefined;
 
 function getRuntimeRootPath(): string {
 	if (_cachedRuntimeRootPath === undefined) {
@@ -12,6 +11,8 @@ function getRuntimeRootPath(): string {
 	}
 	return _cachedRuntimeRootPath;
 }
+
+let _cachedNodecgInstalledPath: string | undefined;
 
 function getNodecgInstalledPath(): string {
 	if (_cachedNodecgInstalledPath === undefined) {

--- a/workspaces/nodecg/src/server/bootstrap.ts
+++ b/workspaces/nodecg/src/server/bootstrap.ts
@@ -11,7 +11,7 @@
 
 import { isLegacyProject, rootPaths } from "@nodecg/internal-util";
 
-if (isLegacyProject) {
+if (isLegacyProject()) {
 	const cwd = process.cwd();
 	const runtimeRootPath = rootPaths.runtimeRootPath;
 	if (cwd !== runtimeRootPath) {

--- a/workspaces/nodecg/src/server/bundle-manager.ts
+++ b/workspaces/nodecg/src/server/bundle-manager.ts
@@ -84,7 +84,7 @@ export class BundleManager extends TypedEmitter<EventMap> {
 			this.emit("ready");
 		}, READY_WAIT_THRESHOLD);
 
-		const bundleRootPaths = isLegacyProject
+		const bundleRootPaths = isLegacyProject()
 			? bundlesPaths
 			: [rootPaths.runtimeRootPath, ...bundlesPaths];
 
@@ -194,7 +194,7 @@ export class BundleManager extends TypedEmitter<EventMap> {
 					loadBundleCfg(cfgPath, bundleName),
 				);
 
-				if (isLegacyProject) {
+				if (isLegacyProject()) {
 					if (!bundle.compatibleRange) {
 						log.error(
 							`${bundle.name}'s package.json does not have a "nodecg.compatibleRange" property.`,

--- a/workspaces/nodecg/src/server/bundle-parser/manifest.ts
+++ b/workspaces/nodecg/src/server/bundle-parser/manifest.ts
@@ -14,7 +14,7 @@ export const parseManifest =
 			);
 		}
 
-		if (isLegacyProject) {
+		if (isLegacyProject()) {
 			if (!packageJson.nodecg) {
 				return IOE.left(
 					new Error(

--- a/workspaces/nodecg/src/server/graphics/index.ts
+++ b/workspaces/nodecg/src/server/graphics/index.ts
@@ -115,7 +115,7 @@ export class GraphicsLib {
 
 				const filePath = req.params.filePath!;
 
-				if (isLegacyProject) {
+				if (isLegacyProject()) {
 					const parentDir = path.join(bundle.dir, "node_modules");
 					const fileLocation = path.join(parentDir, filePath);
 					sendFile(parentDir, fileLocation, res, next);

--- a/workspaces/nodecg/src/server/replicant/server-replicant.ts
+++ b/workspaces/nodecg/src/server/replicant/server-replicant.ts
@@ -46,7 +46,7 @@ export class ServerReplicant<
 
 		function getBundlePath() {
 			const rootPath = rootPaths.runtimeRootPath;
-			if (isLegacyProject) {
+			if (isLegacyProject()) {
 				return path.join(rootPaths.getRuntimeRoot(), "bundles", namespace);
 			}
 			const rootPackageJson = fs.readFileSync(


### PR DESCRIPTION
The @nodecg/internal-util package had module-level side effects that executed expensive filesystem operations at import time:
- recursivelyFindNodeJSProject(process.cwd())
- fs.readFileSync for package.json
- root path calculations

This caused CLI tests to fail when they changed working directory before importing CLI commands. The recursion would search from the wrong directory and throw "Could not find Node.js project" error.

Changes:
- Convert nearestProjectDirFromCwd constant to getNearestProjectDirFromCwd() function
- Convert isLegacyProject constant to isLegacyProject() function
- Update rootPaths to use getters for lazy evaluation
- Add caching to avoid repeated filesystem operations
- Update all consumers to call isLegacyProject as function

This enables tests to set working directory before module evaluation and ensures filesystem operations only happen when needed.

Fixes CLI setup command recursion issue.